### PR TITLE
feat(type)!: Add precision to/from proto for IntervalDayType

### DIFF
--- a/expr/literals.go
+++ b/expr/literals.go
@@ -820,13 +820,11 @@ func LiteralFromProto(l *proto.Expression_Literal) Literal {
 			if err != nil {
 				return nil
 			}
-		default:
-			return nil
 		}
 		return &ProtoLiteral{
 			Value: lit.IntervalDayToSecond,
 			Type: &types.IntervalDayType{
-				Length:           precision.ToProtoVal(),
+				Precision:        precision,
 				Nullability:      nullability,
 				TypeVariationRef: l.TypeVariationReference,
 			},

--- a/expr/literals.go
+++ b/expr/literals.go
@@ -812,9 +812,21 @@ func LiteralFromProto(l *proto.Expression_Literal) Literal {
 				Nullability:      nullability,
 			}}
 	case *proto.Expression_Literal_IntervalDayToSecond_:
+		precision := types.PrecisionMicroSeconds
+		switch lit.IntervalDayToSecond.PrecisionMode.(type) {
+		case *proto.Expression_Literal_IntervalDayToSecond_Precision:
+			var err error
+			precision, err = types.ProtoToTimePrecision(lit.IntervalDayToSecond.GetPrecision())
+			if err != nil {
+				return nil
+			}
+		default:
+			return nil
+		}
 		return &ProtoLiteral{
 			Value: lit.IntervalDayToSecond,
 			Type: &types.IntervalDayType{
+				Length:           precision.ToProtoVal(),
 				Nullability:      nullability,
 				TypeVariationRef: l.TypeVariationReference,
 			},

--- a/expr/proto_literals_test.go
+++ b/expr/proto_literals_test.go
@@ -36,6 +36,7 @@ func TestToProtoLiteral(t *testing.T) {
 }
 
 func TestLiteralFromProtoLiteral(t *testing.T) {
+	intDayToSecVal := &proto.Expression_Literal_IntervalDayToSecond{Days: 1, Seconds: 2, PrecisionMode: &proto.Expression_Literal_IntervalDayToSecond_Precision{Precision: 5}}
 	for _, tc := range []struct {
 		name             string
 		constructedProto *proto.Expression_Literal
@@ -48,6 +49,10 @@ func TestLiteralFromProtoLiteral(t *testing.T) {
 		{"TimeStampTzType",
 			&proto.Expression_Literal{LiteralType: &proto.Expression_Literal_PrecisionTimestampTz{PrecisionTimestampTz: &proto.Expression_Literal_PrecisionTimestamp{Precision: 9, Value: 12345678}}, Nullable: true},
 			&ProtoLiteral{Value: int64(12345678), Type: types.NewPrecisionTimestampTzType(types.PrecisionNanoSeconds).WithNullability(types.NullabilityNullable)},
+		},
+		{"IntervalDayType",
+			&proto.Expression_Literal{LiteralType: &proto.Expression_Literal_IntervalDayToSecond_{IntervalDayToSecond: intDayToSecVal}, Nullable: true},
+			&ProtoLiteral{Value: intDayToSecVal, Type: &types.IntervalDayType{Length: types.PrecisionEMinus5Seconds.ToProtoVal(), Nullability: types.NullabilityNullable}},
 		},
 		{"IntervalYearToMonthType",
 			&proto.Expression_Literal{LiteralType: &proto.Expression_Literal_IntervalYearToMonth_{IntervalYearToMonth: &proto.Expression_Literal_IntervalYearToMonth{Years: 1234, Months: 5}}, Nullable: true},

--- a/expr/proto_literals_test.go
+++ b/expr/proto_literals_test.go
@@ -52,7 +52,7 @@ func TestLiteralFromProtoLiteral(t *testing.T) {
 		},
 		{"IntervalDayType",
 			&proto.Expression_Literal{LiteralType: &proto.Expression_Literal_IntervalDayToSecond_{IntervalDayToSecond: intDayToSecVal}, Nullable: true},
-			&ProtoLiteral{Value: intDayToSecVal, Type: &types.IntervalDayType{Length: types.PrecisionEMinus5Seconds.ToProtoVal(), Nullability: types.NullabilityNullable}},
+			&ProtoLiteral{Value: intDayToSecVal, Type: &types.IntervalDayType{Precision: types.PrecisionEMinus5Seconds, Nullability: types.NullabilityNullable}},
 		},
 		{"IntervalYearToMonthType",
 			&proto.Expression_Literal{LiteralType: &proto.Expression_Literal_IntervalYearToMonth_{IntervalYearToMonth: &proto.Expression_Literal_IntervalYearToMonth{Years: 1234, Months: 5}}, Nullable: true},

--- a/extensions/extension_mgr.go
+++ b/extensions/extension_mgr.go
@@ -21,12 +21,8 @@ type AdvancedExtension = extensions.AdvancedExtension
 const SubstraitDefaultURIPrefix = "https://github.com/substrait-io/substrait/blob/main/extensions/"
 
 // DefaultCollection is loaded with the default Substrait extension
-// definitions.
-// Parser needs to enhanced until than below function files are not processed
-// 1. functions_arithmetic_decimal.yaml (need to parse complex return type)
-// 2. functions_geometry.yaml (need to parse geometry type)
-// 3. type_variations.yaml
-// 4. unknown.yaml
+// definitions. Not all files are currently parsable.
+// Parser needs to enhanced to support all files
 var DefaultCollection Collection
 
 func init() {

--- a/types/interval_day_type.go
+++ b/types/interval_day_type.go
@@ -1,0 +1,67 @@
+package types
+
+import (
+	"fmt"
+
+	"github.com/substrait-io/substrait-go/proto"
+)
+
+// IntervalDayType this is used to represent a type of interval day.
+type IntervalDayType struct {
+	Precision        TimePrecision
+	TypeVariationRef uint32
+	Nullability      Nullability
+}
+
+func (m *IntervalDayType) GetPrecisionProtoVal() int32 {
+	return m.Precision.ToProtoVal()
+}
+
+func (*IntervalDayType) isRootRef() {}
+func (m *IntervalDayType) WithNullability(n Nullability) Type {
+	m.Nullability = n
+	return m
+}
+
+func (m *IntervalDayType) GetType() Type                     { return m }
+func (m *IntervalDayType) GetNullability() Nullability       { return m.Nullability }
+func (m *IntervalDayType) GetTypeVariationReference() uint32 { return m.TypeVariationRef }
+func (m *IntervalDayType) Equals(rhs Type) bool {
+	if o, ok := rhs.(*IntervalDayType); ok {
+		return *o == *m
+	}
+	return false
+}
+
+func (m *IntervalDayType) ToProtoFuncArg() *proto.FunctionArgument {
+	return &proto.FunctionArgument{
+		ArgType: &proto.FunctionArgument_Type{Type: m.ToProto()},
+	}
+}
+
+func (m *IntervalDayType) ToProto() *proto.Type {
+	precisionVal := m.Precision.ToProtoVal()
+	return &proto.Type{Kind: &proto.Type_IntervalDay_{
+		IntervalDay: &proto.Type_IntervalDay{
+			Precision:              &precisionVal,
+			Nullability:            m.Nullability,
+			TypeVariationReference: m.TypeVariationRef}}}
+}
+
+func (*IntervalDayType) ShortString() string { return "iday" }
+func (m *IntervalDayType) String() string {
+	return fmt.Sprintf("interval_day%s<%d>", strNullable(m),
+		m.Precision.ToProtoVal())
+}
+
+func (m *IntervalDayType) ParameterString() string {
+	return fmt.Sprintf("%d", m.Precision.ToProtoVal())
+}
+
+func (s *IntervalDayType) BaseString() string {
+	return "interval_day"
+}
+
+func (m *IntervalDayType) GetPrecision() TimePrecision {
+	return m.Precision
+}

--- a/types/interval_day_type_test.go
+++ b/types/interval_day_type_test.go
@@ -1,0 +1,62 @@
+package types
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/substrait-io/substrait-go/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestIntervalDayType(t *testing.T) {
+	anotherType := &FixedCharType{Length: 10, Nullability: NullabilityNullable}
+	allPossibleTimePrecision := []TimePrecision{PrecisionSeconds, PrecisionDeciSeconds, PrecisionCentiSeconds, PrecisionMilliSeconds,
+		PrecisionEMinus4Seconds, PrecisionEMinus5Seconds, PrecisionMicroSeconds, PrecisionEMinus7Seconds, PrecisionEMinus8Seconds, PrecisionNanoSeconds}
+	allPossibleNullability := []Nullability{NullabilityUnspecified, NullabilityNullable, NullabilityRequired}
+
+	for _, precision := range allPossibleTimePrecision {
+		for _, nullability := range allPossibleNullability {
+			expectedIntervalDayType := &IntervalDayType{Precision: precision, Nullability: nullability}
+			expectedFormatString := fmt.Sprintf("%s<%d>", strNullable(expectedIntervalDayType), precision.ToProtoVal())
+			// verify IntervalDayType
+			createdIntervalDayTypeIfc := (&IntervalDayType{Precision: precision}).WithNullability(nullability)
+			createdIntervalDayType := createdIntervalDayTypeIfc.(*IntervalDayType)
+			assert.True(t, createdIntervalDayType.Equals(expectedIntervalDayType))
+			assert.Equal(t, expectedProtoValMap[precision], createdIntervalDayType.GetPrecisionProtoVal())
+			assert.Equal(t, nullability, createdIntervalDayType.GetNullability())
+			assert.Zero(t, createdIntervalDayType.GetTypeVariationReference())
+			assert.Equal(t, fmt.Sprintf("interval_day%s", expectedFormatString), createdIntervalDayType.String())
+			assert.Equal(t, "iday", createdIntervalDayType.ShortString())
+			assert.Equal(t, "interval_day", createdIntervalDayType.BaseString())
+			assert.Equal(t, precision, createdIntervalDayType.GetPrecision())
+			expectedParameterString := fmt.Sprintf("%d", precision.ToProtoVal())
+			assert.Equal(t, expectedParameterString, createdIntervalDayType.ParameterString())
+			assertIntervalDayTypeProto(t, precision, nullability, createdIntervalDayType)
+			assert.False(t, createdIntervalDayTypeIfc.Equals(anotherType))
+		}
+	}
+}
+
+func assertIntervalDayTypeProto(t *testing.T, expectedPrecision TimePrecision, expectedNullability Nullability,
+	toVerifyType *IntervalDayType) {
+
+	expectedPrecisionProtoVal := expectedPrecision.ToProtoVal()
+	expectedTypeProto := &proto.Type{Kind: &proto.Type_IntervalDay_{
+		IntervalDay: &proto.Type_IntervalDay{
+			Precision:   &expectedPrecisionProtoVal,
+			Nullability: expectedNullability,
+		},
+	}}
+	if diff := cmp.Diff(toVerifyType.ToProto(), expectedTypeProto, protocmp.Transform()); diff != "" {
+		t.Errorf("IntervalDayType proto didn't match, diff:\n%v", diff)
+	}
+
+	expectedFuncArgProto := &proto.FunctionArgument{ArgType: &proto.FunctionArgument_Type{
+		Type: expectedTypeProto,
+	}}
+	if diff := cmp.Diff(toVerifyType.ToProtoFuncArg(), expectedFuncArgProto, protocmp.Transform()); diff != "" {
+		t.Errorf("IntervalDayType func arg proto didn't match, diff:\n%v", diff)
+	}
+}

--- a/types/parser/type_parser.go
+++ b/types/parser/type_parser.go
@@ -268,6 +268,14 @@ func (p *lengthType) RetType() (types.Type, error) {
 		return nil, substraitgo.ErrNotImplemented
 	}
 
+	if types.TypeName(p.TypeName) == types.TypeNameIntervalDay {
+		precision, err := types.ProtoToTimePrecision(lit.Value)
+		if err != nil {
+			return nil, err
+		}
+		return (&types.IntervalDayType{Precision: precision}).WithNullability(n), nil
+	}
+
 	typ, err := types.FixedTypeNameToType(types.TypeName(p.TypeName))
 	if err != nil {
 		return nil, err
@@ -306,6 +314,8 @@ func getParameterizedTypeSingleParam(typeName string, leafParam integer_paramete
 		return &types.ParameterizedPrecisionTimestampType{IntegerOption: leafParam, Nullability: n}, nil
 	case types.TypeNamePrecisionTimestampTz:
 		return &types.ParameterizedPrecisionTimestampTzType{IntegerOption: leafParam, Nullability: n}, nil
+	case types.TypeNameIntervalDay:
+		return &types.ParameterizedIntervalDayType{IntegerOption: leafParam, Nullability: n}, nil
 	default:
 		return nil, substraitgo.ErrNotImplemented
 	}

--- a/types/parser/type_parser_test.go
+++ b/types/parser/type_parser_test.go
@@ -53,6 +53,7 @@ func TestParser(t *testing.T) {
 		{"struct<list?<decimal<P,S>>, i16>", "struct<list?<decimal<P,S>>, i16>", "struct", &types.ParameterizedStructType{Types: []types.FuncDefArgType{&types.ParameterizedListType{Type: &types.ParameterizedDecimalType{Precision: parameterLeaf_P, Scale: parameterLeaf_S, Nullability: types.NullabilityRequired}, Nullability: types.NullabilityNullable}, &types.Int16Type{Nullability: types.NullabilityRequired}}, Nullability: types.NullabilityRequired}},
 		{"map<decimal<P,S>, i16>", "map<decimal<P,S>, i16>", "map", &types.ParameterizedMapType{Key: &types.ParameterizedDecimalType{Precision: parameterLeaf_P, Scale: parameterLeaf_S, Nullability: types.NullabilityRequired}, Value: &types.Int16Type{Nullability: types.NullabilityRequired}, Nullability: types.NullabilityRequired}},
 		{"precision_timestamp_tz?<L1>", "precision_timestamp_tz?<L1>", "pretstz", &types.ParameterizedPrecisionTimestampTzType{IntegerOption: parameterLeaf_L1}},
+		{"interval_day<5>", "interval_day<5>", "iday", &types.ParameterizedIntervalDayType{IntegerOption: concreteLeaf_5}},
 	}
 
 	p, err := parser.New()
@@ -80,7 +81,7 @@ func TestParserRetType(t *testing.T) {
 		shortName   string
 		expectedTyp types.Type
 	}{
-		{"interval_day?<1>", "interval_day?<1>", "iday", &types.IntervalDayType{Length: 1, Nullability: types.NullabilityNullable}},
+		{"interval_day?<1>", "interval_day?<1>", "iday", &types.IntervalDayType{Precision: 1, Nullability: types.NullabilityNullable}},
 	}
 
 	p, err := parser.New()

--- a/types/parser/type_parser_test.go
+++ b/types/parser/type_parser_test.go
@@ -80,7 +80,7 @@ func TestParserRetType(t *testing.T) {
 		shortName   string
 		expectedTyp types.Type
 	}{
-		{"interval_day?<1>", "interval_day?<1>", "iday", &types.IntervalDayType{}},
+		{"interval_day?<1>", "interval_day?<1>", "iday", &types.IntervalDayType{Length: 1, Nullability: types.NullabilityNullable}},
 	}
 
 	p, err := parser.New()
@@ -96,6 +96,7 @@ func TestParserRetType(t *testing.T) {
 				retType, err := d.Expr.(*parser.Type).RetType()
 				assert.NoError(t, err)
 				assert.Equal(t, reflect.TypeOf(td.expectedTyp), reflect.TypeOf(retType))
+				assert.True(t, td.expectedTyp.Equals(retType))
 			}
 		})
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -74,7 +74,6 @@ var fixedTypeNameMap = map[TypeName]FixedType{
 	TypeNameFixedBinary: &FixedBinaryType{},
 	TypeNameFixedChar:   &FixedCharType{},
 	TypeNameVarChar:     &VarCharType{},
-	TypeNameIntervalDay: &IntervalDayType{},
 }
 
 var shortTypeNames = map[TypeName]string{
@@ -123,6 +122,7 @@ func GetTypeNameToTypeMap() map[string]Type {
 		typeMap[string(k)] = v
 	}
 	typeMap[string(TypeNameDecimal)] = &DecimalType{}
+	typeMap[string(TypeNameIntervalDay)] = &IntervalDayType{}
 	return typeMap
 }
 
@@ -264,7 +264,7 @@ func TypeFromProto(t *proto.Type) Type {
 		return &IntervalDayType{
 			Nullability:      t.IntervalDay.Nullability,
 			TypeVariationRef: t.IntervalDay.TypeVariationReference,
-			Length:           precision.ToProtoVal(),
+			Precision:        precision,
 		}
 	case *proto.Type_TimestampTz:
 		return &TimestampTzType{
@@ -501,7 +501,7 @@ func TypeToProto(t Type) *proto.Type {
 				Nullability:            t.Nullability,
 				TypeVariationReference: t.TypeVariationRef}}}
 	case *IntervalDayType:
-		precision := t.Length
+		precision := t.Precision.ToProtoVal()
 		return &proto.Type{Kind: &proto.Type_IntervalDay_{
 			IntervalDay: &proto.Type_IntervalDay{
 				Precision:              &precision,
@@ -704,7 +704,6 @@ type (
 	FixedCharType                         = FixedLenType[FixedChar]
 	VarCharType                           = FixedLenType[VarChar]
 	FixedBinaryType                       = FixedLenType[FixedBinary]
-	IntervalDayType                       = FixedLenType[IntervalDayToSecond]
 	ParameterizedVarCharType              = parameterizedTypeSingleIntegerParam[*VarCharType]
 	ParameterizedFixedCharType            = parameterizedTypeSingleIntegerParam[*FixedCharType]
 	ParameterizedFixedBinaryType          = parameterizedTypeSingleIntegerParam[*FixedBinaryType]
@@ -715,7 +714,7 @@ type (
 
 // FixedLenType is any of the types which also need to track their specific
 // length as they have a fixed length.
-type FixedLenType[T FixedChar | VarChar | FixedBinary | IntervalDayToSecond] struct {
+type FixedLenType[T FixedChar | VarChar | FixedBinary] struct {
 	Nullability      Nullability
 	TypeVariationRef uint32
 	Length           int32

--- a/types/types.go
+++ b/types/types.go
@@ -253,9 +253,18 @@ func TypeFromProto(t *proto.Type) Type {
 			TypeVariationRef: t.IntervalYear.TypeVariationReference,
 		}
 	case *proto.Type_IntervalDay_:
+		var precision = PrecisionMicroSeconds
+		if t.IntervalDay.Precision != nil {
+			var err error
+			precision, err = ProtoToTimePrecision(*t.IntervalDay.Precision)
+			if err != nil {
+				panic(fmt.Sprintf("Invalid precision %v", err))
+			}
+		}
 		return &IntervalDayType{
 			Nullability:      t.IntervalDay.Nullability,
 			TypeVariationRef: t.IntervalDay.TypeVariationReference,
+			Length:           precision.ToProtoVal(),
 		}
 	case *proto.Type_TimestampTz:
 		return &TimestampTzType{
@@ -492,8 +501,10 @@ func TypeToProto(t Type) *proto.Type {
 				Nullability:            t.Nullability,
 				TypeVariationReference: t.TypeVariationRef}}}
 	case *IntervalDayType:
+		precision := t.Length
 		return &proto.Type{Kind: &proto.Type_IntervalDay_{
 			IntervalDay: &proto.Type_IntervalDay{
+				Precision:              &precision,
 				Nullability:            t.Nullability,
 				TypeVariationReference: t.TypeVariationRef}}}
 	case *UUIDType:

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -31,7 +31,7 @@ func TestTypeToString(t *testing.T) {
 		{&TimeType{}, "time", "time"},
 		{&TimestampTzType{}, "timestamp_tz", "tstz"},
 		{&IntervalYearType{}, "interval_year", "iyear"},
-		{&IntervalDayType{Length: 5}, "interval_day<5>", "iday"},
+		{&IntervalDayType{Precision: 5}, "interval_day<5>", "iday"},
 		{&UUIDType{Nullability: NullabilityNullable}, "uuid?", "uuid"},
 		{&FixedBinaryType{Length: 10}, "fixedbinary<10>", "fbin"},
 		{&FixedCharType{Length: 5}, "char<5>", "fchar"},
@@ -77,13 +77,13 @@ func TestTypeRoundtrip(t *testing.T) {
 				&TimestampType{Nullability: n},
 				&TimestampTzType{Nullability: n},
 				&IntervalYearType{Nullability: n},
-				&IntervalDayType{Nullability: n},
 				&UUIDType{Nullability: n},
 				&FixedCharType{Nullability: n, Length: 25},
 				&VarCharType{Nullability: n, Length: 35},
 				&FixedBinaryType{Nullability: n, Length: 45},
-				&IntervalDayType{Nullability: n, Length: 5},
-				&IntervalDayType{Nullability: n},
+				&IntervalDayType{Nullability: n, Precision: 5},
+				&IntervalDayType{Nullability: n, Precision: 0},
+
 				&DecimalType{Nullability: n, Precision: 34, Scale: 3},
 				&MapType{Nullability: n, Key: &Int8Type{}, Value: &Int16Type{Nullability: n}},
 				&ListType{Nullability: n, Type: &TimeType{Nullability: n}},
@@ -95,7 +95,8 @@ func TestTypeRoundtrip(t *testing.T) {
 			for _, tt := range tests {
 				t.Run(tt.String(), func(t *testing.T) {
 					converted := TypeToProto(tt)
-					assert.True(t, tt.Equals(TypeFromProto(converted)))
+					convertedType := TypeFromProto(converted)
+					assert.True(t, tt.Equals(convertedType))
 				})
 			}
 		})
@@ -267,7 +268,7 @@ func TestMatchParameterizeConcreteTypeResultMatch(t *testing.T) {
 	fixedCharLen5 := &FixedCharType{Length: 5}
 	varCharLen5 := &VarCharType{Length: 5}
 	fixedBinaryLen5 := &FixedBinaryType{Length: 5}
-	intervalDayLen5 := &IntervalDayType{Length: 5}
+	intervalDayLen5 := &IntervalDayType{Precision: 5}
 
 	concreteInt38 := integer_parameters.NewConcreteIntParam(38)
 	concreteInt2 := integer_parameters.NewConcreteIntParam(2)
@@ -309,7 +310,7 @@ func TestMatchParameterizeConcreteTypeResultMismatch(t *testing.T) {
 	fixedCharLen6 := &FixedCharType{Length: 6}
 	varCharLen6 := &VarCharType{Length: 6}
 	fixedBinaryLen6 := &FixedBinaryType{Length: 6}
-	intervalDayLen6 := &IntervalDayType{Length: 6}
+	intervalDayLen6 := &IntervalDayType{Precision: 6}
 
 	concreteInt38 := integer_parameters.NewConcreteIntParam(38)
 	concreteInt2 := integer_parameters.NewConcreteIntParam(2)
@@ -354,7 +355,7 @@ func TestMatchParameterizedNonNestedTypeResultMatch(t *testing.T) {
 	paramPrecisionTimeStampTz := &ParameterizedPrecisionTimestampTzType{IntegerOption: intParamLen}
 	argDecimalType := &DecimalType{Precision: 38, Scale: 2}
 	paramDecimalType := &ParameterizedDecimalType{Precision: integer_parameters.NewVariableIntParam("P"), Scale: integer_parameters.NewVariableIntParam("S")}
-	argIntervalDayType := &IntervalDayType{Length: 5}
+	argIntervalDayType := &IntervalDayType{Precision: 5}
 	paramIntervalDayType := &ParameterizedIntervalDayType{IntegerOption: intParamLen}
 
 	for _, td := range []struct {

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -82,6 +82,8 @@ func TestTypeRoundtrip(t *testing.T) {
 				&FixedCharType{Nullability: n, Length: 25},
 				&VarCharType{Nullability: n, Length: 35},
 				&FixedBinaryType{Nullability: n, Length: 45},
+				&IntervalDayType{Nullability: n, Length: 5},
+				&IntervalDayType{Nullability: n},
 				&DecimalType{Nullability: n, Precision: 34, Scale: 3},
 				&MapType{Nullability: n, Key: &Int8Type{}, Value: &Int16Type{Nullability: n}},
 				&ListType{Nullability: n, Type: &TimeType{Nullability: n}},


### PR DESCRIPTION
* Note, this is a breaking change. Earlier consumer's of IntervalDayType on wire
* precision was Microsecond (since not set). Now if Precision will be Seconds (if not set)
* Removed names of files not supported by parser (Addressed [this](https://github.com/substrait-io/substrait-go/pull/59#discussion_r1790791249) review comment)