### PR TITLE
golangci should use the go.mod version of golang

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -19,7 +19,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.59
+          version: v1.60.1
   build:
     name: Build and Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version-file: 'go.mod'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:


### PR DESCRIPTION
Noticed that golangci was failing and saw that go stable was recently updated to v1.23 

I did two things:
1. pin our version of go to what is in `go.mod`
2. upgrade golangci to 1.60.x which is compatible w/ golang 1.23