### PR TITLE
feat: switch type of fetch args in builder to match proto

### DIFF
--- a/plan/builders.go
+++ b/plan/builders.go
@@ -80,8 +80,8 @@ type Builder interface {
 	CreateTableAsSelect(input Rel, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error)
 	CrossRemap(left, right Rel, remap []int32) (*CrossRel, error)
 	Cross(left, right Rel) (*CrossRel, error)
-	FetchRemap(input Rel, offset, count uint64, remap []int32) (*FetchRel, error)
-	Fetch(input Rel, offset, count uint64) (*FetchRel, error)
+	FetchRemap(input Rel, offset, count int64, remap []int32) (*FetchRel, error)
+	Fetch(input Rel, offset, count int64) (*FetchRel, error)
 	FilterRemap(input Rel, condition expr.Expression, remap []int32) (*FilterRel, error)
 	Filter(input Rel, condition expr.Expression) (*FilterRel, error)
 	JoinAndFilterRemap(left, right Rel, condition, postJoinFilter expr.Expression, joinType JoinType, remap []int32) (*JoinRel, error)
@@ -332,7 +332,7 @@ func (b *builder) Cross(left, right Rel) (*CrossRel, error) {
 	return b.CrossRemap(left, right, nil)
 }
 
-func (b *builder) FetchRemap(input Rel, offset, count uint64, remap []int32) (*FetchRel, error) {
+func (b *builder) FetchRemap(input Rel, offset, count int64, remap []int32) (*FetchRel, error) {
 	if input == nil {
 		return nil, errNilInputRel
 	}
@@ -347,11 +347,11 @@ func (b *builder) FetchRemap(input Rel, offset, count uint64, remap []int32) (*F
 	return &FetchRel{
 		RelCommon: RelCommon{mapping: remap},
 		input:     input,
-		offset:    int64(offset), count: int64(count),
+		offset:    offset, count: count,
 	}, nil
 }
 
-func (b *builder) Fetch(input Rel, offset, count uint64) (*FetchRel, error) {
+func (b *builder) Fetch(input Rel, offset, count int64) (*FetchRel, error) {
 	return b.FetchRemap(input, offset, count, nil)
 }
 

--- a/plan/builders.go
+++ b/plan/builders.go
@@ -81,14 +81,14 @@ type Builder interface {
 	CrossRemap(left, right Rel, remap []int32) (*CrossRel, error)
 	Cross(left, right Rel) (*CrossRel, error)
 	// FetchRemap constructs a fetch relation providing an offset (skipping some
-        // number of rows) and a count (restricting output to a maximum number of
-        // rows).  If count is FETCH_COUNT_ALL_RECORDS (-1) all records will be
-        // returned.  Similar to Fetch but allows for reordering and restricting the
-        // returned columns.
+	// number of rows) and a count (restricting output to a maximum number of
+	// rows).  If count is FETCH_COUNT_ALL_RECORDS (-1) all records will be
+	// returned.  Similar to Fetch but allows for reordering and restricting the
+	// returned columns.
 	FetchRemap(input Rel, offset, count int64, remap []int32) (*FetchRel, error)
 	// Fetch constructs a fetch relation providing an offset (skipping some number of
-        // rows) and a count (restricting output to a maximum number of rows).  If count
-        // is FETCH_COUNT_ALL_RECORDS (-1) all records will be returned.
+	// rows) and a count (restricting output to a maximum number of rows).  If count
+	// is FETCH_COUNT_ALL_RECORDS (-1) all records will be returned.
 	Fetch(input Rel, offset, count int64) (*FetchRel, error)
 	FilterRemap(input Rel, condition expr.Expression, remap []int32) (*FilterRel, error)
 	Filter(input Rel, condition expr.Expression) (*FilterRel, error)

--- a/plan/builders.go
+++ b/plan/builders.go
@@ -80,7 +80,9 @@ type Builder interface {
 	CreateTableAsSelect(input Rel, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error)
 	CrossRemap(left, right Rel, remap []int32) (*CrossRel, error)
 	Cross(left, right Rel) (*CrossRel, error)
+	// FetchRemap constructs a fetch relation providing an offset (skipping some number of rows) and a count (restricting output to a maximum number of rows).  If count is FETCH_COUNT_ALL_RECORDS (-1) all records will be returned.  Similar to Fetch but allows for reordering and restricting the returned columns.
 	FetchRemap(input Rel, offset, count int64, remap []int32) (*FetchRel, error)
+	// Fetch constructs a fetch relation providing an offset (skipping some number of rows) and a count (restricting output to a maximum number of rows).  If count is FETCH_COUNT_ALL_RECORDS (-1) all records will be returned.
 	Fetch(input Rel, offset, count int64) (*FetchRel, error)
 	FilterRemap(input Rel, condition expr.Expression, remap []int32) (*FilterRel, error)
 	Filter(input Rel, condition expr.Expression) (*FilterRel, error)
@@ -107,6 +109,8 @@ type Builder interface {
 	// and so on.
 	PlanWithTypes(root Rel, rootNames []string, expectedTypeURLs []string, others ...Rel) (*Plan, error)
 }
+
+const FETCH_COUNT_ALL_RECORDS = -1
 
 func NewBuilderDefault() Builder {
 	return NewBuilder(&extensions.DefaultCollection)

--- a/plan/builders.go
+++ b/plan/builders.go
@@ -80,9 +80,15 @@ type Builder interface {
 	CreateTableAsSelect(input Rel, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error)
 	CrossRemap(left, right Rel, remap []int32) (*CrossRel, error)
 	Cross(left, right Rel) (*CrossRel, error)
-	// FetchRemap constructs a fetch relation providing an offset (skipping some number of rows) and a count (restricting output to a maximum number of rows).  If count is FETCH_COUNT_ALL_RECORDS (-1) all records will be returned.  Similar to Fetch but allows for reordering and restricting the returned columns.
+	// FetchRemap constructs a fetch relation providing an offset (skipping some
+        // number of rows) and a count (restricting output to a maximum number of
+        // rows).  If count is FETCH_COUNT_ALL_RECORDS (-1) all records will be
+        // returned.  Similar to Fetch but allows for reordering and restricting the
+        // returned columns.
 	FetchRemap(input Rel, offset, count int64, remap []int32) (*FetchRel, error)
-	// Fetch constructs a fetch relation providing an offset (skipping some number of rows) and a count (restricting output to a maximum number of rows).  If count is FETCH_COUNT_ALL_RECORDS (-1) all records will be returned.
+	// Fetch constructs a fetch relation providing an offset (skipping some number of
+        // rows) and a count (restricting output to a maximum number of rows).  If count
+        // is FETCH_COUNT_ALL_RECORDS (-1) all records will be returned.
 	Fetch(input Rel, offset, count int64) (*FetchRel, error)
 	FilterRemap(input Rel, condition expr.Expression, remap []int32) (*FilterRel, error)
 	Filter(input Rel, condition expr.Expression) (*FilterRel, error)

--- a/plan/plan_builder_test.go
+++ b/plan/plan_builder_test.go
@@ -403,7 +403,7 @@ func TestFetchRel(t *testing.T) {
 								}
 							},
 							"offset": 100,
-							"count": 50
+							"count": -1
 						}
 					},
 					"names": ["a"]
@@ -422,7 +422,7 @@ func TestFetchRel(t *testing.T) {
 		},
 	})
 
-	fetch, err := b.Fetch(scan, 100, 50)
+	fetch, err := b.Fetch(scan, 100, -1)
 	require.NoError(t, err)
 
 	p, err := b.Plan(fetch, []string{"a"})

--- a/plan/plan_builder_test.go
+++ b/plan/plan_builder_test.go
@@ -422,7 +422,7 @@ func TestFetchRel(t *testing.T) {
 		},
 	})
 
-	fetch, err := b.Fetch(scan, 100, -1)
+	fetch, err := b.Fetch(scan, 100, plan.FETCH_COUNT_ALL_RECORDS)
 	require.NoError(t, err)
 
 	p, err := b.Plan(fetch, []string{"a"})


### PR DESCRIPTION
Recently FetchRel's definition was modified to add -1 as a valid value for count.  This allows one to specify an offset but return all the remaining rows.
