### PR TITLE
fix(expressions): Use compound names in function identifiers

### DIFF
--- a/expr/builder_test.go
+++ b/expr/builder_test.go
@@ -25,7 +25,7 @@ func TestExprBuilder(t *testing.T) {
 		err      string
 	}{
 		{"literal", "i8?(5)", b.Wrap(expr.NewLiteral(int8(5), true)), ""},
-		{"simple add", "add(.field(1) => i8, i8(5)) => i8?",
+		{"simple add", "add:i8_i8(.field(1) => i8, i8(5)) => i8?",
 			b.ScalarFunc(addID).Args(
 				b.RootRef(expr.NewStructFieldRef(1)),
 				b.Literal(expr.NewPrimitiveLiteral(int8(5), false)),
@@ -33,23 +33,23 @@ func TestExprBuilder(t *testing.T) {
 		{"expect args", "",
 			b.ScalarFunc(indexInID),
 			"invalid expression: mismatch in number of arguments provided. got 0, expected 2"},
-		{"with opt", "index_in(i32(5), list<i32>([]), {nan_equality: [NAN_IS_NAN]}) => i64?",
+		{"with opt", "index_in:t_list(i32(5), list<i32>([]), {nan_equality: [NAN_IS_NAN]}) => i64?",
 			b.ScalarFunc(indexInID, &types.FunctionOption{
 				Name:       "nan_equality",
 				Preference: []string{"NAN_IS_NAN"}}).Args(
 				b.Wrap(expr.NewLiteral(int32(5), false)),
 				b.Literal(expr.NewEmptyListLiteral(&types.Int32Type{}, false))), ""},
-		{"with cast", "subtract(.field(3) => i32, cast(.field(6) => fp32 AS i32, fail: FAILURE_BEHAVIOR_THROW_EXCEPTION)) => i32?",
+		{"with cast", "subtract:i32_i32(.field(3) => i32, cast(.field(6) => fp32 AS i32, fail: FAILURE_BEHAVIOR_THROW_EXCEPTION)) => i32?",
 			b.ScalarFunc(subID).Args(
 				b.RootRef(expr.NewStructFieldRef(3)),
 				b.Cast(b.RootRef(expr.NewStructFieldRef(6)), &types.Int32Type{}).
 					FailBehavior(types.BehaviorThrowException),
 			), ""},
-		{"window func", "",
+		{"window func error", "",
 			b.WindowFunc(rankID), "invalid expression: non-decomposable window or agg function '{https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml rank}' must use InitialToResult phase"},
-		{"window func", "rank(; phase: AGGREGATION_PHASE_INITIAL_TO_RESULT, invocation: AGGREGATION_INVOCATION_UNSPECIFIED) => i64?",
+		{"window func", "rank:(; phase: AGGREGATION_PHASE_INITIAL_TO_RESULT, invocation: AGGREGATION_INVOCATION_UNSPECIFIED) => i64?",
 			b.WindowFunc(rankID).Phase(types.AggPhaseInitialToResult), ""},
-		{"nested funcs", "add(extract(YEAR, date(10957)) => i64, rank(; phase: AGGREGATION_PHASE_INITIAL_TO_RESULT, invocation: AGGREGATION_INVOCATION_ALL) => i64?) => i64?",
+		{"nested funcs", "add:i64_i64(extract:req_date(YEAR, date(10957)) => i64, rank:(; phase: AGGREGATION_PHASE_INITIAL_TO_RESULT, invocation: AGGREGATION_INVOCATION_ALL) => i64?) => i64?",
 			b.ScalarFunc(addID).Args(
 				b.ScalarFunc(extractID).Args(b.Enum("YEAR"),
 					b.Wrap(expr.NewLiteral(types.Date(10957), false))),
@@ -58,7 +58,7 @@ func TestExprBuilder(t *testing.T) {
 			b.ScalarFunc(addID).Args(
 				b.RootRef(expr.NewListElemRef(0)),
 				b.Literal(expr.NewPrimitiveLiteral(int32(5), false))), "error resolving ref type: invalid type"},
-		{"window func args", "ntile(i32(5); sort: [{expr: .field(1) => i8, SORT_DIRECTION_ASC_NULLS_FIRST}]; phase: AGGREGATION_PHASE_INITIAL_TO_RESULT, invocation: AGGREGATION_INVOCATION_UNSPECIFIED) => i32?",
+		{"window func args", "ntile:i32(i32(5); sort: [{expr: .field(1) => i8, SORT_DIRECTION_ASC_NULLS_FIRST}]; phase: AGGREGATION_PHASE_INITIAL_TO_RESULT, invocation: AGGREGATION_INVOCATION_UNSPECIFIED) => i32?",
 			b.WindowFunc(ntileID).Args(b.Wrap(expr.NewLiteral(int32(5), false))).
 				Phase(types.AggPhaseInitialToResult).
 				Sort(expr.SortField{

--- a/expr/expression.go
+++ b/expr/expression.go
@@ -71,7 +71,7 @@ func ExprFromProto(e *proto.Expression, baseSchema types.Type, reg ExtensionRegi
 
 		decl, ok := reg.LookupScalarFunction(et.ScalarFunction.FunctionReference)
 		if !ok {
-			return NewCustomScalarFunc(reg, extensions.NewScalarFuncVariant(id), types.TypeFromProto(et.ScalarFunction.OutputType), et.ScalarFunction.Options, args...)
+			return nil, fmt.Errorf("%w: Function %s not found", substraitgo.ErrNotFound, id.Name)
 		}
 
 		fullId := extensions.ID{Name: decl.CompoundName(), URI: id.URI}
@@ -112,17 +112,7 @@ func ExprFromProto(e *proto.Expression, baseSchema types.Type, reg ExtensionRegi
 		}
 		decl, ok := reg.LookupWindowFunction(et.WindowFunction.FunctionReference)
 		if !ok {
-			fn, err := NewCustomWindowFunc(reg, extensions.NewWindowFuncVariant(id), types.TypeFromProto(et.WindowFunction.OutputType),
-				et.WindowFunction.Options, et.WindowFunction.Invocation, et.WindowFunction.Phase, args...)
-			if err != nil {
-				return nil, err
-			}
-
-			fn.Partitions = parts
-			fn.Sorts = sorts
-			fn.LowerBound = BoundFromProto(et.WindowFunction.LowerBound)
-			fn.UpperBound = BoundFromProto(et.WindowFunction.UpperBound)
-			return fn, nil
+			return nil, fmt.Errorf("%w: Function %s not found", substraitgo.ErrNotFound, id.Name)
 		}
 
 		return &WindowFunction{

--- a/expr/expression.go
+++ b/expr/expression.go
@@ -74,10 +74,11 @@ func ExprFromProto(e *proto.Expression, baseSchema types.Type, reg ExtensionRegi
 			return NewCustomScalarFunc(reg, extensions.NewScalarFuncVariant(id), types.TypeFromProto(et.ScalarFunction.OutputType), et.ScalarFunction.Options, args...)
 		}
 
+		fullId := extensions.ID{Name: decl.CompoundName(), URI: id.URI}
 		return &ScalarFunction{
 			funcRef:     et.ScalarFunction.FunctionReference,
 			declaration: decl,
-			id:          id,
+			id:          fullId,
 			args:        args,
 			options:     et.ScalarFunction.Options,
 			outputType:  types.TypeFromProto(et.ScalarFunction.OutputType),

--- a/expr/functions.go
+++ b/expr/functions.go
@@ -746,7 +746,7 @@ func NewAggregateFunctionFromProto(agg *proto.AggregateFunction, baseSchema type
 	}
 	decl, ok := reg.LookupAggregateFunction(agg.FunctionReference)
 	if !ok {
-		return NewCustomAggregateFunc(reg, extensions.NewAggFuncVariant(id), types.TypeFromProto(agg.OutputType), agg.Options, agg.Invocation, agg.Phase, sorts, args...)
+		return nil, fmt.Errorf("%w: Function %s not found", substraitgo.ErrNotFound, id.Name)
 	}
 
 	fullId := extensions.ID{Name: decl.CompoundName(), URI: id.URI}

--- a/expr/functions.go
+++ b/expr/functions.go
@@ -246,9 +246,11 @@ func NewScalarFunc(reg ExtensionRegistry, id extensions.ID, opts []*types.Functi
 		return nil, err
 	}
 
+	compoundId := extensions.ID{Name: decl.CompoundName(), URI: id.URI}
+
 	return &ScalarFunction{
-		funcRef:     reg.GetFuncAnchor(id),
-		id:          id,
+		funcRef:     reg.GetFuncAnchor(compoundId),
+		id:          compoundId,
 		declaration: decl,
 		outputType:  outType,
 		options:     opts,
@@ -452,9 +454,11 @@ func NewWindowFunc(reg ExtensionRegistry, id extensions.ID, opts []*types.Functi
 			substraitgo.ErrInvalidExpr, id)
 	}
 
+	compoundId := extensions.ID{Name: decl.CompoundName(), URI: id.URI}
+
 	return &WindowFunction{
-		funcRef:     reg.GetFuncAnchor(id),
-		id:          id,
+		funcRef:     reg.GetFuncAnchor(compoundId),
+		id:          compoundId,
 		declaration: decl,
 		outputType:  outType,
 		options:     opts,
@@ -684,9 +688,10 @@ func NewAggregateFunc(reg ExtensionRegistry, id extensions.ID, opts []*types.Fun
 		return nil, err
 	}
 
+	compoundId := extensions.ID{Name: decl.CompoundName(), URI: id.URI}
 	return &AggregateFunction{
-		funcRef:     reg.GetFuncAnchor(id),
-		id:          id,
+		funcRef:     reg.GetFuncAnchor(compoundId),
+		id:          compoundId,
 		declaration: decl,
 		outputType:  outType,
 		options:     opts,
@@ -744,9 +749,10 @@ func NewAggregateFunctionFromProto(agg *proto.AggregateFunction, baseSchema type
 		return NewCustomAggregateFunc(reg, extensions.NewAggFuncVariant(id), types.TypeFromProto(agg.OutputType), agg.Options, agg.Invocation, agg.Phase, sorts, args...)
 	}
 
+	fullId := extensions.ID{Name: decl.CompoundName(), URI: id.URI}
 	return &AggregateFunction{
 		funcRef:     agg.FunctionReference,
-		id:          id,
+		id:          fullId,
 		declaration: decl,
 		args:        args,
 		options:     agg.Options,

--- a/expr/testdata/expressions.yaml
+++ b/expr/testdata/expressions.yaml
@@ -13,7 +13,7 @@ cases:
     __test:
       type: fp64
       string: |
-        add(fp64(1), subtract(.field(3) => i16?, multiply(i64(2), [root:(struct<binary?, string, i32>([binary?([98 97 122]) string(foobar) i32(5)]))].field(2) => i32) => i64) => fp32) => fp64
+        add:fp64_fp64(fp64(1), subtract:fp32_fp32(.field(3) => i16?, multiply:i64_i64(i64(2), [root:(struct<binary?, string, i32>([binary?([98 97 122]) string(foobar) i32(5)]))].field(2) => i32) => i64) => fp32) => fp64
     expression:
       scalarFunction:
         functionReference: 2
@@ -50,7 +50,7 @@ cases:
     __test:
       type: i32?
       string: |
-        ntile(.field(1) => i8; sort: [{expr: <IfThen>((.field(0) => i32) ?.field(1) => i8)<Else>(i32(1)), SORT_DIRECTION_CLUSTERED}]; [options: {DECOMPOSABLE => [NONE]}]; partitions: [.field(2) => i16]; phase: AGGREGATION_PHASE_INITIAL_TO_RESULT, invocation: AGGREGATION_INVOCATION_ALL) => i32?
+        ntile:i64(.field(1) => i8; sort: [{expr: <IfThen>((.field(0) => i32) ?.field(1) => i8)<Else>(i32(1)), SORT_DIRECTION_CLUSTERED}]; [options: {DECOMPOSABLE => [NONE]}]; partitions: [.field(2) => i16]; phase: AGGREGATION_PHASE_INITIAL_TO_RESULT, invocation: AGGREGATION_INVOCATION_ALL) => i32?
     expression:
       windowFunction:
         functionReference: 5
@@ -127,7 +127,7 @@ cases:
             rootReference: {}
             directReference: { structField: { field: 2 } }
   - name: singular-or-list
-    __test: 
+    __test:
       type: "boolean"
       string: |
         .field(2) => i16 IN [i16(1),i16(2),i16(3)]
@@ -142,7 +142,7 @@ cases:
           - literal: { i16: 2 }
           - literal: { i16: 3 }
   - name: multi-or-list
-    __test: 
+    __test:
       type: "boolean"
       string: |
         [.field(1) => i8, .field(2) => i16] IN [[i8(1), i16(2)], [i8(3), i16(4)], [i8(5), i16(6)]]
@@ -219,7 +219,7 @@ cases:
                 directReference: { structField: { field: 3 } }
             - literal: { i16: 1 }
   - name: cast
-    __test: 
+    __test:
       type: i64
       string: |
         cast(i16(6) AS i64, fail: FAILURE_BEHAVIOR_RETURN_NULL)

--- a/expr/testdata/extended_exprs.yaml
+++ b/expr/testdata/extended_exprs.yaml
@@ -7,23 +7,23 @@ tests:
     - extensionFunction:
         extensionUriReference: 1
         functionAnchor: 2
-        name: add
+        name: add:fp64_fp64
     - extensionFunction:
         extensionUriReference: 1
         functionAnchor: 3
-        name: subtract
+        name: subtract:fp32_fp32
     - extensionFunction:
         extensionUriReference: 1
         functionAnchor: 4
-        name: multiply
+        name: multiply:i64_i64
     - extensionFunction:
         extensionUriReference: 1
         functionAnchor: 5
-        name: ntile
+        name: ntile:i64
     - extensionFunction:
         extensionUriReference: 1
         functionAnchor: 6
-        name: sum
+        name: sum:i64
   baseSchema:
     names: [a, b, c, d]
     struct:
@@ -50,7 +50,7 @@ tests:
       expression:
         scalarFunction:
           functionReference: 2
-          arguments:        
+          arguments:
             - value:
                 selection:
                   rootReference: {}
@@ -58,5 +58,5 @@ tests:
             - value:
                 selection:
                   rootReference: {}
-                  directReference: { structField: { field: 2 }}          
+                  directReference: { structField: { field: 2 }}
           outputType: { i32: {} }

--- a/plan/plan_builder_test.go
+++ b/plan/plan_builder_test.go
@@ -134,7 +134,7 @@ func TestAggregateRelPlan(t *testing.T) {
 				"extensionFunction": {
 					"extensionUriReference": 1,
 					"functionAnchor": 1,
-					"name": "count"
+					"name": "count:"
 				}
 			}
 		],


### PR DESCRIPTION
This change addresses a bug where the type signatures in substrait proto files were lost in decoding -> encoding, and only simple names were used.

To address this, I updated the expression builders to always use compound names (e.g. `add:i64_i64`) and not just simple names (`add`). The spec currently requires compound names for functions with multiple impls (and may soon [require them always](https://github.com/substrait-io/substrait/pull/537)), and the signatures were lost in the conversion from protobuf to internal formats. That is the first commit, with tests updated in the second commit.

Secondly, I changed the code so that if the function is not found with the given type signature, a "not found" error is returned, just as it is if the function is not found. That's the third commit. I'm less attached to this, but it helped in testing because I found a number of tests that "passed" incorrectly as (with the change above) they were referring to non-existent functions.

For that second part - I'm not sure it's necessary; we can drop that commit if you prefer. Alternatively - it might be worth removing the `NewCustom*Func` functions altogether.