### PR TITLE
DRAFT: Fix golangci-lint failure

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: stable
+      - name: Dump Go version
+        run: go version
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:


### PR DESCRIPTION
* golangci-lint is failing with below error ([here](https://github.com/substrait-io/substrait-go/actions/runs/10449096336/job/28930736501?pr=48))
`The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.`

* Based on [this](https://github.com/actions/runner-images/issues/6709#issuecomment-1361269639) thread, this error is seen on ubuntu-latest. Tried using ubuntu-20.04 as suggested in thread but action failed in installation of golangci-lint [here](https://github.com/substrait-io/substrait-go/actions/runs/10451322115/job/28937500404)
* Tried macos-latest too but it fails too with some type errors ([here](https://github.com/substrait-io/substrait-go/actions/runs/10451446736/job/28937886358)) which seems incorrect. 

