### PR TITLE
Add Match method to FuncDefArgType interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@
 
 module github.com/substrait-io/substrait-go
 
-go 1.21
+go 1.22
 
 require (
 	github.com/alecthomas/participle/v2 v2.0.0
@@ -24,7 +24,6 @@ require (
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/crypto v0.7.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/alecthomas/participle/v2 v2.0.0 h1:Fgrq+MbuSsJwIkw3fEj9h75vDP0Er5Jzep
 github.com/alecthomas/participle/v2 v2.0.0/go.mod h1:rAKZdJldHu8084ojcWevWAL8KmEU+AT+Olodb+WoN2Y=
 github.com/alecthomas/repr v0.2.0 h1:HAzS41CIzNW5syS8Mf9UwXhNH1J9aix/BvDRf1Ml2Yk=
 github.com/alecthomas/repr v0.2.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
-github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/cockroachdb/apd/v3 v3.2.1 h1:U+8j7t0axsIgvQUqthuNm82HIrYXodOV2iWLWtEaIwg=
 github.com/cockroachdb/apd/v3 v3.2.1/go.mod h1:klXJcjp+FffLTHlhIG69tezTDvdP065naDsHzKhYSqc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -57,8 +55,6 @@ github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=

--- a/types/any_type.go
+++ b/types/any_type.go
@@ -32,3 +32,11 @@ func (s AnyType) GetParameterizedParams() []interface{} {
 	// any type doesn't have any abstract parameters
 	return nil
 }
+
+func (m AnyType) MatchWithNullability(ot Type) bool {
+	return m.Nullability == ot.GetNullability()
+}
+
+func (m AnyType) MatchWithoutNullability(ot Type) bool {
+	return true
+}

--- a/types/integer_parameters/concrete_int_param.go
+++ b/types/integer_parameters/concrete_int_param.go
@@ -16,7 +16,7 @@ func NewConcreteIntParam(v int32) IntegerParameter {
 
 func (m *ConcreteIntParam) IsCompatible(o IntegerParameter) bool {
 	if t, ok := o.(*ConcreteIntParam); ok {
-		return t == m
+		return *t == *m
 	}
 	return false
 }

--- a/types/parameterized_decimal_type.go
+++ b/types/parameterized_decimal_type.go
@@ -47,3 +47,19 @@ func (m *ParameterizedDecimalType) GetParameterizedParams() []interface{} {
 	}
 	return params
 }
+
+func (m *ParameterizedDecimalType) MatchWithNullability(ot Type) bool {
+	if m.Nullability != ot.GetNullability() {
+		return false
+	}
+	return m.MatchWithoutNullability(ot)
+}
+
+func (m *ParameterizedDecimalType) MatchWithoutNullability(ot Type) bool {
+	if odt, ok := ot.(*DecimalType); ok {
+		concretePrecision := integer_parameters.NewConcreteIntParam(odt.Precision)
+		concreteScale := integer_parameters.NewConcreteIntParam(odt.Scale)
+		return m.Precision.IsCompatible(concretePrecision) && m.Scale.IsCompatible(concreteScale)
+	}
+	return false
+}

--- a/types/parameterized_list_type.go
+++ b/types/parameterized_list_type.go
@@ -37,3 +37,21 @@ func (m *ParameterizedListType) GetParameterizedParams() []interface{} {
 	}
 	return []interface{}{m.Type}
 }
+
+func (m *ParameterizedListType) MatchWithNullability(ot Type) bool {
+	if m.Nullability != ot.GetNullability() {
+		return false
+	}
+	if olt, ok := ot.(*ListType); ok {
+		result := m.Type.MatchWithNullability(olt.Type)
+		return result
+	}
+	return false
+}
+
+func (m *ParameterizedListType) MatchWithoutNullability(ot Type) bool {
+	if olt, ok := ot.(*ListType); ok {
+		return m.Type.MatchWithoutNullability(olt.Type)
+	}
+	return false
+}

--- a/types/parameterized_map_type.go
+++ b/types/parameterized_map_type.go
@@ -43,3 +43,20 @@ func (m *ParameterizedMapType) GetParameterizedParams() []interface{} {
 	}
 	return abstractParams
 }
