### PR TITLE
ci(release): Github token env var to docker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Run go-semantic-release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run go-semantic-release        
         run: |
-          docker run -v "$(pwd)":/code nightapes/go-semantic-release:2.1.0 release -l trace
+          docker run -e GITHUB_TOKEN:${{ secrets.GITHUB_TOKEN }} -v "$(pwd)":/code nightapes/go-semantic-release:2.1.0 release -l trace


### PR DESCRIPTION
Looks like the env var needs to be passed directly to the docker command rather than just set for the step.