### PR TITLE
feat(expressions): Implement more expression types

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ This is work in progress still, things still to do:
   - [x] IfThen
   - [x] SwitchExpression
   - [x] SingularOrList
-  - [ ] MultiOrList
+  - [x] MultiOrList
   - [x] Cast
-  - [ ] Nested
+  - [x] Nested
   - [ ] Subquery
 - [ ] Plan Building helpers
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Experimental Go bindings for [substrait](https://substrait.io)
 This is work in progress still, things still to do:
 
 - [ ] Expression parsing
-- [ ] Reading in extension yamls
-- [ ] CI building and testing the implementation
+- [x] Reading in extension yamls
+- [x] CI building and testing the implementation
 - [ ] Serialization/Deserialization of some expression types:
-  - [ ] IfThen
-  - [ ] SwitchExpression
-  - [ ] SingularOrList
+  - [x] IfThen
+  - [x] SwitchExpression
+  - [x] SingularOrList
   - [ ] MultiOrList
-  - [ ] Cast
+  - [x] Cast
   - [ ] Nested
   - [ ] Subquery
 - [ ] Plan Building helpers

--- a/errors.go
+++ b/errors.go
@@ -7,6 +7,7 @@ import "errors"
 var (
 	ErrNotImplemented = errors.New("not implemented")
 	ErrInvalidType    = errors.New("invalid type")
+	ErrInvalidExpr    = errors.New("invalid expression")
 	ErrNotFound       = errors.New("not found")
 	ErrKeyExists      = errors.New("key already exists")
 )

--- a/expr/expression.go
+++ b/expr/expression.go
@@ -4,11 +4,13 @@ package expr
 
 import (
 	"fmt"
+	"strings"
 
 	substraitgo "github.com/substrait-io/substrait-go"
 	"github.com/substrait-io/substrait-go/extensions"
 	"github.com/substrait-io/substrait-go/proto"
 	"github.com/substrait-io/substrait-go/types"
+	"golang.org/x/exp/slices"
 )
 
 type ExtensionLookup interface {
@@ -185,10 +187,175 @@ type IfThen struct {
 	Else Expression
 }
 
+func (ex *IfThen) String() string {
+	var b strings.Builder
+	b.WriteString("<IfThen>(")
+	for i, clause := range ex.IFs {
+		if i != 0 {
+			b.WriteString(": ")
+		}
+		b.WriteString("(" + clause.If.String() + ") ?")
+		b.WriteString(clause.Then.String())
+	}
+	b.WriteString(")<Else>(")
+	if ex.Else != nil {
+		b.WriteString(ex.Else.String())
+	}
+	b.WriteString(")")
+	return b.String()
+}
+
+func (ex *IfThen) ToProtoFuncArg() *proto.FunctionArgument {
+	return &proto.FunctionArgument{
+		ArgType: &proto.FunctionArgument_Value{
+			Value: ex.ToProto(),
+		},
+	}
+}
+
+func (ex *IfThen) isRootRef() {}
+
+func (ex *IfThen) IsScalar() bool {
+	for _, clause := range ex.IFs {
+		if clause.If != nil && !clause.If.IsScalar() {
+			return false
+		}
+		if clause.Then != nil && !clause.Then.IsScalar() {
+			return false
+		}
+	}
+	return ex.Else == nil || ex.Else.IsScalar()
+}
+
+func (ex *IfThen) GetType() types.Type {
+	return ex.Else.GetType()
+}
+
+func (ex *IfThen) ToProto() *proto.Expression {
+	ifthenClauses := make([]*proto.Expression_IfThen_IfClause, len(ex.IFs))
+	for i, c := range ex.IFs {
+		ifthenClauses[i].If = c.If.ToProto()
+		ifthenClauses[i].Then = c.Then.ToProto()
+	}
+
+	var elseClause *proto.Expression
+	if ex.Else != nil {
+		elseClause = ex.Else.ToProto()
+	}
+	return &proto.Expression{
+		RexType: &proto.Expression_IfThen_{
+			IfThen: &proto.Expression_IfThen{
+				Ifs:  ifthenClauses,
+				Else: elseClause,
+			},
+		},
+	}
+}
+
+func (ex *IfThen) Equals(other Expression) bool {
+	rhs, ok := other.(*IfThen)
+	if !ok {
+		return false
+	}
+
+	if len(ex.IFs) != len(rhs.IFs) {
+		return false
+	}
+
+	for i := range ex.IFs {
+		if !ex.IFs[i].If.Equals(rhs.IFs[i].If) {
+			return false
+		}
+
+		if !ex.IFs[i].Then.Equals(rhs.IFs[i].Then) {
+			return false
+		}
+	}
+
+	return ex.Else != nil && ex.Else.Equals(rhs.Else)
+}
+
+func (ex *IfThen) Visit(visit VisitFunc) Expression {
+	var out *IfThen
+
+	for i, clause := range ex.IFs {
+		afterIf := visit(clause.If)
+		afterThen := visit(clause.Then)
+
+		if out == nil && (afterIf != clause.If || afterThen != clause.Then) {
+			out = &IfThen{IFs: slices.Clone(ex.IFs)}
+		}
+
+		if out != nil {
+			out.IFs[i].If = afterIf
+			out.IFs[i].Then = afterThen
+		}
+	}
+
+	afterElse := visit(ex.Else)
+	if out == nil {
+		if afterElse == ex.Else {
+			return ex
+		}
+
+		out = &IfThen{IFs: slices.Clone(ex.IFs)}
+	}
+
+	out.Else = afterElse
+	return out
+}
+
 type Cast struct {
 	Type            types.Type
 	Input           Expression
 	FailureBehavior types.CastFailBehavior
+}
+
+func (ex *Cast) String() string {
+	return fmt.Sprintf("cast(%s AS %s, fail: %s)",
+		ex.Input, ex.Type, ex.FailureBehavior)
+}
+
+func (ex *Cast) ToProtoFuncArg() *proto.FunctionArgument {
+	return &proto.FunctionArgument{
+		ArgType: &proto.FunctionArgument_Value{Value: ex.ToProto()},
+	}
+}
+
+func (ex *Cast) isRootRef() {}
+
+func (ex *Cast) IsScalar() bool {
+	return ex.Input.IsScalar()
+}
+
+func (ex *Cast) GetType() types.Type {
+	return ex.Type
+}
+
+func (ex *Cast) ToProto() *proto.Expression {
+	return &proto.Expression{
+		RexType: &proto.Expression_Cast_{
+			Cast: &proto.Expression_Cast{
+				Type:            types.TypeToProto(ex.Type),
+				Input:           ex.Input.ToProto(),
+				FailureBehavior: ex.FailureBehavior,
+			},
+		},
+	}
+}
+
+func (ex *Cast) Equals(other Expression) bool {
+	rhs, ok := other.(*Cast)
+	if !ok {
+		return false
+	}
+
+	return ex.Type.Equals(rhs.Type) && ex.Input.Equals(rhs.Input) &&
+		ex.FailureBehavior == rhs.FailureBehavior
+}
+
+func (ex *Cast) Visit(visit VisitFunc) Expression {
+	return visit(ex.Input)
 }
 
 type SwitchExpr struct {
@@ -200,17 +367,318 @@ type SwitchExpr struct {
 	Else Expression
 }
 
-type SinglularOrList struct {
+func (ex *SwitchExpr) String() string {
+	var b strings.Builder
+	b.WriteString("CASE ")
+	b.WriteString(ex.Match.String())
+	b.WriteString(":")
+	for _, c := range ex.IFs {
+		b.WriteString("\nWHEN ")
+		b.WriteString(c.If.String())
+		b.WriteString(" THEN ")
+		b.WriteString(c.Then.String())
+		b.WriteByte(';')
+	}
+	b.WriteString("Else ")
+	b.WriteString(ex.Else.String())
+	return b.String()
+}
+
+func (ex *SwitchExpr) ToProtoFuncArg() *proto.FunctionArgument {
+	return &proto.FunctionArgument{
+		ArgType: &proto.FunctionArgument_Value{
+			Value: ex.ToProto(),
+		},
+	}
+}
+
+func (ex *SwitchExpr) isRootRef() {}
+
+func (ex *SwitchExpr) IsScalar() bool {
+	if !ex.Match.IsScalar() {
+		return false
+	}
+
+	for _, c := range ex.IFs {
+		if !c.Then.IsScalar() {
+			return false
+		}
+	}
+
+	if ex.Else != nil {
+		return ex.Else.IsScalar()
+	}
+
+	return true
+}
+
+func (ex *SwitchExpr) GetType() types.Type {
+	if len(ex.IFs) > 0 {
+		return ex.IFs[0].Then.GetType()
+	}
+	return ex.Else.GetType()
+}
+
+func (ex *SwitchExpr) ToProto() *proto.Expression {
+	var elseExpr *proto.Expression
+	if ex.Else != nil {
+		elseExpr = ex.Else.ToProto()
+	}
+
+	cases := make([]*proto.Expression_SwitchExpression_IfValue, len(ex.IFs))
+	for i, c := range ex.IFs {
+		cases[i].If = c.If.ToProtoLiteral()
+		cases[i].Then = c.Then.ToProto()
+	}
+
+	return &proto.Expression{
+		RexType: &proto.Expression_SwitchExpression_{
+			SwitchExpression: &proto.Expression_SwitchExpression{
+				Match: ex.Match.ToProto(),
+				Ifs:   cases,
+				Else:  elseExpr,
+			},
+		},
+	}
+}
+
+func (ex *SwitchExpr) Equals(other Expression) bool {
+	rhs, ok := other.(*SwitchExpr)
+	if !ok {
+		return false
+	}
+
+	switch {
+	case len(ex.IFs) != len(rhs.IFs):
+		return false
+	case !ex.Match.Equals(rhs.Match):
+		return false
+	}
+
+	for i := range ex.IFs {
+		if !ex.IFs[i].If.Equals(rhs.IFs[i].If) {
+			return false
+		}
+		if !ex.IFs[i].Then.Equals(rhs.IFs[i].Then) {
+			return false
+		}
+	}
+
+	if ex.Else != nil && ex.Else.Equals(rhs.Else) {
+		return true
+	}
+
+	// if rhs.Else == nil then we're equal, otherwise
+	// ex.Else is nil and rhs.Else is not nil
+	return rhs.Else == nil
+}
+
+func (ex *SwitchExpr) Visit(visit VisitFunc) Expression {
+	var out *SwitchExpr
+	if after := visit(ex.Match); after != ex.Match {
+		out = &SwitchExpr{
+			Match: after,
+			IFs: make([]struct {
+				If   Literal
+				Then Expression
+			}, len(ex.IFs)),
+			Else: ex.Else,
+		}
+	}
+
+	for i, c := range ex.IFs {
+		afterIf := visit(c.If)
+		afterThen := visit(c.Then)
+
+		if out == nil && (afterIf != c.If || afterThen != c.Then) {
+			out = &SwitchExpr{
+				Match: ex.Match,
+				IFs: make([]struct {
+					If   Literal
+					Then Expression
+				}, len(ex.IFs)),
+				Else: ex.Else,
+			}
+			for j := 0; j < i; j++ {
+				out.IFs[j] = ex.IFs[j]
+			}
+		}
+
+		if out != nil {
+			out.IFs[i].If = afterIf.(Literal)
+			out.IFs[i].Then = afterThen
+		}
+	}
+
+	afterElse := visit(ex.Else)
+	if out == nil {
+		if afterElse == ex.Else {
+			return ex
+		}
+
+		out = &SwitchExpr{
+			Match: ex.Match,
+			IFs:   slices.Clone(ex.IFs),
+		}
+	}
+
+	out.Else = afterElse
+	return out
+}
+
+type SingularOrList struct {
 	Value   Expression
 	Options []Expression
 }
 
-type MultiOrList struct {
-	Value   Expression
-	Options []struct {
-		Fields []Expression
+func (ex *SingularOrList) String() string {
+	var b strings.Builder
+	b.WriteString(ex.Value.String())
+	b.WriteString(" IN [")
+	for i, o := range ex.Options {
+		if i != 0 {
+			b.WriteString(",")
+		}
+		b.WriteString(o.String())
+	}
+	b.WriteString("]")
+	return b.String()
+}
+
+func (ex *SingularOrList) ToProtoFuncArg() *proto.FunctionArgument {
+	return &proto.FunctionArgument{
+		ArgType: &proto.FunctionArgument_Value{
+			Value: ex.ToProto(),
+		},
 	}
 }
+
+func (ex *SingularOrList) isRootRef() {}
+
+func (ex *SingularOrList) IsScalar() bool {
+	if !ex.Value.IsScalar() {
+		return false
+	}
+
+	for _, o := range ex.Options {
+		if !o.IsScalar() {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (ex *SingularOrList) GetType() types.Type {
+	return &types.BooleanType{Nullability: types.NullabilityNullable}
+}
+
+func (ex *SingularOrList) ToProto() *proto.Expression {
+	opts := make([]*proto.Expression, len(ex.Options))
+	for i, o := range ex.Options {
+		opts[i] = o.ToProto()
+	}
+	return &proto.Expression{
+		RexType: &proto.Expression_SingularOrList_{
+			SingularOrList: &proto.Expression_SingularOrList{
+				Value:   ex.Value.ToProto(),
+				Options: opts,
+			},
+		},
+	}
+}
+
+func (ex *SingularOrList) Equals(other Expression) bool {
+	rhs, ok := other.(*SingularOrList)
+	if !ok {
+		return false
+	}
+
+	if !ex.Value.Equals(rhs.Value) {
+		return false
+	}
+
+	if len(ex.Options) != len(rhs.Options) {
+		return false
+	}
+
+	for i := range ex.Options {
+		if !ex.Options[i].Equals(rhs.Options[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (ex *SingularOrList) Visit(visit VisitFunc) Expression {
+	var out *SingularOrList
+	if temp := visit(ex.Value); temp != ex.Value {
+		out = &SingularOrList{
+			Value:   temp,
+			Options: make([]Expression, len(ex.Options)),
+		}
+	}
+
+	for i, o := range ex.Options {
+		temp := visit(o)
+		if out == nil && temp != o {
+			out = &SingularOrList{Value: ex.Value, Options: make([]Expression, len(ex.Options))}
+			for j := 0; j < len(ex.Options); j++ {
+				out.Options[j] = ex.Options[j]
+			}
+		}
+
+		if out != nil {
+			out.Options[i] = temp
+		}
+	}
+
+	if out == nil {
+		return ex
+	}
+
+	return out
+}
+
+type MultiOrList struct {
+	Value   []Expression
+	Options [][]Expression
+}
+
+func (ex *MultiOrList) String() string {
+	var b strings.Builder
+	writeList := func(list []Expression) {
+		b.WriteByte('[')
+		for i, v := range list {
+			if i != 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString(v.String())
+		}
+		b.WriteByte(']')
+	}
+
+	writeList(ex.Value)
+	b.WriteString("IN [")
+	for i, opts := range ex.Options {
+		if i != 0 {
+			b.WriteString(", ")
+		}
+		writeList(opts)
+	}
+	b.WriteString("]")
+
+	return b.String()
+}
+
+func (ex *MultiOrList) ToProtoFuncArg() *proto.FunctionArgument {}
+func (ex *MultiOrList) isRootRef()                              {}
+func (ex *MultiOrList) IsScalar() bool                          {}
+func (ex *MultiOrList) GetType() types.Type                     {}
+func (ex *MultiOrList) ToProto() *proto.Expression              {}
+func (ex *MultiOrList) Equals(Expression) bool                  {}
+func (ex *MultiOrList) Visit(VisitFunc) Expression              {}
 
 type NestedExpr interface {
 	types.FuncArg
@@ -228,6 +696,15 @@ type MapExpr struct {
 func (m *MapExpr) IsNullable() bool      { return m.Nullable }
 func (m *MapExpr) TypeVariation() uint32 { return m.TypeVariationRef }
 
+func (ex *MapExpr) String() string                          {}
+func (ex *MapExpr) ToProtoFuncArg() *proto.FunctionArgument {}
+func (ex *MapExpr) isRootRef()                              {}
+func (ex *MapExpr) IsScalar() bool                          {}
+func (ex *MapExpr) GetType() types.Type                     {}
+func (ex *MapExpr) ToProto() *proto.Expression              {}
+func (ex *MapExpr) Equals(Expression) bool                  {}
+func (ex *MapExpr) Visit(VisitFunc) Expression              {}
+
 type StructExpr struct {
 	Nullable         bool
 	TypeVariationRef uint32
@@ -237,6 +714,15 @@ type StructExpr struct {
 func (s *StructExpr) IsNullable() bool      { return s.Nullable }
 func (s *StructExpr) TypeVariation() uint32 { return s.TypeVariationRef }
 
+func (ex *StructExpr) String() string                          {}
+func (ex *StructExpr) ToProtoFuncArg() *proto.FunctionArgument {}
+func (ex *StructExpr) isRootRef()                              {}
+func (ex *StructExpr) IsScalar() bool                          {}
+func (ex *StructExpr) GetType() types.Type                     {}
+func (ex *StructExpr) ToProto() *proto.Expression              {}
+func (ex *StructExpr) Equals(Expression) bool                  {}
+func (ex *StructExpr) Visit(VisitFunc) Expression              {}
+
 type ListExpr struct {
 	Nullable         bool
 	TypeVariationRef uint32
@@ -245,3 +731,77 @@ type ListExpr struct {
 
 func (l *ListExpr) IsNullable() bool      { return l.Nullable }
 func (l *ListExpr) TypeVariation() uint32 { return l.TypeVariationRef }
+
+func (ex *ListExpr) String() string                          {}
+func (ex *ListExpr) ToProtoFuncArg() *proto.FunctionArgument {}
+func (ex *ListExpr) isRootRef()                              {}
+func (ex *ListExpr) IsScalar() bool                          {}
+func (ex *ListExpr) GetType() types.Type                     {}
+func (ex *ListExpr) ToProto() *proto.Expression              {}
+func (ex *ListExpr) Equals(Expression) bool                  {}
+func (ex *ListExpr) Visit(VisitFunc) Expression              {}
+
+type ExpressionReference struct {
+	OutputNames []string
+	// only one of these should ever be set at a time
+	// this is ensured by the explicit setters rather than
+	// making them public
+	expr    Expression
+	measure *AggregateFunction
+}
+
+func (er *ExpressionReference) ToProto() *proto.ExpressionReference {
+	out := &proto.ExpressionReference{OutputNames: er.OutputNames}
+	switch {
+	case er.expr != nil:
+		out.ExprType = &proto.ExpressionReference_Expression{
+			Expression: er.expr.ToProto(),
+		}
+	case er.measure != nil:
+		out.ExprType = &proto.ExpressionReference_Measure{
+			Measure: er.measure.ToProto(),
+		}
+	}
+
+	return out
+}
+
+func (er *ExpressionReference) SetExpr(ex Expression) {
+	er.expr = ex
+	er.measure = nil
+}
+
+func (er *ExpressionReference) SetMeasure(m *AggregateFunction) {
+	er.expr = nil
+	er.measure = m
+}
+
+func (er *ExpressionReference) GetExpr() Expression            { return er.expr }
+func (er *ExpressionReference) GetMeasure() *AggregateFunction { return er.measure }
+
+type Extended struct {
+	Version          *types.Version
+	Extensions       extensions.Set
+	ReferredExpr     []ExpressionReference
+	BaseSchema       types.NamedStruct
+	AdvancedExts     *extensions.AdvancedExtension
+	ExpectedTypeURLs []string
+}
+
+func (ex *Extended) ToProto() *proto.ExtendedExpression {
+	uris, decls := ex.Extensions.ToProto()
+	refs := make([]*proto.ExpressionReference, len(ex.ReferredExpr))
+	for i, ref := range ex.ReferredExpr {
+		refs[i] = ref.ToProto()
+	}
+
+	return &proto.ExtendedExpression{
+		Version:            ex.Version,
+		ExtensionUris:      uris,
+		Extensions:         decls,
+		BaseSchema:         ex.BaseSchema.ToProto(),
+		AdvancedExtensions: ex.AdvancedExts,
+		ExpectedTypeUrls:   ex.ExpectedTypeURLs,
+		ReferredExpr:       refs,
+	}
+}

--- a/expr/expressions_test.go
+++ b/expr/expressions_test.go
@@ -61,7 +61,7 @@ func ExampleExpression_scalarFunction() {
 		"relations": []
 	}`
 
-	var plan types.Plan
+	var plan proto.Plan
 	if err := protojson.Unmarshal([]byte(planExt), &plan); err != nil {
 		panic(err)
 	}
@@ -224,7 +224,7 @@ func TestExpressionsRoundtrip(t *testing.T) {
 	}`
 
 	var (
-		plan            types.Plan
+		plan            proto.Plan
 		emptyCollection ext.Collection
 	)
 	if err := protojson.Unmarshal([]byte(planExt), &plan); err != nil {

--- a/expr/field_reference.go
+++ b/expr/field_reference.go
@@ -327,6 +327,10 @@ func (f *FieldReference) ToProtoFieldRef() *proto.Expression_FieldReference {
 				},
 			}
 		}
+	} else {
+		ret.RootType = &proto.Expression_FieldReference_RootReference_{
+			RootReference: &proto.Expression_FieldReference_RootReference{},
+		}
 	}
 
 	return ret

--- a/expr/functions.go
+++ b/expr/functions.go
@@ -509,12 +509,24 @@ func NewAggregateFunctionFromProto(agg *proto.AggregateFunction, baseSchema type
 		}
 	}
 
-	id, ok := ext.DecodeFunc(agg.FunctionReference)
-	if !ok {
-		return nil, substraitgo.ErrNotFound
+	var (
+		id   extensions.ID
+		decl *extensions.AggregateFunctionVariant
+		ok   bool
+	)
+
+	if ext != nil {
+		if id, ok = ext.DecodeFunc(agg.FunctionReference); !ok {
+			return nil, substraitgo.ErrNotFound
+		}
 	}
 
-	decl, _ := ext.LookupAggregateFunction(agg.FunctionReference, c)
+	if c != nil {
+		if decl, ok = ext.LookupAggregateFunction(agg.FunctionReference, c); !ok {
+			return nil, substraitgo.ErrNotFound
+		}
+	}
+
 	return &AggregateFunction{
 		FuncRef:     agg.FunctionReference,
 		ID:          id,

--- a/expr/testdata/expressions.yaml
+++ b/expr/testdata/expressions.yaml
@@ -1,0 +1,231 @@
+name: tests
+baseSchema:
+  names: [a, b, c, d]
+  struct:
+    nullability: NULLABILITY_REQUIRED
+    types:
+      - i32: { nullability: NULLABILITY_REQUIRED }
+      - i8: { nullability: NULLABILITY_REQUIRED }
+      - i16: { nullability: NULLABILITY_REQUIRED }
+      - i16: { nullability: NULLABILITY_NULLABLE }
+cases:
+  - name: scalar-func
+    __test:
+      type: fp64
+      string: |
+        (fp64(1), (.field(3) => i16?, (i64(2), [root:(struct<binary?, string, i32>([binary?([98 97 122]) string(foobar) i32(5)]))].field(2) => i32) => i64) => fp32) => fp64
+    expression:
+      scalarFunction:
+        functionReference: 2
+        arguments:
+          - value:
+              literal: { fp64: 1.0 }
+          - value:
+              scalarFunction:
+                functionReference: 3
+                outputType: { fp32: {} }
+                arguments:
+                  - value:
+                      selection:
+                        rootReference: {}
+                        directReference: { structField: { field: 3 }}
+                  - value:
+                      scalarFunction:
+                        functionReference: 4
+                        outputType: { i64: {} }
+                        arguments:
+                          - value: { literal: { i64: 2 } }
+                          - value:
+                              selection:
+                                expression:
+                                  literal:
+                                    struct:
+                                      fields:
+                                        - { binary: "YmF6", nullable: true }
+                                        - { string: "foobar", nullable: false }
+                                        - { i32: 5, nullable: false }
+                                directReference: { structField: { field: 2 } }
+        outputType: { fp64: {} }
+  - name: window-func
+    __test:
+      type: i32?
+      string: |
+        (.field(1) => i8; sort: [{expr: <IfThen>((.field(0) => i32) ?.field(1) => i8)<Else>(i32(1)), SORT_DIRECTION_CLUSTERED}]; [options: {DECOMPOSABLE => [NONE]}]; partitions: [.field(2) => i16]; phase: AGGREGATION_PHASE_INITIAL_TO_RESULT, invocation: AGGREGATION_INVOCATION_ALL) => i32?
+    expression:
+      windowFunction:
+        functionReference: 5
+        outputType: { i32: { nullability: "NULLABILITY_NULLABLE" } }
+        options:
+          - name: "DECOMPOSABLE"
+            preference: ["NONE"]
+        arguments:
+          - value:
+              selection:
+                rootReference: {}
+                directReference: { structField: { field: 1 } }
+        phase: "AGGREGATION_PHASE_INITIAL_TO_RESULT"
+        invocation: "AGGREGATION_INVOCATION_ALL"
+        sorts:
+          - direction: "SORT_DIRECTION_CLUSTERED"
+            expr:
+              ifThen:
+                ifs:
+                  - if:
+                      selection:
+                        rootReference: {}
+                        directReference: { structField: { field: 0 } }
+                    then:
+                      selection:
+                        rootReference: {}
+                        directReference: { structField: { field: 1 } }
+                else:
+                  literal: { i32: 1, nullable: false }
+        lowerBound: { unbounded: {} }
+        upperBound: { currentRow: {} }
+        partitions:
+          - selection:
+              rootReference: {}
+              directReference: { structField: { field: 2 } }
+  - name: ifthen
+    __test: { type: "i8" }
+    expression:
+      ifThen:
+        ifs:
+          - if:
+              selection:
+                rootReference: {}
+                directReference: { structField: { field: 0 } }
+            then:
+              selection:
+                rootReference: {}
+                directReference: { structField: { field: 1 } }
+        else:
+          selection:
+            rootReference: {}
+            directReference: { structField: { field: 1 } }
+  - name: switch-expr
+    __test: { type: "i16?"}
+    expression:
+      switchExpression:
+        match:
+          selection:
+            rootReference: {}
+            directReference: { structField: { field: 0 }}
+        ifs:
+          - if: { i32: 0 }
+            then:
+              selection:
+                rootReference: {}
+                directReference: { structField: { field: 2 }}
+          - if: { i32: 1 }
+            then:
+              selection:
+                rootReference: {}
+                directReference: { structField: { field: 3 } }
+        else:
+          selection:
+            rootReference: {}
+            directReference: { structField: { field: 2 } }
+  - name: singular-or-list
+    __test: 
+      type: "boolean"
+      string: |
+        .field(2) => i16 IN [i16(1),i16(2),i16(3)]
+    expression:
+      singularOrList:
+        value:
+          selection:
+            rootReference: {}
+            directReference: { structField: { field: 2 } }
+        options:
+          - literal: { i16: 1 }
+          - literal: { i16: 2 }
+          - literal: { i16: 3 }
+  - name: multi-or-list
+    __test: 
+      type: "boolean"
+      string: |
+        [.field(1) => i8, .field(2) => i16] IN [[i8(1), i16(2)], [i8(3), i16(4)], [i8(5), i16(6)]]
+    expression:
+      multiOrList:
+        value:
+          - selection:
+              rootReference: {}
+              directReference: { structField: { field: 1 }}
+          - selection:
+              rootReference: {}
+              directReference: { structField: { field: 2  }}
+        options:
+          - fields:
+            - literal: { i8: 1 }
+            - literal: { i16: 2 }
+          - fields:
+            - literal: { i8: 3 }
+            - literal: { i16: 4 }
+          - fields:
+            - literal: { i8: 5 }
+            - literal: { i16: 6 }
+  - name: nested-map-expr
+    __test: { type: "map<i8,i16>?" }
+    expression:
+      nested:
+        nullable: true
+        map:
+          keyValues:
+            - key:
+                literal: { i8: 1 }
+              value:
+                selection:
+                  rootReference: {}
+                  directReference: { structField: { field: 2 }}
+            - key:
+                selection:
+                  rootReference: {}
+                  directReference: { structField: { field: 1 }}
+              value:
+                literal: { i16: 2 }
+            - key:
+                selection:
+                  rootReference: {}
+                  directReference: { structField: { field: 0 }}
+              value:
+                selection:
+                  rootReference: {}
+                  directReference: { structField: { field: 3  }}
+  - name: nested-struct-expr
+    __test: { type: "struct<fp32, i32, fp64, i16?>" }
+    expression:
+      nested:
+        nullable: false
+        struct:
+          fields:
+            - literal: { fp32: 1.5 }
+            - selection:
+                rootReference: {}
+                directReference: { structField: { field: 0 } }
+            - literal: { fp64: 1.5 }
+            - selection:
+                rootReference: {}
+                directReference: { structField: { field: 3 } }
+  - name: nested-list-expr
+    __test: { type: "list<i16?>?" }
+    expression:
+      nested:
+        nullable: true
+        list:
+          values:
+            - selection:
+                rootReference: {}
+                directReference: { structField: { field: 3 } }
+            - literal: { i16: 1 }
+  - name: cast
+    __test: 
+      type: i64
+      string: |
+        cast(i16(6) AS i64, fail: FAILURE_BEHAVIOR_RETURN_NULL)
+    expression:
+      cast:
+        type: { i64: {} }
+        failureBehavior: FAILURE_BEHAVIOR_RETURN_NULL
+        input:
+          literal: { i16: 6 }

--- a/expr/testdata/extended_exprs.yaml
+++ b/expr/testdata/extended_exprs.yaml
@@ -1,0 +1,62 @@
+tests:
+- version: { producer: substraitgo-test }
+  extensionUris:
+    - extensionUriAnchor: 1
+      uri: https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml
+  extensions:
+    - extensionFunction:
+        extensionUriReference: 1
+        functionAnchor: 2
+        name: add
+    - extensionFunction:
+        extensionUriReference: 1
+        functionAnchor: 3
+        name: subtract
+    - extensionFunction:
+        extensionUriReference: 1
+        functionAnchor: 4
+        name: multiply
+    - extensionFunction:
+        extensionUriReference: 1
+        functionAnchor: 5
+        name: ntile
+    - extensionFunction:
+        extensionUriReference: 1
+        functionAnchor: 6
+        name: sum
+  baseSchema:
+    names: [a, b, c, d]
+    struct:
+      nullability: NULLABILITY_REQUIRED
+      types:
+        - i32: { nullability: NULLABILITY_REQUIRED }
+        - i8: { nullability: NULLABILITY_REQUIRED }
+        - i16: { nullability: NULLABILITY_REQUIRED }
+        - i16: { nullability: NULLABILITY_NULLABLE }
+  expectedTypeUrls:
+    - substrait.Plan
+  referredExpr:
+    - outputNames: [sum]
+      measure:
+        functionReference: 6
+        outputType: { i64: {} }
+        arguments:
+          - type: { i64: {} }
+          - value:
+              selection:
+                rootReference: {}
+                directReference: { structField: { field: 0 }}
+    - outputNames: [x]
+      expression:
+        scalarFunction:
+          functionReference: 2
+          arguments:        
+            - value:
+                selection:
+                  rootReference: {}
+                  directReference: { structField: { field: 1 }}
+            - value:
+                selection:
+                  rootReference: {}
+                  directReference: { structField: { field: 2 }}          
+          outputType: { i32: {} }

--- a/extensions/extension_mgr.go
+++ b/extensions/extension_mgr.go
@@ -12,6 +12,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+type AdvancedExtension = extensions.AdvancedExtension
+
 type ID struct {
 	URI, Name string
 }
@@ -178,6 +180,8 @@ type Set interface {
 	GetTypeAnchor(id ID) uint32
 	GetFuncAnchor(id ID) uint32
 	GetTypeVariationAnchor(id ID) uint32
+
+	ToProto() ([]*extensions.SimpleExtensionURI, []*extensions.SimpleExtensionDeclaration)
 }
 
 func NewSet() Set {
@@ -203,6 +207,57 @@ type set struct {
 
 	funcMap map[uint32]ID
 	funcs   map[ID]uint32
+}
+
+func (e *set) ToProto() ([]*extensions.SimpleExtensionURI, []*extensions.SimpleExtensionDeclaration) {
+	backRef := make(map[string]uint32)
+	uris := make([]*extensions.SimpleExtensionURI, 0, len(e.uris))
+	for anchor, uri := range e.uris {
+		backRef[uri] = anchor
+		uris = append(uris, &extensions.SimpleExtensionURI{
+			ExtensionUriAnchor: anchor,
+			Uri:                uri,
+		})
+	}
+
+	decls := make([]*extensions.SimpleExtensionDeclaration, 0, len(e.types)+len(e.typeVariations)+len(e.funcs))
+	for id, anchor := range e.types {
+		decls = append(decls, &extensions.SimpleExtensionDeclaration{
+			MappingType: &extensions.SimpleExtensionDeclaration_ExtensionType_{
+				ExtensionType: &extensions.SimpleExtensionDeclaration_ExtensionType{
+					ExtensionUriReference: backRef[id.URI],
+					TypeAnchor:            anchor,
+					Name:                  id.Name,
+				},
+			},
+		})
+	}
+
+	for id, anchor := range e.typeVariations {
+		decls = append(decls, &extensions.SimpleExtensionDeclaration{
+			MappingType: &extensions.SimpleExtensionDeclaration_ExtensionTypeVariation_{
+				ExtensionTypeVariation: &extensions.SimpleExtensionDeclaration_ExtensionTypeVariation{
+					ExtensionUriReference: backRef[id.URI],
+					TypeVariationAnchor:   anchor,
+					Name:                  id.Name,
+				},
+			},
+		})
+	}
+
+	for id, anchor := range e.funcs {
+		decls = append(decls, &extensions.SimpleExtensionDeclaration{
+			MappingType: &extensions.SimpleExtensionDeclaration_ExtensionFunction_{
+				ExtensionFunction: &extensions.SimpleExtensionDeclaration_ExtensionFunction{
+					ExtensionUriReference: backRef[id.URI],
+					FunctionAnchor:        anchor,
+					Name:                  id.Name,
+				},
+			},
+		})
+	}
+
+	return uris, decls
 }
 
 func (e *set) LookupWindowFunction(anchor uint32, c *Collection) (sv *WindowFunctionVariant, ok bool) {

--- a/extensions/extension_mgr.go
+++ b/extensions/extension_mgr.go
@@ -7,7 +7,6 @@ import (
 	"io"
 
 	substraitgo "github.com/substrait-io/substrait-go"
-	"github.com/substrait-io/substrait-go/proto"
 	"github.com/substrait-io/substrait-go/proto/extensions"
 	"gopkg.in/yaml.v3"
 )
@@ -389,9 +388,14 @@ func (e *set) addURI(uri string) (uint32, error) {
 	return sz, nil
 }
 
-func GetExtensionSet(plan *proto.Plan) Set {
+type TopLevel interface {
+	GetExtensionUris() []*extensions.SimpleExtensionURI
+	GetExtensions() []*extensions.SimpleExtensionDeclaration
+}
+
+func GetExtensionSet(plan TopLevel) Set {
 	uris := make(map[uint32]string)
-	for _, uri := range plan.ExtensionUris {
+	for _, uri := range plan.GetExtensionUris() {
 		uris[uri.ExtensionUriAnchor] = uri.Uri
 	}
 
@@ -405,7 +409,7 @@ func GetExtensionSet(plan *proto.Plan) Set {
 		typeVariations:   make(map[ID]uint32),
 	}
 
-	for _, ext := range plan.Extensions {
+	for _, ext := range plan.GetExtensions() {
 		switch e := ext.MappingType.(type) {
 		case *extensions.SimpleExtensionDeclaration_ExtensionTypeVariation_:
 			etv := e.ExtensionTypeVariation

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"github.com/substrait-io/substrait-go/extensions"
+	"github.com/substrait-io/substrait-go/proto"
+	"github.com/substrait-io/substrait-go/types"
+)
+
+type Relation = *proto.PlanRel
+
+type Plan struct {
+	Version            *types.Version
+	Extensions         extensions.Set
+	ExpectedTypeURLs   []string
+	AdvancedExtensions *extensions.AdvancedExtension
+	Relations          []Relation
+}
+
+func FromProto(plan *proto.Plan) (*Plan, error) {
+	return &Plan{
+		Version:            plan.Version,
+		Relations:          plan.Relations,
+		Extensions:         extensions.GetExtensionSet(plan),
+		AdvancedExtensions: plan.AdvancedExtensions,
+		ExpectedTypeURLs:   plan.ExpectedTypeUrls,
+	}, nil
+}
+
+func (p *Plan) ToProto() (*proto.Plan, error) {
+	uris, decls := p.Extensions.ToProto()
+	return &proto.Plan{
+		Version:            p.Version,
+		ExpectedTypeUrls:   p.ExpectedTypeURLs,
+		AdvancedExtensions: p.AdvancedExtensions,
+		Relations:          p.Relations,
+		Extensions:         decls,
+		ExtensionUris:      uris,
+	}, nil
+}

--- a/types/parser/type_parser.go
+++ b/types/parser/type_parser.go
@@ -323,7 +323,7 @@ type mapType struct {
 func (*mapType) ShortType() string { return "map" }
 
 func (m *mapType) String() string {
-	return "map<" + m.Key.Expr.String() + ", " + m.Value.Expr.String() + ">"
+	return "map<" + m.Key.Expr.String() + "," + m.Value.Expr.String() + ">"
 }
 
 func (t *mapType) Type(n types.Nullability) (types.Type, error) {

--- a/types/parser/type_parser_test.go
+++ b/types/parser/type_parser_test.go
@@ -23,7 +23,7 @@ func TestParser(t *testing.T) {
 		{"decimal<10,5>", "decimal<10, 5>"},
 		{"list<decimal<10,5>>", "list<decimal<10, 5>>"},
 		{"struct<i16?,i32>", "struct<i16?, i32>"},
-		{"map<boolean?,struct<i16?,i32?,i64?>?>?", "map<boolean?, struct<i16?, i32?, i64?>?>?"},
+		{"map<boolean?,struct<i16?,i32?,i64?>?>?", "map<boolean?,struct<i16?, i32?, i64?>?>?"},
 	}
 
 	p, err := parser.New()

--- a/types/types.go
+++ b/types/types.go
@@ -5,6 +5,7 @@ package types
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/substrait-io/substrait-go/proto"
@@ -49,9 +50,13 @@ const (
 	SortClustered      = SortDirection(proto.SortField_SORT_DIRECTION_CLUSTERED)
 )
 
+func (s SortDirection) String() string { return proto.SortField_SortDirection(s).String() }
+
 func (SortDirection) isSortKind() {}
 
 type FunctionRef uint32
+
+func (f FunctionRef) String() string { return "comparison_func_ref: " + strconv.Itoa(int(f)) }
 
 func (FunctionRef) isSortKind() {}
 
@@ -240,6 +245,7 @@ type (
 
 	SortKind interface {
 		isSortKind()
+		fmt.Stringer
 	}
 
 	// Type corresponds to the proto.Type message and represents
@@ -252,6 +258,9 @@ type (
 		GetNullability() Nullability
 		GetTypeVariationReference() uint32
 		Equals(Type) bool
+		// WithNullability returns a copy of this type but with
+		// the nullability set to the passed in value
+		WithNullability(Nullability) Type
 	}
 )
 
@@ -414,7 +423,13 @@ type PrimitiveType[T primitiveTypeIFace] struct {
 	TypeVariationRef uint32
 }
 
-func (*PrimitiveType[T]) isRootRef()                          {}
+func (*PrimitiveType[T]) isRootRef() {}
+func (s *PrimitiveType[T]) WithNullability(n Nullability) Type {
+	out := *s
+	out.Nullability = n
+	return &out
+}
+
 func (s *PrimitiveType[T]) GetType() Type                     { return s }
 func (s *PrimitiveType[T]) GetNullability() Nullability       { return s.Nullability }
 func (s *PrimitiveType[T]) GetTypeVariationReference() uint32 { return s.TypeVariationRef }
@@ -471,7 +486,13 @@ type FixedLenType[T FixedChar | VarChar | FixedBinary] struct {
 	Length           int32
 }
 
-func (*FixedLenType[T]) isRootRef()                          {}
+func (*FixedLenType[T]) isRootRef() {}
+func (s *FixedLenType[T]) WithNullability(n Nullability) Type {
+	out := *s
+	out.Nullability = n
+	return &out
+}
+
 func (s *FixedLenType[T]) GetType() Type                     { return s }
 func (s *FixedLenType[T]) GetNullability() Nullability       { return s.Nullability }
 func (s *FixedLenType[T]) GetTypeVariationReference() uint32 { return s.TypeVariationRef }
@@ -501,7 +522,13 @@ type DecimalType struct {
 	Scale, Precision int32
 }
 
-func (*DecimalType) isRootRef()                          {}
+func (*DecimalType) isRootRef() {}
+func (s *DecimalType) WithNullability(n Nullability) Type {
+	out := *s
+	out.Nullability = n
+	return &out
+}
+
 func (s *DecimalType) GetType() Type                     { return s }
 func (s *DecimalType) GetNullability() Nullability       { return s.Nullability }
 func (s *DecimalType) GetTypeVariationReference() uint32 { return s.TypeVariationRef }
@@ -538,7 +565,13 @@ type StructType struct {
 	Types            []Type
 }
 
-func (*StructType) isRootRef()                          {}
+func (*StructType) isRootRef() {}
+func (s *StructType) WithNullability(n Nullability) Type {
+	out := *s
+	out.Nullability = n
+	return &out
+}
+
 func (s *StructType) GetType() Type                     { return s }
 func (s *StructType) GetNullability() Nullability       { return s.Nullability }
 func (s *StructType) GetTypeVariationReference() uint32 { return s.TypeVariationRef }
@@ -603,7 +636,13 @@ type ListType struct {
 	Type Type
 }
 
-func (*ListType) isRootRef()                          {}
+func (*ListType) isRootRef() {}
+func (s *ListType) WithNullability(n Nullability) Type {
+	out := *s
+	out.Nullability = n
+	return &out
+}
+
 func (s *ListType) GetType() Type                     { return s }
 func (s *ListType) GetNullability() Nullability       { return s.Nullability }
 func (s *ListType) GetTypeVariationReference() uint32 { return s.TypeVariationRef }
@@ -645,7 +684,13 @@ type MapType struct {
 	Key, Value       Type
 }
 
-func (*MapType) isRootRef()                          {}
+func (*MapType) isRootRef() {}
+func (s *MapType) WithNullability(n Nullability) Type {
+	out := *s
+	out.Nullability = n
+	return &out
+}
+
 func (s *MapType) GetType() Type                     { return s }
 func (s *MapType) GetNullability() Nullability       { return s.Nullability }
 func (s *MapType) GetTypeVariationReference() uint32 { return s.TypeVariationRef }
@@ -810,7 +855,13 @@ type UserDefinedType struct {
 	TypeParameters   []TypeParam
 }
 
-func (*UserDefinedType) isRootRef()                          {}
+func (*UserDefinedType) isRootRef() {}
+func (s *UserDefinedType) WithNullability(n Nullability) Type {
+	out := *s
+	out.Nullability = n
+	return &out
+}
+
 func (s *UserDefinedType) GetType() Type                     { return s }
 func (s *UserDefinedType) GetNullability() Nullability       { return s.Nullability }
 func (s *UserDefinedType) GetTypeVariationReference() uint32 { return s.TypeVariationRef }

--- a/types/types.go
+++ b/types/types.go
@@ -10,7 +10,7 @@ import (
 	"github.com/substrait-io/substrait-go/proto"
 )
 
-type Plan = proto.Plan
+type Version = proto.Version
 
 type Nullability = proto.Type_Nullability
 
@@ -875,6 +875,13 @@ func (e Enum) String() string { return string(e) }
 type NamedStruct struct {
 	Names  []string
 	Struct StructType
+}
+
+func (n *NamedStruct) ToProto() *proto.NamedStruct {
+	return &proto.NamedStruct{
+		Names:  n.Names,
+		Struct: n.Struct.ToProto().GetStruct(),
+	}
 }
 
 func (n *NamedStruct) String() string {

--- a/types/types.go
+++ b/types/types.go
@@ -877,6 +877,26 @@ type NamedStruct struct {
 	Struct StructType
 }
 
+func NewNamedStructFromProto(n *proto.NamedStruct) NamedStruct {
+	if n == nil {
+		return NamedStruct{}
+	}
+
+	fields := make([]Type, len(n.Struct.Types))
+	for i, f := range n.Struct.Types {
+		fields[i] = TypeFromProto(f)
+	}
+
+	return NamedStruct{
+		Names: n.Names,
+		Struct: StructType{
+			Nullability:      n.Struct.Nullability,
+			TypeVariationRef: n.Struct.TypeVariationReference,
+			Types:            fields,
+		},
+	}
+}
+
 func (n *NamedStruct) ToProto() *proto.NamedStruct {
 	return &proto.NamedStruct{
 		Names:  n.Names,


### PR DESCRIPTION
This implements handling for all expression types *except* for Subquery, and sets up the framework for plan handling.

Including a unit test framework for defining expressions in a test yaml file which get used as test cases.