### PR TITLE
fix(expressions): Use compound names in protobufs

### DIFF
--- a/expr/expression.go
+++ b/expr/expression.go
@@ -77,7 +77,6 @@ func ExprFromProto(e *proto.Expression, baseSchema types.Type, reg ExtensionRegi
 		return &ScalarFunction{
 			funcRef:     et.ScalarFunction.FunctionReference,
 			declaration: decl,
-			id:          id,
 			args:        args,
 			options:     et.ScalarFunction.Options,
 			outputType:  types.TypeFromProto(et.ScalarFunction.OutputType),
@@ -126,7 +125,6 @@ func ExprFromProto(e *proto.Expression, baseSchema types.Type, reg ExtensionRegi
 
 		return &WindowFunction{
 			funcRef:     et.WindowFunction.FunctionReference,
-			id:          id,
 			declaration: decl,
 			args:        args,
 			options:     et.WindowFunction.Options,

--- a/expr/expressions_test.go
+++ b/expr/expressions_test.go
@@ -292,28 +292,28 @@ func TestRoundTripUsingTestData(t *testing.T) {
 				"extensionFunction": {
 					"extensionUriReference": 1,
 					"functionAnchor": 2,
-					"name": "add"
+					"name": "add:fp64_fp64"
 				}
 			},
 			{
 				"extensionFunction": {
 					"extensionUriReference": 1,
 					"functionAnchor": 3,
-					"name": "subtract"
+					"name": "subtract:fp64_fp64"
 				}
 			},
 			{
 				"extensionFunction": {
 					"extensionUriReference": 1,
 					"functionAnchor": 4,
-					"name": "multiply"
+					"name": "multiply:fp64_fp64"
 				}
 			},
 			{
 				"extensionFunction": {
 					"extensionUriReference": 1,
 					"functionAnchor": 5,
-					"name": "ntile"
+					"name": "ntile:i32"
 				}
 			}
 		],

--- a/expr/expressions_test.go
+++ b/expr/expressions_test.go
@@ -60,7 +60,7 @@ func ExampleExpression_scalarFunction() {
 				"extensionFunction": {
 					"extensionUriReference": 1,
 					"functionAnchor": 2,
-					"name": "add"
+					"name": "add:i32_i32"
 				}
 			}
 		],
@@ -105,7 +105,7 @@ func ExampleExpression_scalarFunction() {
 	// having to construct the protobuf
 	const substraitext = `https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml`
 
-	var addVariant = ext.NewScalarFuncVariant(ext.ID{URI: substraitext, Name: "add"})
+	var addVariant = ext.NewScalarFuncVariant(ext.ID{URI: substraitext, Name: "add:i32_i32"})
 
 	var ex expr.Expression
 	refArg, _ := expr.NewRootFieldRef(expr.NewStructFieldRef(0), &types.StructType{Types: []types.Type{&types.Int32Type{}}})
@@ -186,28 +186,28 @@ func TestExpressionsRoundtrip(t *testing.T) {
 				"extensionFunction": {
 					"extensionUriReference": 1,
 					"functionAnchor": 2,
-					"name": "add"
+					"name": "add:fp64_fp64"
 				}
 			},
 			{
 				"extensionFunction": {
 					"extensionUriReference": 1,
 					"functionAnchor": 3,
-					"name": "subtract"
+					"name": "subtract:fp32_fp32"
 				}
 			},
 			{
 				"extensionFunction": {
 					"extensionUriReference": 1,
 					"functionAnchor": 4,
-					"name": "multiply"
+					"name": "multiply:i64_i64"
 				}
 			},
 			{
 				"extensionFunction": {
 					"extensionUriReference": 1,
 					"functionAnchor": 5,
-					"name": "ntile"
+					"name": "ntile:"
 				}
 			}
 		],

--- a/expr/testdata/extended_exprs.yaml
+++ b/expr/testdata/extended_exprs.yaml
@@ -7,23 +7,23 @@ tests:
     - extensionFunction:
         extensionUriReference: 1
         functionAnchor: 2
-        name: add
+        name: add:i64_i64
     - extensionFunction:
         extensionUriReference: 1
         functionAnchor: 3
-        name: subtract
+        name: subtract:i64_i64
     - extensionFunction:
         extensionUriReference: 1
         functionAnchor: 4
-        name: multiply
+        name: multiply:i64_i64
     - extensionFunction:
         extensionUriReference: 1
         functionAnchor: 5
-        name: ntile
+        name: ntile:i64_i64
     - extensionFunction:
         extensionUriReference: 1
         functionAnchor: 6
-        name: sum
+        name: sum:i64
   baseSchema:
     names: [a, b, c, d]
     struct:
@@ -50,7 +50,7 @@ tests:
       expression:
         scalarFunction:
           functionReference: 2
-          arguments:        
+          arguments:
             - value:
                 selection:
                   rootReference: {}
@@ -58,5 +58,5 @@ tests:
             - value:
                 selection:
                   rootReference: {}
-                  directReference: { structField: { field: 2 }}          
+                  directReference: { structField: { field: 2 }}
           outputType: { i32: {} }

--- a/extensions/extension_mgr.go
+++ b/extensions/extension_mgr.go
@@ -45,8 +45,12 @@ func init() {
 	}
 }
 
+// The unique identifier for a substrait object
 type ID struct {
-	URI, Name string
+	URI string
+	// Name of the object. For functions, a simple name may be used for lookups,
+	// but as a unique identifier the compound name will be used
+	Name string
 }
 
 type Collection struct {

--- a/extensions/extension_mgr.go
+++ b/extensions/extension_mgr.go
@@ -360,7 +360,7 @@ func (e *set) DecodeType(anchor uint32) (id ID, ok bool) {
 func (e *set) GetTypeAnchor(id ID) uint32 {
 	a, ok := e.types[id]
 	if !ok {
-		e.addURI(id.URI)
+		e.addOrGetURI(id.URI)
 		a = uint32(len(e.types)) + 1
 		e.encodeType(a, id)
 	}
@@ -370,7 +370,7 @@ func (e *set) GetTypeAnchor(id ID) uint32 {
 func (e *set) GetFuncAnchor(id ID) uint32 {
 	a, ok := e.funcs[id]
 	if !ok {
-		e.addURI(id.URI)
+		e.addOrGetURI(id.URI)
 		a = uint32(len(e.funcs)) + 1
 		e.encodeFunc(a, id)
 	}
@@ -380,7 +380,7 @@ func (e *set) GetFuncAnchor(id ID) uint32 {
 func (e *set) GetTypeVariationAnchor(id ID) uint32 {
 	a, ok := e.typeVariations[id]
 	if !ok {
-		e.addURI(id.URI)
+		e.addOrGetURI(id.URI)
 		// add 1 to the length to avoid an anchor of 0
 		// so that it's easier to tell when there is no
 		// type variation.
@@ -414,7 +414,12 @@ func (e *set) FindURI(uri string) (uint32, bool) {
 	return 0, false
 }
 
-func (e *set) addURI(uri string) (uint32, error) {
+func (e *set) addOrGetURI(uri string) (uint32, error) {
+	for k, v := range e.uris {
+		if v == uri {
+			return k, nil
+		}
+	}
 	sz := uint32(len(e.uris)) + 1
 	if _, ok := e.uris[sz]; ok {
 		return 0, substraitgo.ErrKeyExists

--- a/extensions/variants.go
+++ b/extensions/variants.go
@@ -83,16 +83,6 @@ func EvaluateTypeExpression(nullHandling NullabilityHandling, expr parser.TypeEx
 	return outType, nil
 }
 
-// When parsing a function variant from a string, we may know the string form of
-// an argument, but nothing else. This represents that type of argument.
-type unknownArgType struct {
-	arg string
-}
-
-func (a unknownArgType) toTypeString() string {
-	return a.arg
-}
-
 func parseFuncName(compoundName string) (name string, args ArgumentList) {
 	name, argsStr, _ := strings.Cut(compoundName, ":")
 	if len(argsStr) == 0 {
@@ -100,7 +90,12 @@ func parseFuncName(compoundName string) (name string, args ArgumentList) {
 	}
 	splitArgs := strings.Split(argsStr, "_")
 	for _, argStr := range splitArgs {
-		args = append(args, unknownArgType{arg: argStr})
+		parsed, err := defParser.ParseString(argStr)
+		if err != nil {
+			panic(err)
+		}
+		exp := ValueArg{Name: name, Value: parsed}
+		args = append(args, exp)
 	}
 
 	return name, args

--- a/plan/plan_builder_test.go
+++ b/plan/plan_builder_test.go
@@ -101,6 +101,7 @@ func TestBuildEmitOutOfRangePlan(t *testing.T) {
 }
 
 func checkRoundTrip(t *testing.T, expectedJSON string, p *plan.Plan) {
+	t.Helper()
 	protoPlan, err := p.ToProto()
 	require.NoError(t, err)
 
@@ -134,7 +135,7 @@ func TestAggregateRelPlan(t *testing.T) {
 				"extensionFunction": {
 					"extensionUriReference": 1,
 					"functionAnchor": 1,
-					"name": "count"
+					"name": "count:"
 				}
 			}
 		],


### PR DESCRIPTION
This PR finds and fixes a number of related issues:

1. Adding multiple functions to the extension registry could insert the same extension file multiple times
2. Unrecognized compound names from protobufs were parsed as simple names
3. Compound names were not used for the protobuf output

This also updates tests to match the above - in particular, any tests with protobuf output now uses compound names.

I made some choices along the way for how to make this work; I'll comment inline in this PR.

Supersedes #23.