### PR TITLE
ci(build-test): add Github Action to build, run unit tests, and linting

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: PR Build Check
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and Test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.18'
+          cache: true
+      - name: Install staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+      - name: Build
+        run: go build ./...
+      - name: Run Tests
+        run: go test -v ./...
+      - name: Lint
+        run: staticcheck -f stylish ./...


### PR DESCRIPTION
This is just a simple Github Action for now, so we can at least have CI to run unit tests and lint everything on PRs and merges.