+
+func (m *ParameterizedMapType) MatchWithNullability(ot Type) bool {
+	if m.Nullability != ot.GetNullability() {
+		return false
+	}
+	if omt, ok := ot.(*MapType); ok {
+		return m.Key.MatchWithNullability(omt.Key) && m.Value.MatchWithNullability(omt.Value)
+	}
+	return false
+}
+
+func (m *ParameterizedMapType) MatchWithoutNullability(ot Type) bool {
+	if omt, ok := ot.(*MapType); ok {
+		return m.Key.MatchWithoutNullability(omt.Key) && m.Value.MatchWithoutNullability(omt.Value)
+	}
+	return false
+}

--- a/types/parameterized_single_integer_param_type.go
+++ b/types/parameterized_single_integer_param_type.go
@@ -54,3 +54,25 @@ func (m *parameterizedTypeSingleIntegerParam[T]) GetParameterizedParams() []inte
 	}
 	return []interface{}{m.IntegerOption}
 }
+
+func (m *parameterizedTypeSingleIntegerParam[T]) MatchWithNullability(ot Type) bool {
+	if m.Nullability != ot.GetNullability() {
+		return false
+	}
+	return m.MatchWithoutNullability(ot)
+}
+
+func (m *parameterizedTypeSingleIntegerParam[T]) MatchWithoutNullability(ot Type) bool {
+	if reflect.TypeFor[T]() != reflect.TypeOf(ot) {
+		return false
+	}
+	if odt, ok := ot.(FixedType); ok {
+		concreteLength := integer_parameters.NewConcreteIntParam(odt.GetLength())
+		return m.IntegerOption.IsCompatible(concreteLength)
+	}
+	if odt, ok := ot.(timestampPrecisionType); ok {
+		concreteLength := integer_parameters.NewConcreteIntParam(odt.GetPrecision().ToProtoVal())
+		return m.IntegerOption.IsCompatible(concreteLength)
+	}
+	return false
+}

--- a/types/parameterized_struct_type.go
+++ b/types/parameterized_struct_type.go
@@ -54,3 +54,36 @@ func (m *ParameterizedStructType) GetParameterizedParams() []interface{} {
 	}
 	return abstractParams
 }
+
+func (m *ParameterizedStructType) MatchWithNullability(ot Type) bool {
+	if m.Nullability != ot.GetNullability() {
+		return false
+	}
+	if omt, ok := ot.(*StructType); ok {
+		if len(m.Types) != len(omt.Types) {
+			return false
+		}
+		for i, typ := range m.Types {
+			if !typ.MatchWithNullability(omt.Types[i]) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func (m *ParameterizedStructType) MatchWithoutNullability(ot Type) bool {
+	if omt, ok := ot.(*StructType); ok {
+		if len(m.Types) != len(omt.Types) {
+			return false
+		}
+		for i, typ := range m.Types {
+			if !typ.MatchWithoutNullability(omt.Types[i]) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}

--- a/types/precison_timestamp_types.go
+++ b/types/precison_timestamp_types.go
@@ -108,6 +108,10 @@ func (m *PrecisionTimestampType) BaseString() string {
 	return typeNames[reflect.TypeOf(m)]
 }
 
+func (m *PrecisionTimestampType) GetPrecision() TimePrecision {
+	return m.Precision
+}
+
 // PrecisionTimestampTzType this is used to represent a type of Precision timestamp with TimeZone
 type PrecisionTimestampTzType struct {
 	PrecisionTimestampType


### PR DESCRIPTION
* Added MatchWithNullability and MatchWithoutNullability methods on FuncDefArgType interface. This method returns true if argument "t" is type compatible with this type otherwise it returns false
* These two APIs are necessary considering Match behavior will differ based on function's nullability handling (MIRROR, DECLARED_OUTPUT, DISCRETE).
* Nullability "MIRROR" and "DECLARED_OUTPUT" requires MatchWithoutNullability
* Nullability "DISCRETE" will require MatchWithNullability
* Also updated go version to 1.22 to fix golint error with reflect API TypeFor
* In follow up PR I will add Match method on FunctionVariant interface