### PR TITLE
ci(release): use docker run -u root to fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         # if event_name == pull_request it will not perform a release          
         run: |
           echo $USER    
-          docker run -u $USER -e GITHUB_ACTION=${{ github.action}} \
+          docker run -u 1000 -e GITHUB_ACTION=${{ github.action}} \
             -e GITHUB_EVENT_NAME=${{ github.event_name }} \
             -e GITHUB_REF=${{ github.ref }} \
             -e GITHUB_SHA=${{ github.sha }} \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,4 +30,4 @@ jobs:
           fetch-depth: 0
       - name: Run go-semantic-release        
         run: |
-          docker run -e CI=true -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} -v "$(pwd)":/code nightapes/go-semantic-release:2.1.0 release -l trace
+          docker run -u root -e CI=true -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} -v "$(pwd)":/code nightapes/go-semantic-release:2.1.0 release -l trace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
         with:          
-          fetch-depth: 0
-      - name: Run a test
-        run: |
-          docker run -v "$(pwd)":/code -w /code alpine:3.14 touch .version
+          fetch-depth: 0      
       - name: Run go-semantic-release
         # the dockerfile for go-semantic-release uses USER 1000 so hopefully
         # this is sufficient to have permissions?
@@ -41,4 +38,4 @@ jobs:
             -e GITHUB_EVENT_NAME=${{ github.event_name }} \
             -e GITHUB_REF=${{ github.ref }} \
             -e GITHUB_SHA=${{ github.sha }} \
-            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} -v "$(pwd)":/code nightapes/go-semantic-release:2.1.0 release -l trace
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} -v "$(pwd)":/code nightapes/go-semantic-release:latest release -l trace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  pull_request:    
   schedule:
     # 2 AM on Sunday
     - cron: "0 2 * * 0"
@@ -26,8 +27,15 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-        with:
+        with:          
           fetch-depth: 0
-      - name: Run go-semantic-release        
+      - run: ls -la
+      - name: Run go-semantic-release
+        # if event_name == pull_request it will not perform a release          
         run: |
-          docker run -u root -e CI=true -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} -v "$(pwd)":/code nightapes/go-semantic-release:2.1.0 release -l trace
+          echo $USER    
+          docker run -u $USER -e GITHUB_ACTION=${{ github.action}} \
+            -e GITHUB_EVENT_NAME=${{ github.event_name }} \
+            -e GITHUB_REF=${{ github.ref }} \
+            -e GITHUB_SHA=${{ github.sha }} \
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} -v "$(pwd)":/code nightapes/go-semantic-release:2.1.0 release -l trace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,14 @@ jobs:
         uses: actions/checkout@v3
         with:          
           fetch-depth: 0
-      - run: ls -la
-      - name: Run go-semantic-release
-        # if event_name == pull_request it will not perform a release          
+      - name: Run a test
         run: |
-          echo $USER    
+          docker run -v "$(pwd)":/code -w /code alpine:3.14 touch .version
+      - name: Run go-semantic-release
+        # the dockerfile for go-semantic-release uses USER 1000 so hopefully
+        # this is sufficient to have permissions?
+        # if event_name == pull_request it will not perform a release          
+        run: |          
           docker run -u 1000 -e GITHUB_ACTION=${{ github.action}} \
             -e GITHUB_EVENT_NAME=${{ github.event_name }} \
             -e GITHUB_REF=${{ github.ref }} \

--- a/.release.yml
+++ b/.release.yml
@@ -9,4 +9,4 @@ changelog:
   printAll: true
   title: "v{{.Version}}"
   showAuthors: false
-  showBodyAsheader: false
+


### PR DESCRIPTION
`go-semantic-release` tries to write a `.version` file and then fails with a permission denied error, probably because the `docker run` runs as a different user. So let's use `-u root` so the release workflow can succeed.