### PR TITLE
Remove submodule, simplify buf gen

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "substrait"]
-	path = substrait
-	url = https://github.com/substrait-io/substrait

--- a/README.md
+++ b/README.md
@@ -4,25 +4,28 @@ Experimental Go bindings for [substrait](https://substrait.io)
 
 ## Generate from proto files
 
-initialize the submodule if you haven't yet done so:
+### Install buf
+
+First ensure you have `buf` installed by following https://docs.buf.build/installation.
+
+### Install go plugin
+
+Run the following to install the Go plugin for protobuf:
 
 ```bash
-git submodule update --init
+$ go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 ```
 
-Update the submodule for any upstream changes 
+Ensure that your GOPATH is on your path:
 
 ```bash
-git submodule update --remote substrait
+$ export PATH="$PATH:$(go env GOPATH)/bin"
 ```
 
-Then generate the files and copy them out
+### Run go generate
 
-```bash
-pushd substrait
-buf generate
-cp -r gen/proto/go/substrait/* ../proto
-popd
-```
+As long as buf and the Go protobuf plugin are installed, you can 
+simply run `go generate` to generate the updated `.pb.go` files. It
+will generate them by referencing the primary substrait-io repository.
 
-After this you can commit the updated `.pb.go` files.
+You can then commit the updated files.

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+version: v1
+plugins:
+  - name: go
+    out: proto
+    opt: module=github.com/substrait-io/substrait-go/proto

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package substraitgo contains the experimental go bindings for substrait
+// (https://substrait.io).
+package substraitgo
+
+//go:generate buf generate https://github.com/substrait-io/substrait.git#branch=main

--- a/doc.go
+++ b/doc.go
@@ -4,4 +4,4 @@
 // (https://substrait.io).
 package substraitgo
 
-//go:generate buf generate https://github.com/substrait-io/substrait.git#branch=main
+//go:generate buf generate https://github.com/substrait-io/substrait.git#branch=v0.1.2

--- a/doc.go
+++ b/doc.go
@@ -4,4 +4,4 @@
 // (https://substrait.io).
 package substraitgo
 
-//go:generate buf generate https://github.com/substrait-io/substrait.git#branch=master
+//go:generate buf generate https://github.com/substrait-io/substrait.git#branch=main

--- a/doc.go
+++ b/doc.go
@@ -4,4 +4,4 @@
 // (https://substrait.io).
 package substraitgo
 
-//go:generate buf generate https://github.com/substrait-io/substrait.git#branch=v0.1.2
+//go:generate buf generate https://github.com/substrait-io/substrait.git#branch=master

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 module github.com/substrait-io/substrait-go
 
 go 1.18


### PR DESCRIPTION
@cpcloud here we go. Removing the need for the submodule because buf is able to reference the `.proto` files remotely.