### PR TITLE
feat:  Add new Remap interface to relations

### DIFF
--- a/plan/builders.go
+++ b/plan/builders.go
@@ -71,13 +71,18 @@ type Builder interface {
 	// from the output.
 
 	Project(input Rel, exprs ...expr.Expression) (*ProjectRel, error)
+	// Deprecated: Use Project(...).ChangeMapping() instead.
 	ProjectRemap(input Rel, remap []int32, exprs ...expr.Expression) (*ProjectRel, error)
+	// Deprecated: Use AggregateColumns(...).ChangeMapping() instead.
 	AggregateColumnsRemap(input Rel, remap []int32, measures []AggRelMeasure, groupByCols ...int32) (*AggregateRel, error)
 	AggregateColumns(input Rel, measures []AggRelMeasure, groupByCols ...int32) (*AggregateRel, error)
+	// Deprecated: Use AggregateExprs(...).ChangeMapping() instead.
 	AggregateExprsRemap(input Rel, remap []int32, measures []AggRelMeasure, groups ...[]expr.Expression) (*AggregateRel, error)
 	AggregateExprs(input Rel, measures []AggRelMeasure, groups ...[]expr.Expression) (*AggregateRel, error)
+	// Deprecated: Use CreateTableAsSelect(...).ChangeMapping() instead.
 	CreateTableAsSelectRemap(input Rel, remap []int32, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error)
 	CreateTableAsSelect(input Rel, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error)
+	// Deprecated: Use Cross(...).ChangeMapping() instead.
 	CrossRemap(left, right Rel, remap []int32) (*CrossRel, error)
 	Cross(left, right Rel) (*CrossRel, error)
 	// FetchRemap constructs a fetch relation providing an offset (skipping some
@@ -85,19 +90,27 @@ type Builder interface {
 	// rows).  If count is FETCH_COUNT_ALL_RECORDS (-1) all records will be
 	// returned.  Similar to Fetch but allows for reordering and restricting the
 	// returned columns.
+	//
+	// Deprecated: Use Fetch(...).ChangeMapping() instead.
 	FetchRemap(input Rel, offset, count int64, remap []int32) (*FetchRel, error)
 	// Fetch constructs a fetch relation providing an offset (skipping some number of
 	// rows) and a count (restricting output to a maximum number of rows).  If count
 	// is FETCH_COUNT_ALL_RECORDS (-1) all records will be returned.
 	Fetch(input Rel, offset, count int64) (*FetchRel, error)
+	// Deprecated: Use Filter(...).ChangeMapping() instead.
 	FilterRemap(input Rel, condition expr.Expression, remap []int32) (*FilterRel, error)
 	Filter(input Rel, condition expr.Expression) (*FilterRel, error)
+	// Deprecated: Use JoinAndFilter(...).ChangeMapping() instead.
 	JoinAndFilterRemap(left, right Rel, condition, postJoinFilter expr.Expression, joinType JoinType, remap []int32) (*JoinRel, error)
+	// Deprecated: Use Fetch(...).ChangeMapping() instead.
 	JoinAndFilter(left, right Rel, condition, postJoinFilter expr.Expression, joinType JoinType) (*JoinRel, error)
+	// Deprecated: Use Join(...).ChangeMapping() instead.
 	JoinRemap(left, right Rel, condition expr.Expression, joinType JoinType, remap []int32) (*JoinRel, error)
 	Join(left, right Rel, condition expr.Expression, joinType JoinType) (*JoinRel, error)
+	// Deprecated: Use NamedScan(...).ChangeMapping() instead.
 	NamedScanRemap(tableName []string, schema types.NamedStruct, remap []int32) (*NamedTableReadRel, error)
 	NamedScan(tableName []string, schema types.NamedStruct) *NamedTableReadRel
+	// Deprecated: Use NamedWriteMap(...).ChangeMapping() instead.
 	NamedWriteRemap(input Rel, op WriteOp, tableName []string, schema types.NamedStruct, remap []int32) (*NamedTableWriteRel, error)
 	// NamedInsert inserts data from the input relation into a named table.
 	NamedInsert(input Rel, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error)
@@ -105,12 +118,16 @@ type Builder interface {
 	// provided input relation, which typically includes conditions that filter
 	// the rows to delete.
 	NamedDelete(input Rel, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error)
+	// Deprecated: Use VirtualTable(...).ChangeMapping() instead.
 	VirtualTableRemap(fields []string, remap []int32, values ...expr.StructLiteralValue) (*VirtualTableReadRel, error)
 	VirtualTable(fields []string, values ...expr.StructLiteralValue) (*VirtualTableReadRel, error)
+	// Deprecated: Use VirtualTableFromExpr(...).ChangeMapping() instead.
 	VirtualTableFromExprRemap(fieldNames []string, remap []int32, values ...expr.VirtualTableExpressionValue) (*VirtualTableReadRel, error)
 	VirtualTableFromExpr(fieldNames []string, values ...expr.VirtualTableExpressionValue) (*VirtualTableReadRel, error)
+	// Deprecated: Use Sort(...).ChangeMapping() instead.
 	SortRemap(input Rel, remap []int32, sorts ...expr.SortField) (*SortRel, error)
 	Sort(input Rel, sorts ...expr.SortField) (*SortRel, error)
+	// Deprecated: Use Set(...).ChangeMapping() instead.
 	SetRemap(op SetOp, remap []int32, inputs ...Rel) (*SetRel, error)
 	Set(op SetOp, inputs ...Rel) (*SetRel, error)
 

--- a/plan/builders.go
+++ b/plan/builders.go
@@ -110,7 +110,7 @@ type Builder interface {
 	// Deprecated: Use NamedScan(...).ChangeMapping() instead.
 	NamedScanRemap(tableName []string, schema types.NamedStruct, remap []int32) (*NamedTableReadRel, error)
 	NamedScan(tableName []string, schema types.NamedStruct) *NamedTableReadRel
-	// Deprecated: Use NamedWriteMap(...).ChangeMapping() instead.
+	// Deprecated: Use NamedWrite(...).ChangeMapping() instead.
 	NamedWriteRemap(input Rel, op WriteOp, tableName []string, schema types.NamedStruct, remap []int32) (*NamedTableWriteRel, error)
 	// NamedInsert inserts data from the input relation into a named table.
 	NamedInsert(input Rel, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error)
@@ -504,12 +504,16 @@ func (b *builder) NamedWriteRemap(input Rel, op WriteOp, tableName []string, sch
 	}, nil
 }
 
+func (b *builder) NamedWrite(input Rel, op WriteOp, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error) {
+	return b.NamedWriteRemap(input, op, tableName, schema, nil)
+}
+
 func (b *builder) NamedInsert(input Rel, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error) {
-	return b.NamedWriteRemap(input, WriteOpInsert, tableName, schema, nil)
+	return b.NamedWrite(input, WriteOpInsert, tableName, schema)
 }
 
 func (b *builder) NamedDelete(input Rel, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error) {
-	return b.NamedWriteRemap(input, WriteOpDelete, tableName, schema, nil)
+	return b.NamedWrite(input, WriteOpDelete, tableName, schema)
 }
 
 func (b *builder) NamedScanRemap(tableName []string, schema types.NamedStruct, remap []int32) (*NamedTableReadRel, error) {

--- a/plan/builders.go
+++ b/plan/builders.go
@@ -112,6 +112,8 @@ type Builder interface {
 	NamedScan(tableName []string, schema types.NamedStruct) *NamedTableReadRel
 	// Deprecated: Use NamedWrite(...).Remap() instead.
 	NamedWriteRemap(input Rel, op WriteOp, tableName []string, schema types.NamedStruct, remap []int32) (*NamedTableWriteRel, error)
+	// NamedWrite performs the given write operation from the input relation over a named table.
+	NamedWrite(input Rel, op WriteOp, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error)
 	// NamedInsert inserts data from the input relation into a named table.
 	NamedInsert(input Rel, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error)
 	// NamedDelete deletes rows from a specified named table based on the

--- a/plan/builders.go
+++ b/plan/builders.go
@@ -71,18 +71,18 @@ type Builder interface {
 	// from the output.
 
 	Project(input Rel, exprs ...expr.Expression) (*ProjectRel, error)
-	// Deprecated: Use Project(...).ChangeMapping() instead.
+	// Deprecated: Use Project(...).Remap() instead.
 	ProjectRemap(input Rel, remap []int32, exprs ...expr.Expression) (*ProjectRel, error)
-	// Deprecated: Use AggregateColumns(...).ChangeMapping() instead.
+	// Deprecated: Use AggregateColumns(...).Remap() instead.
 	AggregateColumnsRemap(input Rel, remap []int32, measures []AggRelMeasure, groupByCols ...int32) (*AggregateRel, error)
 	AggregateColumns(input Rel, measures []AggRelMeasure, groupByCols ...int32) (*AggregateRel, error)
-	// Deprecated: Use AggregateExprs(...).ChangeMapping() instead.
+	// Deprecated: Use AggregateExprs(...).Remap() instead.
 	AggregateExprsRemap(input Rel, remap []int32, measures []AggRelMeasure, groups ...[]expr.Expression) (*AggregateRel, error)
 	AggregateExprs(input Rel, measures []AggRelMeasure, groups ...[]expr.Expression) (*AggregateRel, error)
-	// Deprecated: Use CreateTableAsSelect(...).ChangeMapping() instead.
+	// Deprecated: Use CreateTableAsSelect(...).Remap() instead.
 	CreateTableAsSelectRemap(input Rel, remap []int32, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error)
 	CreateTableAsSelect(input Rel, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error)
-	// Deprecated: Use Cross(...).ChangeMapping() instead.
+	// Deprecated: Use Cross(...).Remap() instead.
 	CrossRemap(left, right Rel, remap []int32) (*CrossRel, error)
 	Cross(left, right Rel) (*CrossRel, error)
 	// FetchRemap constructs a fetch relation providing an offset (skipping some
@@ -91,26 +91,26 @@ type Builder interface {
 	// returned.  Similar to Fetch but allows for reordering and restricting the
 	// returned columns.
 	//
-	// Deprecated: Use Fetch(...).ChangeMapping() instead.
+	// Deprecated: Use Fetch(...).Remap() instead.
 	FetchRemap(input Rel, offset, count int64, remap []int32) (*FetchRel, error)
 	// Fetch constructs a fetch relation providing an offset (skipping some number of
 	// rows) and a count (restricting output to a maximum number of rows).  If count
 	// is FETCH_COUNT_ALL_RECORDS (-1) all records will be returned.
 	Fetch(input Rel, offset, count int64) (*FetchRel, error)
-	// Deprecated: Use Filter(...).ChangeMapping() instead.
+	// Deprecated: Use Filter(...).Remap() instead.
 	FilterRemap(input Rel, condition expr.Expression, remap []int32) (*FilterRel, error)
 	Filter(input Rel, condition expr.Expression) (*FilterRel, error)
-	// Deprecated: Use JoinAndFilter(...).ChangeMapping() instead.
+	// Deprecated: Use JoinAndFilter(...).Remap() instead.
 	JoinAndFilterRemap(left, right Rel, condition, postJoinFilter expr.Expression, joinType JoinType, remap []int32) (*JoinRel, error)
-	// Deprecated: Use Fetch(...).ChangeMapping() instead.
+	// Deprecated: Use Fetch(...).Remap() instead.
 	JoinAndFilter(left, right Rel, condition, postJoinFilter expr.Expression, joinType JoinType) (*JoinRel, error)
-	// Deprecated: Use Join(...).ChangeMapping() instead.
+	// Deprecated: Use Join(...).Remap() instead.
 	JoinRemap(left, right Rel, condition expr.Expression, joinType JoinType, remap []int32) (*JoinRel, error)
 	Join(left, right Rel, condition expr.Expression, joinType JoinType) (*JoinRel, error)
-	// Deprecated: Use NamedScan(...).ChangeMapping() instead.
+	// Deprecated: Use NamedScan(...).Remap() instead.
 	NamedScanRemap(tableName []string, schema types.NamedStruct, remap []int32) (*NamedTableReadRel, error)
 	NamedScan(tableName []string, schema types.NamedStruct) *NamedTableReadRel
-	// Deprecated: Use NamedWrite(...).ChangeMapping() instead.
+	// Deprecated: Use NamedWrite(...).Remap() instead.
 	NamedWriteRemap(input Rel, op WriteOp, tableName []string, schema types.NamedStruct, remap []int32) (*NamedTableWriteRel, error)
 	// NamedInsert inserts data from the input relation into a named table.
 	NamedInsert(input Rel, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error)
@@ -118,16 +118,16 @@ type Builder interface {
 	// provided input relation, which typically includes conditions that filter
 	// the rows to delete.
 	NamedDelete(input Rel, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error)
-	// Deprecated: Use VirtualTable(...).ChangeMapping() instead.
+	// Deprecated: Use VirtualTable(...).Remap() instead.
 	VirtualTableRemap(fields []string, remap []int32, values ...expr.StructLiteralValue) (*VirtualTableReadRel, error)
 	VirtualTable(fields []string, values ...expr.StructLiteralValue) (*VirtualTableReadRel, error)
-	// Deprecated: Use VirtualTableFromExpr(...).ChangeMapping() instead.
+	// Deprecated: Use VirtualTableFromExpr(...).Remap() instead.
 	VirtualTableFromExprRemap(fieldNames []string, remap []int32, values ...expr.VirtualTableExpressionValue) (*VirtualTableReadRel, error)
 	VirtualTableFromExpr(fieldNames []string, values ...expr.VirtualTableExpressionValue) (*VirtualTableReadRel, error)
-	// Deprecated: Use Sort(...).ChangeMapping() instead.
+	// Deprecated: Use Sort(...).Remap() instead.
 	SortRemap(input Rel, remap []int32, sorts ...expr.SortField) (*SortRel, error)
 	Sort(input Rel, sorts ...expr.SortField) (*SortRel, error)
-	// Deprecated: Use Set(...).ChangeMapping() instead.
+	// Deprecated: Use Set(...).Remap() instead.
 	SetRemap(op SetOp, remap []int32, inputs ...Rel) (*SetRel, error)
 	Set(op SetOp, inputs ...Rel) (*SetRel, error)
 

--- a/plan/common.go
+++ b/plan/common.go
@@ -49,6 +49,10 @@ func (rc *RelCommon) remap(initial types.RecordType) types.RecordType {
 
 func (rc *RelCommon) OutputMapping() []int32 { return rc.mapping }
 
+func (rc *RelCommon) ClearMapping() {
+	rc.mapping = nil
+}
+
 func (rc *RelCommon) GetAdvancedExtension() *extensions.AdvancedExtension {
 	return rc.advExtension
 }

--- a/plan/common.go
+++ b/plan/common.go
@@ -54,6 +54,10 @@ func (rc *RelCommon) OutputMapping() []int32 {
 	return mapCopy
 }
 
+func (rc *RelCommon) setMapping(mapping []int32) {
+	rc.mapping = mapping
+}
+
 func (rc *RelCommon) GetAdvancedExtension() *extensions.AdvancedExtension {
 	return rc.advExtension
 }

--- a/plan/common.go
+++ b/plan/common.go
@@ -54,10 +54,6 @@ func (rc *RelCommon) OutputMapping() []int32 {
 	return mapCopy
 }
 
-func (rc *RelCommon) ClearMapping() {
-	rc.mapping = nil
-}
-
 func (rc *RelCommon) GetAdvancedExtension() *extensions.AdvancedExtension {
 	return rc.advExtension
 }

--- a/plan/common.go
+++ b/plan/common.go
@@ -47,7 +47,12 @@ func (rc *RelCommon) remap(initial types.RecordType) types.RecordType {
 	return *types.NewRecordTypeFromTypes(outTypes)
 }
 
-func (rc *RelCommon) OutputMapping() []int32 { return rc.mapping }
+func (rc *RelCommon) OutputMapping() []int32 {
+	// Make a copy of the output mapping to prevent accidental modification.
+	mapCopy := make([]int32, len(rc.mapping))
+	copy(mapCopy, rc.mapping)
+	return mapCopy
+}
 
 func (rc *RelCommon) ClearMapping() {
 	rc.mapping = nil

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -272,14 +272,15 @@ type Rel interface {
 	// output columns from the underlying relation.
 	OutputMapping() []int32
 
-	// ChangeMapping modifies the current relation by applying the provided
-	// mapping to the current relation.  Typically used to remove any unneeded
-	// columns or provide them in a different order.  If there already is a
-	// mapping on this relation, this provides mapping over the current mapping.
+	// Remap modifies the current relation by applying the provided
+	// mapping to the current relation.  Typically used to remove any
+	// unneeded columns or provide them in a different order.  If there
+	// already is a mapping on this relation, this provides mapping over
+	// the current mapping.
 	//
-	// If any column numbers specified are outside the currently available input
-	// range an error is returned and the mapping is left unchanged.
-	ChangeMapping(mapping ...int32) error
+	// If any column numbers specified are outside the currently available
+	// input range an error is returned and the mapping is left unchanged.
+	Remap(mapping ...int32) error
 	// directOutputSchema returns the output record type of the underlying
 	// relation as a struct type.  Mapping is not applied.
 	directOutputSchema() types.RecordType

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -255,6 +255,9 @@ type RewriteFunc func(expr.Expression) (expr.Expression, error)
 // It contains the common functionality between the different relations
 // and should be type switched to determine which relation type it actually
 // is for evaluation.
+//
+// All methods in this interface should be considered constant (i.e.
+// immutable).
 type Rel interface {
 	// Hint returns a set of changes to the operation which can influence
 	// efficiency and performance but should not impact correctness.
@@ -280,7 +283,7 @@ type Rel interface {
 	//
 	// If any column numbers specified are outside the currently available
 	// input range an error is returned and the mapping is left unchanged.
-	Remap(mapping ...int32) error
+	Remap(mapping ...int32) (Rel, error)
 	// directOutputSchema returns the output record type of the underlying
 	// relation as a struct type.  Mapping is not applied.
 	directOutputSchema() types.RecordType

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -256,8 +256,7 @@ type RewriteFunc func(expr.Expression) (expr.Expression, error)
 // and should be type switched to determine which relation type it actually
 // is for evaluation.
 //
-// All methods in this interface should be considered constant (i.e.
-// immutable).
+// All the exported methods in this interface should be considered constant.
 type Rel interface {
 	// Hint returns a set of changes to the operation which can influence
 	// efficiency and performance but should not impact correctness.

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -271,8 +271,7 @@ type Rel interface {
 	// result should be 3 columns consisting of the 5th, 2nd and 1st
 	// output columns from the underlying relation.
 	OutputMapping() []int32
-	// ClearMapping resets the mapping for this relation.
-	ClearMapping()
+
 	// ChangeMapping modifies the current relation by applying the provided
 	// mapping to the current relation.  Typically used to remove any unneeded
 	// columns or provide them in a different order.  If there already is a

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -271,6 +271,16 @@ type Rel interface {
 	// result should be 3 columns consisting of the 5th, 2nd and 1st
 	// output columns from the underlying relation.
 	OutputMapping() []int32
+	// ClearMapping resets the mapping for this relation.
+	ClearMapping()
+	// ChangeMapping modifies the current relation by applying the provided
+	// mapping to the current relation.  Typically used to remove any unneeded
+	// columns or provide them in a different order.  If there already is a
+	// mapping on this relation, this provides mapping over the current mapping.
+	//
+	// If any column numbers specified are outside the currently available input
+	// range an error is returned and the mapping is left unchanged.
+	ChangeMapping(mapping []int32) error
 	// directOutputSchema returns the output record type of the underlying
 	// relation as a struct type.  Mapping is not applied.
 	directOutputSchema() types.RecordType

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -280,7 +280,7 @@ type Rel interface {
 	//
 	// If any column numbers specified are outside the currently available input
 	// range an error is returned and the mapping is left unchanged.
-	ChangeMapping(mapping []int32) error
+	ChangeMapping(mapping ...int32) error
 	// directOutputSchema returns the output record type of the underlying
 	// relation as a struct type.  Mapping is not applied.
 	directOutputSchema() types.RecordType

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -284,6 +284,11 @@ type Rel interface {
 	// If any column numbers specified are outside the currently available
 	// input range an error is returned and the mapping is left unchanged.
 	Remap(mapping ...int32) (Rel, error)
+
+	// setMapping sets the current mapping and is for internal use.
+	// It performs no checks.  End users should call Remap() instead.
+	setMapping(mapping []int32)
+
 	// directOutputSchema returns the output record type of the underlying
 	// relation as a struct type.  Mapping is not applied.
 	directOutputSchema() types.RecordType

--- a/plan/plan_builder_test.go
+++ b/plan/plan_builder_test.go
@@ -97,7 +97,7 @@ func TestEmitEmptyPlan(t *testing.T) {
 	assert.Equal(t, "NSTRUCT<a: fp32, b: string>", p.GetRoots()[0].RecordType().String())
 
 	// Verify the mapping remains the same after receiving an error.
-	newRoot, err = root.Remap(-1)
+	_, err = root.Remap(-1)
 	require.Error(t, err)
 	assert.Equal(t, "NSTRUCT<a: fp32, b: string>", p.GetRoots()[0].RecordType().String())
 

--- a/plan/plan_builder_test.go
+++ b/plan/plan_builder_test.go
@@ -82,14 +82,14 @@ func TestEmitEmptyPlan(t *testing.T) {
 
 	b = plan.NewBuilderDefault()
 	root = b.NamedScan([]string{"test"}, baseSchema)
-	err = root.ChangeMapping()
+	err = root.Remap()
 	require.NoError(t, err)
 	_, err = b.Plan(root, []string{})
 	require.NoError(t, err)
 
 	b = plan.NewBuilderDefault()
 	root = b.NamedScan([]string{"test"}, baseSchema)
-	err = root.ChangeMapping(1, 0)
+	err = root.Remap(1, 0)
 	require.NoError(t, err)
 	p, err := b.Plan(root, []string{"a", "b"})
 	require.NoError(t, err)
@@ -97,7 +97,7 @@ func TestEmitEmptyPlan(t *testing.T) {
 	assert.Equal(t, "NSTRUCT<a: fp32, b: string>", p.GetRoots()[0].RecordType().String())
 
 	// Verify the mapping remains the same after receiving an error.
-	err = root.ChangeMapping(-1)
+	err = root.Remap(-1)
 	require.Error(t, err)
 	assert.Equal(t, "NSTRUCT<a: fp32, b: string>", p.GetRoots()[0].RecordType().String())
 
@@ -119,7 +119,7 @@ func TestBuildEmitOutOfRangePlan(t *testing.T) {
 
 	b = plan.NewBuilderDefault()
 	root := b.NamedScan([]string{"test"}, baseSchema)
-	err = root.ChangeMapping(2)
+	err = root.Remap(2)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 }
@@ -127,10 +127,10 @@ func TestBuildEmitOutOfRangePlan(t *testing.T) {
 func TestMappingOfMapping(t *testing.T) {
 	b := plan.NewBuilderDefault()
 	ns := b.NamedScan([]string{"test"}, baseSchema)
-	err := ns.ChangeMapping(1, 0)
+	err := ns.Remap(1, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, "struct<fp32, string>", ns.RecordType().String())
-	err = ns.ChangeMapping(1)
+	err = ns.Remap(1)
 	assert.NoError(t, err)
 	assert.Equal(t, "struct<string>", ns.RecordType().String())
 }
@@ -298,7 +298,7 @@ func TestAggregateRelErrors(t *testing.T) {
 
 	acr, err := b.AggregateColumns(scan, nil, 0)
 	assert.NoError(t, err)
-	err = acr.ChangeMapping(-1, 5)
+	err = acr.Remap(-1, 5)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -310,7 +310,7 @@ func TestAggregateRelErrors(t *testing.T) {
 	ref, _ = b.RootFieldRef(scan, 0)
 	ae, err := b.AggregateExprs(scan, nil, []expr.Expression{ref})
 	assert.NoError(t, err)
-	err = ae.ChangeMapping(5, -1)
+	err = ae.Remap(5, -1)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -320,7 +320,7 @@ func TestAggregateRelErrors(t *testing.T) {
 
 	ae, err = b.AggregateExprs(scan, nil, []expr.Expression{ref})
 	assert.NoError(t, err)
-	err = ae.ChangeMapping(1)
+	err = ae.Remap(1)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -328,14 +328,14 @@ func TestAggregateRelErrors(t *testing.T) {
 	assert.NoError(t, err)
 	ae, err = b.AggregateExprs(scan, nil, []expr.Expression{ref})
 	assert.NoError(t, err)
-	err = ae.ChangeMapping(0)
+	err = ae.Remap(0)
 	assert.NoError(t, err)
 
 	_, err = b.AggregateColumnsRemap(scan, []int32{0}, nil, 0)
 	assert.NoError(t, err)
 	ae, err = b.AggregateColumns(scan, nil, 0)
 	assert.NoError(t, err)
-	err = ae.ChangeMapping(0)
+	err = ae.Remap(0)
 	assert.NoError(t, err)
 }
 
@@ -429,7 +429,7 @@ func TestCrossRelErrors(t *testing.T) {
 
 	c, err := b.Cross(left, right)
 	assert.NoError(t, err)
-	err = c.ChangeMapping(-1)
+	err = c.Remap(-1)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -439,7 +439,7 @@ func TestCrossRelErrors(t *testing.T) {
 
 	c, err = b.Cross(left, right)
 	assert.NoError(t, err)
-	err = c.ChangeMapping(5)
+	err = c.Remap(5)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -450,7 +450,7 @@ func TestCrossRelErrors(t *testing.T) {
 	// Output is length 2 + 2
 	c, err = b.Cross(left, right)
 	assert.NoError(t, err)
-	err = c.ChangeMapping(2, 3)
+	err = c.Remap(2, 3)
 	assert.NoError(t, err)
 }
 
@@ -512,7 +512,7 @@ func TestFetchRel(t *testing.T) {
 
 	checkRoundTrip(t, expectedJSON, p)
 
-	err = fetch.ChangeMapping(0)
+	err = fetch.Remap(0)
 	assert.NoError(t, err)
 }
 
@@ -538,7 +538,7 @@ func TestFetchRelErrors(t *testing.T) {
 
 	f, err := b.Fetch(scan, 0, 0)
 	assert.NoError(t, err)
-	err = f.ChangeMapping(-1)
+	err = f.Remap(-1)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -548,7 +548,7 @@ func TestFetchRelErrors(t *testing.T) {
 
 	f, err = b.Fetch(scan, 0, 0)
 	assert.NoError(t, err)
-	err = f.ChangeMapping(2)
+	err = f.Remap(2)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -610,7 +610,7 @@ func TestFilterRelation(t *testing.T) {
 
 	checkRoundTrip(t, expectedJSON, p)
 
-	err = filter.ChangeMapping(0)
+	err = filter.Remap(0)
 	assert.NoError(t, err)
 }
 
@@ -648,7 +648,7 @@ func TestFilterRelationErrors(t *testing.T) {
 
 	f, err := b.Filter(scan, refBool)
 	assert.NoError(t, err)
-	err = f.ChangeMapping(-1)
+	err = f.Remap(-1)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -658,7 +658,7 @@ func TestFilterRelationErrors(t *testing.T) {
 
 	f, err = b.Filter(scan, refBool)
 	assert.NoError(t, err)
-	err = f.ChangeMapping(3)
+	err = f.Remap(3)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 }
@@ -877,7 +877,7 @@ func TestJoinRelationError(t *testing.T) {
 
 	j, err := b.Join(left, right, goodcond, plan.JoinTypeInner)
 	assert.NoError(t, err)
-	err = j.ChangeMapping(-1)
+	err = j.Remap(-1)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -887,7 +887,7 @@ func TestJoinRelationError(t *testing.T) {
 
 	j, err = b.Join(left, right, goodcond, plan.JoinTypeLeftAnti)
 	assert.NoError(t, err)
-	err = j.ChangeMapping(2)
+	err = j.Remap(2)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -1118,7 +1118,7 @@ func TestSortRelationErrors(t *testing.T) {
 	fields, _ = b.SortFields(scan, 1, 0)
 	s, err := b.Sort(scan, fields...)
 	assert.NoError(t, err)
-	err = s.ChangeMapping(-1)
+	err = s.Remap(-1)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -1136,7 +1136,7 @@ func TestSortRelationErrors(t *testing.T) {
 
 	sortRel, err := b.Sort(scan, fields...)
 	assert.NoError(t, err)
-	err = sortRel.ChangeMapping(3)
+	err = sortRel.Remap(3)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 }
@@ -1438,7 +1438,7 @@ func TestProjectErrors(t *testing.T) {
 
 	p, err := b.Project(scan, ref)
 	assert.NoError(t, err)
-	err = p.ChangeMapping(-1)
+	err = p.Remap(-1)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -1448,7 +1448,7 @@ func TestProjectErrors(t *testing.T) {
 
 	p, err = b.Project(scan, ref)
 	assert.NoError(t, err)
-	err = p.ChangeMapping(3)
+	err = p.Remap(3)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -1457,7 +1457,7 @@ func TestProjectErrors(t *testing.T) {
 
 	p, err = b.Project(scan, ref)
 	assert.NoError(t, err)
-	err = p.ChangeMapping(2)
+	err = p.Remap(2)
 	assert.NoError(t, err, "Expected expression mapping to be in-bounds")
 }
 
@@ -1669,7 +1669,7 @@ func TestSetRelErrors(t *testing.T) {
 
 	s, err := b.Set(plan.SetOpMinusMultiset, scan1, scan2)
 	assert.NoError(t, err)
-	err = s.ChangeMapping(-1)
+	err = s.Remap(-1)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -1679,7 +1679,7 @@ func TestSetRelErrors(t *testing.T) {
 
 	s, err = b.Set(plan.SetOpMinusMultiset, scan1, scan2)
 	assert.NoError(t, err)
-	err = s.ChangeMapping(3)
+	err = s.Remap(3)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 }

--- a/plan/plan_builder_test.go
+++ b/plan/plan_builder_test.go
@@ -141,9 +141,8 @@ func TestFailedMappingOfMapping(t *testing.T) {
 	newRel, err := ns.Remap(1, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, "struct<fp32, string>", newRel.RecordType().String())
-	newRel2, err := newRel.Remap(-1)
+	_, err = newRel.Remap(-1)
 	assert.ErrorContains(t, err, "output mapping index out of range")
-	assert.Equal(t, "struct<fp32, string>", newRel2.RecordType().String())
 }
 
 func checkRoundTrip(t *testing.T, expectedJSON string, p *plan.Plan) {

--- a/plan/plan_builder_test.go
+++ b/plan/plan_builder_test.go
@@ -74,22 +74,22 @@ func TestBasicEmitPlan(t *testing.T) {
 
 func TestEmitEmptyPlan(t *testing.T) {
 	b := plan.NewBuilderDefault()
-	root := b.NamedScan([]string{"test"}, baseSchema)
-	err := root.ChangeMapping([]int32{})
+	root, err := b.NamedScanRemap([]string{"test"},
+		baseSchema, []int32{})
 	require.NoError(t, err)
 	_, err = b.Plan(root, []string{})
 	require.NoError(t, err)
 
 	b = plan.NewBuilderDefault()
 	root = b.NamedScan([]string{"test"}, baseSchema)
-	err = root.ChangeMapping([]int32{})
+	err = root.ChangeMapping()
 	require.NoError(t, err)
 	_, err = b.Plan(root, []string{})
 	require.NoError(t, err)
 
 	b = plan.NewBuilderDefault()
 	root = b.NamedScan([]string{"test"}, baseSchema)
-	err = root.ChangeMapping([]int32{1, 0})
+	err = root.ChangeMapping(1, 0)
 	require.NoError(t, err)
 	p, err := b.Plan(root, []string{"a", "b"})
 	require.NoError(t, err)
@@ -97,7 +97,7 @@ func TestEmitEmptyPlan(t *testing.T) {
 	assert.Equal(t, "NSTRUCT<a: fp32, b: string>", p.GetRoots()[0].RecordType().String())
 
 	// Verify the mapping remains the same after receiving an error.
-	err = root.ChangeMapping([]int32{-1})
+	err = root.ChangeMapping(-1)
 	require.Error(t, err)
 	assert.Equal(t, "NSTRUCT<a: fp32, b: string>", p.GetRoots()[0].RecordType().String())
 
@@ -119,7 +119,7 @@ func TestBuildEmitOutOfRangePlan(t *testing.T) {
 
 	b = plan.NewBuilderDefault()
 	root := b.NamedScan([]string{"test"}, baseSchema)
-	err = root.ChangeMapping([]int32{2})
+	err = root.ChangeMapping(2)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 }
@@ -127,10 +127,10 @@ func TestBuildEmitOutOfRangePlan(t *testing.T) {
 func TestMappingOfMapping(t *testing.T) {
 	b := plan.NewBuilderDefault()
 	ns := b.NamedScan([]string{"test"}, baseSchema)
-	err := ns.ChangeMapping([]int32{1, 0})
+	err := ns.ChangeMapping(1, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, "struct<fp32, string>", ns.RecordType().String())
-	err = ns.ChangeMapping([]int32{1})
+	err = ns.ChangeMapping(1)
 	assert.NoError(t, err)
 	assert.Equal(t, "struct<string>", ns.RecordType().String())
 }
@@ -298,7 +298,7 @@ func TestAggregateRelErrors(t *testing.T) {
 
 	acr, err := b.AggregateColumns(scan, nil, 0)
 	assert.NoError(t, err)
-	err = acr.ChangeMapping([]int32{-1, 5})
+	err = acr.ChangeMapping(-1, 5)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -310,7 +310,7 @@ func TestAggregateRelErrors(t *testing.T) {
 	ref, _ = b.RootFieldRef(scan, 0)
 	ae, err := b.AggregateExprs(scan, nil, []expr.Expression{ref})
 	assert.NoError(t, err)
-	err = ae.ChangeMapping([]int32{5, -1})
+	err = ae.ChangeMapping(5, -1)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -320,7 +320,7 @@ func TestAggregateRelErrors(t *testing.T) {
 
 	ae, err = b.AggregateExprs(scan, nil, []expr.Expression{ref})
 	assert.NoError(t, err)
-	err = ae.ChangeMapping([]int32{1})
+	err = ae.ChangeMapping(1)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -328,14 +328,14 @@ func TestAggregateRelErrors(t *testing.T) {
 	assert.NoError(t, err)
 	ae, err = b.AggregateExprs(scan, nil, []expr.Expression{ref})
 	assert.NoError(t, err)
-	err = ae.ChangeMapping([]int32{0})
+	err = ae.ChangeMapping(0)
 	assert.NoError(t, err)
 
 	_, err = b.AggregateColumnsRemap(scan, []int32{0}, nil, 0)
 	assert.NoError(t, err)
 	ae, err = b.AggregateColumns(scan, nil, 0)
 	assert.NoError(t, err)
-	err = ae.ChangeMapping([]int32{0})
+	err = ae.ChangeMapping(0)
 	assert.NoError(t, err)
 }
 
@@ -429,7 +429,7 @@ func TestCrossRelErrors(t *testing.T) {
 
 	c, err := b.Cross(left, right)
 	assert.NoError(t, err)
-	err = c.ChangeMapping([]int32{-1})
+	err = c.ChangeMapping(-1)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -439,7 +439,7 @@ func TestCrossRelErrors(t *testing.T) {
 
 	c, err = b.Cross(left, right)
 	assert.NoError(t, err)
-	err = c.ChangeMapping([]int32{5})
+	err = c.ChangeMapping(5)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -450,7 +450,7 @@ func TestCrossRelErrors(t *testing.T) {
 	// Output is length 2 + 2
 	c, err = b.Cross(left, right)
 	assert.NoError(t, err)
-	err = c.ChangeMapping([]int32{2, 3})
+	err = c.ChangeMapping(2, 3)
 	assert.NoError(t, err)
 }
 
@@ -512,7 +512,7 @@ func TestFetchRel(t *testing.T) {
 
 	checkRoundTrip(t, expectedJSON, p)
 
-	err = fetch.ChangeMapping([]int32{0})
+	err = fetch.ChangeMapping(0)
 	assert.NoError(t, err)
 }
 
@@ -538,7 +538,7 @@ func TestFetchRelErrors(t *testing.T) {
 
 	f, err := b.Fetch(scan, 0, 0)
 	assert.NoError(t, err)
-	err = f.ChangeMapping([]int32{-1})
+	err = f.ChangeMapping(-1)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -548,7 +548,7 @@ func TestFetchRelErrors(t *testing.T) {
 
 	f, err = b.Fetch(scan, 0, 0)
 	assert.NoError(t, err)
-	err = f.ChangeMapping([]int32{2})
+	err = f.ChangeMapping(2)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -610,7 +610,7 @@ func TestFilterRelation(t *testing.T) {
 
 	checkRoundTrip(t, expectedJSON, p)
 
-	err = filter.ChangeMapping([]int32{0})
+	err = filter.ChangeMapping(0)
 	assert.NoError(t, err)
 }
 
@@ -648,7 +648,7 @@ func TestFilterRelationErrors(t *testing.T) {
 
 	f, err := b.Filter(scan, refBool)
 	assert.NoError(t, err)
-	err = f.ChangeMapping([]int32{-1})
+	err = f.ChangeMapping(-1)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -658,7 +658,7 @@ func TestFilterRelationErrors(t *testing.T) {
 
 	f, err = b.Filter(scan, refBool)
 	assert.NoError(t, err)
-	err = f.ChangeMapping([]int32{3})
+	err = f.ChangeMapping(3)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 }
@@ -877,7 +877,7 @@ func TestJoinRelationError(t *testing.T) {
 
 	j, err := b.Join(left, right, goodcond, plan.JoinTypeInner)
 	assert.NoError(t, err)
-	err = j.ChangeMapping([]int32{-1})
+	err = j.ChangeMapping(-1)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -887,7 +887,7 @@ func TestJoinRelationError(t *testing.T) {
 
 	j, err = b.Join(left, right, goodcond, plan.JoinTypeLeftAnti)
 	assert.NoError(t, err)
-	err = j.ChangeMapping([]int32{2})
+	err = j.ChangeMapping(2)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -1118,7 +1118,7 @@ func TestSortRelationErrors(t *testing.T) {
 	fields, _ = b.SortFields(scan, 1, 0)
 	s, err := b.Sort(scan, fields...)
 	assert.NoError(t, err)
-	err = s.ChangeMapping([]int32{-1})
+	err = s.ChangeMapping(-1)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -1136,7 +1136,7 @@ func TestSortRelationErrors(t *testing.T) {
 
 	sortRel, err := b.Sort(scan, fields...)
 	assert.NoError(t, err)
-	err = sortRel.ChangeMapping([]int32{3})
+	err = sortRel.ChangeMapping(3)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 }
@@ -1438,7 +1438,7 @@ func TestProjectErrors(t *testing.T) {
 
 	p, err := b.Project(scan, ref)
 	assert.NoError(t, err)
-	err = p.ChangeMapping([]int32{-1})
+	err = p.ChangeMapping(-1)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -1448,7 +1448,7 @@ func TestProjectErrors(t *testing.T) {
 
 	p, err = b.Project(scan, ref)
 	assert.NoError(t, err)
-	err = p.ChangeMapping([]int32{3})
+	err = p.ChangeMapping(3)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -1457,7 +1457,7 @@ func TestProjectErrors(t *testing.T) {
 
 	p, err = b.Project(scan, ref)
 	assert.NoError(t, err)
-	err = p.ChangeMapping([]int32{2})
+	err = p.ChangeMapping(2)
 	assert.NoError(t, err, "Expected expression mapping to be in-bounds")
 }
 
@@ -1669,7 +1669,7 @@ func TestSetRelErrors(t *testing.T) {
 
 	s, err := b.Set(plan.SetOpMinusMultiset, scan1, scan2)
 	assert.NoError(t, err)
-	err = s.ChangeMapping([]int32{-1})
+	err = s.ChangeMapping(-1)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -1679,7 +1679,7 @@ func TestSetRelErrors(t *testing.T) {
 
 	s, err = b.Set(plan.SetOpMinusMultiset, scan1, scan2)
 	assert.NoError(t, err)
-	err = s.ChangeMapping([]int32{3})
+	err = s.ChangeMapping(3)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 }

--- a/plan/plan_builder_test.go
+++ b/plan/plan_builder_test.go
@@ -96,6 +96,11 @@ func TestEmitEmptyPlan(t *testing.T) {
 
 	assert.Equal(t, "NSTRUCT<a: fp32, b: string>", p.GetRoots()[0].RecordType().String())
 
+	// Verify the mapping remains the same after receiving an error.
+	err = root.ChangeMapping([]int32{-1})
+	require.Error(t, err)
+	assert.Equal(t, "NSTRUCT<a: fp32, b: string>", p.GetRoots()[0].RecordType().String())
+
 	protoPlan, err := p.ToProto()
 	require.NoError(t, err)
 

--- a/plan/relations.go
+++ b/plan/relations.go
@@ -158,7 +158,7 @@ type MappableRel interface {
 }
 
 // RemapHelper implements the core functionality of RemapHelper for relations.
-// It returns the relation's existing mapping on an error to ease being called.
+// It returns the relation's existing mapping or an error to ease being called.
 func RemapHelper(r MappableRel, mapping []int32) ([]int32, error) {
 	if len(mapping) == 0 {
 		return []int32{}, nil
@@ -242,9 +242,9 @@ func (n *NamedTableReadRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, _
 
 func (n *NamedTableReadRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(n, mapping)
-	newRel := n
+	newRel := *n
 	newRel.mapping = newMapping
-	return newRel, err
+	return &newRel, err
 }
 
 // VirtualTableReadRel represents a table composed of literals.
@@ -304,9 +304,9 @@ func (v *VirtualTableReadRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc,
 
 func (v *VirtualTableReadRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(v, mapping)
-	newRel := v
+	newRel := *v
 	newRel.mapping = newMapping
-	return newRel, err
+	return &newRel, err
 }
 
 // ExtensionTableReadRel is a stub type that can be used to extend
@@ -361,9 +361,9 @@ func (e *ExtensionTableReadRel) CopyWithExpressionRewrite(rewriteFunc RewriteFun
 
 func (e *ExtensionTableReadRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(e, mapping)
-	newRel := e
+	newRel := *e
 	newRel.mapping = newMapping
-	return newRel, err
+	return &newRel, err
 }
 
 // PathType is the type of a LocalFileReadRel's uris.
@@ -551,9 +551,9 @@ func (lf *LocalFileReadRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, _
 
 func (lf *LocalFileReadRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(lf, mapping)
-	newRel := lf
+	newRel := *lf
 	newRel.mapping = newMapping
-	return newRel, err
+	return &newRel, err
 }
 
 // ProjectRel represents calculated expressions of fields (e.g. a+b),
@@ -647,9 +647,9 @@ func (p *ProjectRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInput
 
 func (p *ProjectRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(p, mapping)
-	newRel := p
+	newRel := *p
 	newRel.mapping = newMapping
-	return newRel, err
+	return &newRel, err
 }
 
 var defFilter = expr.NewPrimitiveLiteral(true, false)
@@ -806,9 +806,9 @@ func (j *JoinRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInputs .
 
 func (j *JoinRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(j, mapping)
-	newRel := j
+	newRel := *j
 	newRel.mapping = newMapping
-	return newRel, err
+	return &newRel, err
 }
 
 // CrossRel is a cartesian product relational operator of two tables.
@@ -874,9 +874,9 @@ func (c *CrossRel) CopyWithExpressionRewrite(_ RewriteFunc, newInputs ...Rel) (R
 
 func (c *CrossRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(c, mapping)
-	newRel := c
+	newRel := *c
 	newRel.mapping = newMapping
-	return newRel, err
+	return &newRel, err
 }
 
 // FetchRel is a relational operator representing LIMIT/OFFSET or
@@ -947,9 +947,9 @@ func (f *FetchRel) CopyWithExpressionRewrite(_ RewriteFunc, newInputs ...Rel) (R
 
 func (f *FetchRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(f, mapping)
-	newRel := f
+	newRel := *f
 	newRel.mapping = newMapping
-	return newRel, err
+	return &newRel, err
 }
 
 type AggRelMeasure struct {
@@ -1102,9 +1102,9 @@ func (ar *AggregateRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newIn
 
 func (ar *AggregateRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(ar, mapping)
-	newRel := ar
+	newRel := *ar
 	newRel.mapping = newMapping
-	return newRel, err
+	return &newRel, err
 }
 
 // SortRel is an ORDER BY relational operator, describing a base relation,
@@ -1190,9 +1190,9 @@ func (sr *SortRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInputs 
 
 func (sr *SortRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(sr, mapping)
-	newRel := sr
+	newRel := *sr
 	newRel.mapping = newMapping
-	return newRel, err
+	return &newRel, err
 }
 
 // FilterRel is a relational operator capturing simple filters (
@@ -1268,9 +1268,9 @@ func (fr *FilterRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInput
 
 func (fr *FilterRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(fr, mapping)
-	newRel := fr
+	newRel := *fr
 	newRel.mapping = newMapping
-	return newRel, err
+	return &newRel, err
 }
 
 type SetOp = proto.SetRel_SetOp
@@ -1348,9 +1348,9 @@ func (s *SetRel) CopyWithExpressionRewrite(_ RewriteFunc, newInputs ...Rel) (Rel
 
 func (s *SetRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(s, mapping)
-	newRel := s
+	newRel := *s
 	newRel.mapping = newMapping
-	return newRel, err
+	return &newRel, err
 }
 
 // ExtensionSingleRel is a stub to support extensions with a single input.
@@ -1412,9 +1412,9 @@ func (es *ExtensionSingleRel) CopyWithExpressionRewrite(_ RewriteFunc, newInputs
 
 func (es *ExtensionSingleRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(es, mapping)
-	newRel := es
+	newRel := *es
 	newRel.mapping = newMapping
-	return newRel, err
+	return &newRel, err
 }
 
 // ExtensionLeafRel is a stub to support extensions with zero inputs.
@@ -1463,9 +1463,9 @@ func (el *ExtensionLeafRel) CopyWithExpressionRewrite(_ RewriteFunc, _ ...Rel) (
 
 func (el *ExtensionLeafRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(el, mapping)
-	newRel := el
+	newRel := *el
 	newRel.mapping = newMapping
-	return newRel, err
+	return &newRel, err
 }
 
 // ExtensionMultiRel is a stub to support extensions with multiple inputs.
@@ -1526,9 +1526,9 @@ func (em *ExtensionMultiRel) CopyWithExpressionRewrite(_ RewriteFunc, newInputs 
 
 func (em *ExtensionMultiRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(em, mapping)
-	newRel := em
+	newRel := *em
 	newRel.mapping = newMapping
-	return newRel, err
+	return &newRel, err
 }
 
 type HashMergeJoinType int8
@@ -1651,9 +1651,9 @@ func (hr *HashJoinRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInp
 
 func (hr *HashJoinRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(hr, mapping)
-	newRel := hr
+	newRel := *hr
 	newRel.mapping = newMapping
-	return newRel, err
+	return &newRel, err
 }
 
 // MergeJoinRel represents a join done by taking advantage of two sets
@@ -1762,9 +1762,9 @@ func (mr *MergeJoinRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newIn
 
 func (mr *MergeJoinRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(mr, mapping)
-	newRel := mr
+	newRel := *mr
 	newRel.mapping = newMapping
-	return newRel, err
+	return &newRel, err
 }
 
 type WriteOp = proto.WriteRel_WriteOp
@@ -1880,9 +1880,9 @@ func (wr *NamedTableWriteRel) CopyWithExpressionRewrite(_ RewriteFunc, newInputs
 
 func (wr *NamedTableWriteRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(wr, mapping)
-	newRel := wr
+	newRel := *wr
 	newRel.mapping = newMapping
-	return newRel, err
+	return &newRel, err
 }
 
 var (

--- a/plan/relations.go
+++ b/plan/relations.go
@@ -157,13 +157,15 @@ type MappableRel interface {
 	OutputMapping() []int32
 }
 
+// ChangeMapping implements the core functionality of ChangeMapping for relations.
+// It returns the relation's existing mapping on an error to ease being called.
 func ChangeMapping(r MappableRel, mapping []int32) ([]int32, error) {
 	nOutput := r.RecordType().FieldCount()
 	oldMapping := r.OutputMapping()
 	newMapping := make([]int32, 0, len(mapping))
 	for _, idx := range mapping {
 		if idx < 0 || idx >= nOutput {
-			return nil, errOutputMappingOutOfRange
+			return r.OutputMapping(), errOutputMappingOutOfRange
 		}
 		if len(oldMapping) > 0 {
 			newMapping = append(newMapping, oldMapping[idx])

--- a/plan/relations.go
+++ b/plan/relations.go
@@ -180,12 +180,6 @@ func RemapHelper(r MappableRel, mapping []int32) ([]int32, error) {
 	return mapping, nil
 }
 
-func (b *baseReadRel) Remap(mapping ...int32) error {
-	newMapping, err := RemapHelper(b, mapping)
-	b.mapping = newMapping
-	return err
-}
-
 // NamedTableReadRel is a named scan of a base table. The list of strings
 // that make up the names are to represent namespacing (e.g. mydb.mytable).
 // This assumes a shared catalog between systems exchanging a message.
@@ -246,6 +240,13 @@ func (n *NamedTableReadRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, _
 	return &nt, nil
 }
 
+func (n *NamedTableReadRel) Remap(mapping ...int32) (Rel, error) {
+	newMapping, err := RemapHelper(n, mapping)
+	newRel := n
+	newRel.mapping = newMapping
+	return newRel, err
+}
+
 // VirtualTableReadRel represents a table composed of literals.
 type VirtualTableReadRel struct {
 	baseReadRel
@@ -301,6 +302,13 @@ func (v *VirtualTableReadRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc,
 	return &vtr, nil
 }
 
+func (v *VirtualTableReadRel) Remap(mapping ...int32) (Rel, error) {
+	newMapping, err := RemapHelper(v, mapping)
+	newRel := v
+	newRel.mapping = newMapping
+	return newRel, err
+}
+
 // ExtensionTableReadRel is a stub type that can be used to extend
 // and introduce new table types outside the specification by utilizing
 // protobuf Any type.
@@ -349,6 +357,13 @@ func (e *ExtensionTableReadRel) CopyWithExpressionRewrite(rewriteFunc RewriteFun
 	etr := *e
 	etr.updateFilters(newExprs)
 	return &etr, nil
+}
+
+func (e *ExtensionTableReadRel) Remap(mapping ...int32) (Rel, error) {
+	newMapping, err := RemapHelper(e, mapping)
+	newRel := e
+	newRel.mapping = newMapping
+	return newRel, err
 }
 
 // PathType is the type of a LocalFileReadRel's uris.
@@ -534,6 +549,13 @@ func (lf *LocalFileReadRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, _
 	return &lfr, nil
 }
 
+func (lf *LocalFileReadRel) Remap(mapping ...int32) (Rel, error) {
+	newMapping, err := RemapHelper(lf, mapping)
+	newRel := lf
+	newRel.mapping = newMapping
+	return newRel, err
+}
+
 // ProjectRel represents calculated expressions of fields (e.g. a+b),
 // the OutputMapping will be used to represent classical relational
 // projections.
@@ -623,10 +645,11 @@ func (p *ProjectRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInput
 	return &proj, nil
 }
 
-func (p *ProjectRel) Remap(mapping ...int32) error {
+func (p *ProjectRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(p, mapping)
-	p.mapping = newMapping
-	return err
+	newRel := p
+	newRel.mapping = newMapping
+	return newRel, err
 }
 
 var defFilter = expr.NewPrimitiveLiteral(true, false)
@@ -781,10 +804,11 @@ func (j *JoinRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInputs .
 	return &join, nil
 }
 
-func (j *JoinRel) Remap(mapping ...int32) error {
+func (j *JoinRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(j, mapping)
-	j.mapping = newMapping
-	return err
+	newRel := j
+	newRel.mapping = newMapping
+	return newRel, err
 }
 
 // CrossRel is a cartesian product relational operator of two tables.
@@ -848,10 +872,11 @@ func (c *CrossRel) CopyWithExpressionRewrite(_ RewriteFunc, newInputs ...Rel) (R
 	return c.Copy(newInputs...)
 }
 
-func (c *CrossRel) Remap(mapping ...int32) error {
+func (c *CrossRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(c, mapping)
-	c.mapping = newMapping
-	return err
+	newRel := c
+	newRel.mapping = newMapping
+	return newRel, err
 }
 
 // FetchRel is a relational operator representing LIMIT/OFFSET or
@@ -920,10 +945,11 @@ func (f *FetchRel) CopyWithExpressionRewrite(_ RewriteFunc, newInputs ...Rel) (R
 	return f.Copy(newInputs...)
 }
 
-func (f *FetchRel) Remap(mapping ...int32) error {
+func (f *FetchRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(f, mapping)
-	f.mapping = newMapping
-	return err
+	newRel := f
+	newRel.mapping = newMapping
+	return newRel, err
 }
 
 type AggRelMeasure struct {
@@ -1074,10 +1100,11 @@ func (ar *AggregateRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newIn
 	return &aggregate, nil
 }
 
-func (ar *AggregateRel) Remap(mapping ...int32) error {
+func (ar *AggregateRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(ar, mapping)
-	ar.mapping = newMapping
-	return err
+	newRel := ar
+	newRel.mapping = newMapping
+	return newRel, err
 }
 
 // SortRel is an ORDER BY relational operator, describing a base relation,
@@ -1161,10 +1188,11 @@ func (sr *SortRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInputs 
 	return &sort, nil
 }
 
-func (sr *SortRel) Remap(mapping ...int32) error {
+func (sr *SortRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(sr, mapping)
-	sr.mapping = newMapping
-	return err
+	newRel := sr
+	newRel.mapping = newMapping
+	return newRel, err
 }
 
 // FilterRel is a relational operator capturing simple filters (
@@ -1238,10 +1266,11 @@ func (fr *FilterRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInput
 	return &filter, nil
 }
 
-func (fr *FilterRel) Remap(mapping ...int32) error {
+func (fr *FilterRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(fr, mapping)
-	fr.mapping = newMapping
-	return err
+	newRel := fr
+	newRel.mapping = newMapping
+	return newRel, err
 }
 
 type SetOp = proto.SetRel_SetOp
@@ -1317,10 +1346,11 @@ func (s *SetRel) CopyWithExpressionRewrite(_ RewriteFunc, newInputs ...Rel) (Rel
 	return s.Copy(newInputs...)
 }
 
-func (s *SetRel) Remap(mapping ...int32) error {
+func (s *SetRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(s, mapping)
-	s.mapping = newMapping
-	return err
+	newRel := s
+	newRel.mapping = newMapping
+	return newRel, err
 }
 
 // ExtensionSingleRel is a stub to support extensions with a single input.
@@ -1380,10 +1410,11 @@ func (es *ExtensionSingleRel) CopyWithExpressionRewrite(_ RewriteFunc, newInputs
 	return es.Copy(newInputs...)
 }
 
-func (es *ExtensionSingleRel) Remap(mapping ...int32) error {
+func (es *ExtensionSingleRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(es, mapping)
-	es.mapping = newMapping
-	return err
+	newRel := es
+	newRel.mapping = newMapping
+	return newRel, err
 }
 
 // ExtensionLeafRel is a stub to support extensions with zero inputs.
@@ -1430,10 +1461,11 @@ func (el *ExtensionLeafRel) CopyWithExpressionRewrite(_ RewriteFunc, _ ...Rel) (
 	return el, nil
 }
 
-func (el *ExtensionLeafRel) Remap(mapping ...int32) error {
+func (el *ExtensionLeafRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(el, mapping)
-	el.mapping = newMapping
-	return err
+	newRel := el
+	newRel.mapping = newMapping
+	return newRel, err
 }
 
 // ExtensionMultiRel is a stub to support extensions with multiple inputs.
@@ -1492,10 +1524,11 @@ func (em *ExtensionMultiRel) CopyWithExpressionRewrite(_ RewriteFunc, newInputs 
 	return em.Copy(newInputs...)
 }
 
-func (em *ExtensionMultiRel) Remap(mapping ...int32) error {
+func (em *ExtensionMultiRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(em, mapping)
-	em.mapping = newMapping
-	return err
+	newRel := em
+	newRel.mapping = newMapping
+	return newRel, err
 }
 
 type HashMergeJoinType int8
@@ -1616,10 +1649,11 @@ func (hr *HashJoinRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInp
 	return &join, nil
 }
 
-func (hr *HashJoinRel) Remap(mapping ...int32) error {
+func (hr *HashJoinRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(hr, mapping)
-	hr.mapping = newMapping
-	return err
+	newRel := hr
+	newRel.mapping = newMapping
+	return newRel, err
 }
 
 // MergeJoinRel represents a join done by taking advantage of two sets
@@ -1726,10 +1760,11 @@ func (mr *MergeJoinRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newIn
 	return &merge, nil
 }
 
-func (mr *MergeJoinRel) Remap(mapping ...int32) error {
+func (mr *MergeJoinRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(mr, mapping)
-	mr.mapping = newMapping
-	return err
+	newRel := mr
+	newRel.mapping = newMapping
+	return newRel, err
 }
 
 type WriteOp = proto.WriteRel_WriteOp
@@ -1843,10 +1878,11 @@ func (wr *NamedTableWriteRel) CopyWithExpressionRewrite(_ RewriteFunc, newInputs
 	return wr.Copy(newInputs...)
 }
 
-func (wr *NamedTableWriteRel) Remap(mapping ...int32) error {
+func (wr *NamedTableWriteRel) Remap(mapping ...int32) (Rel, error) {
 	newMapping, err := RemapHelper(wr, mapping)
-	wr.mapping = newMapping
-	return err
+	newRel := wr
+	newRel.mapping = newMapping
+	return newRel, err
 }
 
 var (

--- a/plan/relations.go
+++ b/plan/relations.go
@@ -160,6 +160,9 @@ type MappableRel interface {
 // ChangeMapping implements the core functionality of ChangeMapping for relations.
 // It returns the relation's existing mapping on an error to ease being called.
 func ChangeMapping(r MappableRel, mapping []int32) ([]int32, error) {
+	if len(mapping) == 0 {
+		return []int32{}, nil
+	}
 	nOutput := r.RecordType().FieldCount()
 	oldMapping := r.OutputMapping()
 	newMapping := make([]int32, 0, len(mapping))
@@ -177,7 +180,7 @@ func ChangeMapping(r MappableRel, mapping []int32) ([]int32, error) {
 	return mapping, nil
 }
 
-func (b *baseReadRel) ChangeMapping(mapping []int32) error {
+func (b *baseReadRel) ChangeMapping(mapping ...int32) error {
 	newMapping, err := ChangeMapping(b, mapping)
 	b.mapping = newMapping
 	return err
@@ -620,7 +623,7 @@ func (p *ProjectRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInput
 	return &proj, nil
 }
 
-func (p *ProjectRel) ChangeMapping(mapping []int32) error {
+func (p *ProjectRel) ChangeMapping(mapping ...int32) error {
 	newMapping, err := ChangeMapping(p, mapping)
 	p.mapping = newMapping
 	return err
@@ -778,7 +781,7 @@ func (j *JoinRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInputs .
 	return &join, nil
 }
 
-func (j *JoinRel) ChangeMapping(mapping []int32) error {
+func (j *JoinRel) ChangeMapping(mapping ...int32) error {
 	newMapping, err := ChangeMapping(j, mapping)
 	j.mapping = newMapping
 	return err
@@ -845,7 +848,7 @@ func (c *CrossRel) CopyWithExpressionRewrite(_ RewriteFunc, newInputs ...Rel) (R
 	return c.Copy(newInputs...)
 }
 
-func (c *CrossRel) ChangeMapping(mapping []int32) error {
+func (c *CrossRel) ChangeMapping(mapping ...int32) error {
 	newMapping, err := ChangeMapping(c, mapping)
 	c.mapping = newMapping
 	return err
@@ -917,7 +920,7 @@ func (f *FetchRel) CopyWithExpressionRewrite(_ RewriteFunc, newInputs ...Rel) (R
 	return f.Copy(newInputs...)
 }
 
-func (f *FetchRel) ChangeMapping(mapping []int32) error {
+func (f *FetchRel) ChangeMapping(mapping ...int32) error {
 	newMapping, err := ChangeMapping(f, mapping)
 	f.mapping = newMapping
 	return err
@@ -1071,7 +1074,7 @@ func (ar *AggregateRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newIn
 	return &aggregate, nil
 }
 
-func (ar *AggregateRel) ChangeMapping(mapping []int32) error {
+func (ar *AggregateRel) ChangeMapping(mapping ...int32) error {
 	newMapping, err := ChangeMapping(ar, mapping)
 	ar.mapping = newMapping
 	return err
@@ -1158,7 +1161,7 @@ func (sr *SortRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInputs 
 	return &sort, nil
 }
 
-func (sr *SortRel) ChangeMapping(mapping []int32) error {
+func (sr *SortRel) ChangeMapping(mapping ...int32) error {
 	newMapping, err := ChangeMapping(sr, mapping)
 	sr.mapping = newMapping
 	return err
@@ -1235,7 +1238,7 @@ func (fr *FilterRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInput
 	return &filter, nil
 }
 
-func (fr *FilterRel) ChangeMapping(mapping []int32) error {
+func (fr *FilterRel) ChangeMapping(mapping ...int32) error {
 	newMapping, err := ChangeMapping(fr, mapping)
 	fr.mapping = newMapping
 	return err
@@ -1314,7 +1317,7 @@ func (s *SetRel) CopyWithExpressionRewrite(_ RewriteFunc, newInputs ...Rel) (Rel
 	return s.Copy(newInputs...)
 }
 
-func (s *SetRel) ChangeMapping(mapping []int32) error {
+func (s *SetRel) ChangeMapping(mapping ...int32) error {
 	newMapping, err := ChangeMapping(s, mapping)
 	s.mapping = newMapping
 	return err
@@ -1377,7 +1380,7 @@ func (es *ExtensionSingleRel) CopyWithExpressionRewrite(_ RewriteFunc, newInputs
 	return es.Copy(newInputs...)
 }
 
-func (es *ExtensionSingleRel) ChangeMapping(mapping []int32) error {
+func (es *ExtensionSingleRel) ChangeMapping(mapping ...int32) error {
 	newMapping, err := ChangeMapping(es, mapping)
 	es.mapping = newMapping
 	return err
@@ -1427,7 +1430,7 @@ func (el *ExtensionLeafRel) CopyWithExpressionRewrite(_ RewriteFunc, _ ...Rel) (
 	return el, nil
 }
 
-func (el *ExtensionLeafRel) ChangeMapping(mapping []int32) error {
+func (el *ExtensionLeafRel) ChangeMapping(mapping ...int32) error {
 	newMapping, err := ChangeMapping(el, mapping)
 	el.mapping = newMapping
 	return err
@@ -1489,7 +1492,7 @@ func (em *ExtensionMultiRel) CopyWithExpressionRewrite(_ RewriteFunc, newInputs 
 	return em.Copy(newInputs...)
 }
 
-func (em *ExtensionMultiRel) ChangeMapping(mapping []int32) error {
+func (em *ExtensionMultiRel) ChangeMapping(mapping ...int32) error {
 	newMapping, err := ChangeMapping(em, mapping)
 	em.mapping = newMapping
 	return err
@@ -1613,7 +1616,7 @@ func (hr *HashJoinRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInp
 	return &join, nil
 }
 
-func (hr *HashJoinRel) ChangeMapping(mapping []int32) error {
+func (hr *HashJoinRel) ChangeMapping(mapping ...int32) error {
 	newMapping, err := ChangeMapping(hr, mapping)
 	hr.mapping = newMapping
 	return err
@@ -1723,7 +1726,7 @@ func (mr *MergeJoinRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newIn
 	return &merge, nil
 }
 
-func (mr *MergeJoinRel) ChangeMapping(mapping []int32) error {
+func (mr *MergeJoinRel) ChangeMapping(mapping ...int32) error {
 	newMapping, err := ChangeMapping(mr, mapping)
 	mr.mapping = newMapping
 	return err
@@ -1840,7 +1843,7 @@ func (wr *NamedTableWriteRel) CopyWithExpressionRewrite(_ RewriteFunc, newInputs
 	return wr.Copy(newInputs...)
 }
 
-func (wr *NamedTableWriteRel) ChangeMapping(mapping []int32) error {
+func (wr *NamedTableWriteRel) ChangeMapping(mapping ...int32) error {
 	newMapping, err := ChangeMapping(wr, mapping)
 	wr.mapping = newMapping
 	return err

--- a/plan/relations.go
+++ b/plan/relations.go
@@ -157,9 +157,9 @@ type MappableRel interface {
 	OutputMapping() []int32
 }
 
-// ChangeMapping implements the core functionality of ChangeMapping for relations.
+// RemapHelper implements the core functionality of RemapHelper for relations.
 // It returns the relation's existing mapping on an error to ease being called.
-func ChangeMapping(r MappableRel, mapping []int32) ([]int32, error) {
+func RemapHelper(r MappableRel, mapping []int32) ([]int32, error) {
 	if len(mapping) == 0 {
 		return []int32{}, nil
 	}
@@ -180,8 +180,8 @@ func ChangeMapping(r MappableRel, mapping []int32) ([]int32, error) {
 	return mapping, nil
 }
 
-func (b *baseReadRel) ChangeMapping(mapping ...int32) error {
-	newMapping, err := ChangeMapping(b, mapping)
+func (b *baseReadRel) Remap(mapping ...int32) error {
+	newMapping, err := RemapHelper(b, mapping)
 	b.mapping = newMapping
 	return err
 }
@@ -623,8 +623,8 @@ func (p *ProjectRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInput
 	return &proj, nil
 }
 
-func (p *ProjectRel) ChangeMapping(mapping ...int32) error {
-	newMapping, err := ChangeMapping(p, mapping)
+func (p *ProjectRel) Remap(mapping ...int32) error {
+	newMapping, err := RemapHelper(p, mapping)
 	p.mapping = newMapping
 	return err
 }
@@ -781,8 +781,8 @@ func (j *JoinRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInputs .
 	return &join, nil
 }
 
-func (j *JoinRel) ChangeMapping(mapping ...int32) error {
-	newMapping, err := ChangeMapping(j, mapping)
+func (j *JoinRel) Remap(mapping ...int32) error {
+	newMapping, err := RemapHelper(j, mapping)
 	j.mapping = newMapping
 	return err
 }
@@ -848,8 +848,8 @@ func (c *CrossRel) CopyWithExpressionRewrite(_ RewriteFunc, newInputs ...Rel) (R
 	return c.Copy(newInputs...)
 }
 
-func (c *CrossRel) ChangeMapping(mapping ...int32) error {
-	newMapping, err := ChangeMapping(c, mapping)
+func (c *CrossRel) Remap(mapping ...int32) error {
+	newMapping, err := RemapHelper(c, mapping)
 	c.mapping = newMapping
 	return err
 }
@@ -920,8 +920,8 @@ func (f *FetchRel) CopyWithExpressionRewrite(_ RewriteFunc, newInputs ...Rel) (R
 	return f.Copy(newInputs...)
 }
 
-func (f *FetchRel) ChangeMapping(mapping ...int32) error {
-	newMapping, err := ChangeMapping(f, mapping)
+func (f *FetchRel) Remap(mapping ...int32) error {
+	newMapping, err := RemapHelper(f, mapping)
 	f.mapping = newMapping
 	return err
 }
@@ -1074,8 +1074,8 @@ func (ar *AggregateRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newIn
 	return &aggregate, nil
 }
 
-func (ar *AggregateRel) ChangeMapping(mapping ...int32) error {
-	newMapping, err := ChangeMapping(ar, mapping)
+func (ar *AggregateRel) Remap(mapping ...int32) error {
+	newMapping, err := RemapHelper(ar, mapping)
 	ar.mapping = newMapping
 	return err
 }
@@ -1161,8 +1161,8 @@ func (sr *SortRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInputs 
 	return &sort, nil
 }
 
-func (sr *SortRel) ChangeMapping(mapping ...int32) error {
-	newMapping, err := ChangeMapping(sr, mapping)
+func (sr *SortRel) Remap(mapping ...int32) error {
+	newMapping, err := RemapHelper(sr, mapping)
 	sr.mapping = newMapping
 	return err
 }
@@ -1238,8 +1238,8 @@ func (fr *FilterRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInput
 	return &filter, nil
 }
 
-func (fr *FilterRel) ChangeMapping(mapping ...int32) error {
-	newMapping, err := ChangeMapping(fr, mapping)
+func (fr *FilterRel) Remap(mapping ...int32) error {
+	newMapping, err := RemapHelper(fr, mapping)
 	fr.mapping = newMapping
 	return err
 }
@@ -1317,8 +1317,8 @@ func (s *SetRel) CopyWithExpressionRewrite(_ RewriteFunc, newInputs ...Rel) (Rel
 	return s.Copy(newInputs...)
 }
 
-func (s *SetRel) ChangeMapping(mapping ...int32) error {
-	newMapping, err := ChangeMapping(s, mapping)
+func (s *SetRel) Remap(mapping ...int32) error {
+	newMapping, err := RemapHelper(s, mapping)
 	s.mapping = newMapping
 	return err
 }
@@ -1380,8 +1380,8 @@ func (es *ExtensionSingleRel) CopyWithExpressionRewrite(_ RewriteFunc, newInputs
 	return es.Copy(newInputs...)
 }
 
-func (es *ExtensionSingleRel) ChangeMapping(mapping ...int32) error {
-	newMapping, err := ChangeMapping(es, mapping)
+func (es *ExtensionSingleRel) Remap(mapping ...int32) error {
+	newMapping, err := RemapHelper(es, mapping)
 	es.mapping = newMapping
 	return err
 }
@@ -1430,8 +1430,8 @@ func (el *ExtensionLeafRel) CopyWithExpressionRewrite(_ RewriteFunc, _ ...Rel) (
 	return el, nil
 }
 
-func (el *ExtensionLeafRel) ChangeMapping(mapping ...int32) error {
-	newMapping, err := ChangeMapping(el, mapping)
+func (el *ExtensionLeafRel) Remap(mapping ...int32) error {
+	newMapping, err := RemapHelper(el, mapping)
 	el.mapping = newMapping
 	return err
 }
@@ -1492,8 +1492,8 @@ func (em *ExtensionMultiRel) CopyWithExpressionRewrite(_ RewriteFunc, newInputs 
 	return em.Copy(newInputs...)
 }
 
-func (em *ExtensionMultiRel) ChangeMapping(mapping ...int32) error {
-	newMapping, err := ChangeMapping(em, mapping)
+func (em *ExtensionMultiRel) Remap(mapping ...int32) error {
+	newMapping, err := RemapHelper(em, mapping)
 	em.mapping = newMapping
 	return err
 }
@@ -1616,8 +1616,8 @@ func (hr *HashJoinRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInp
 	return &join, nil
 }
 
-func (hr *HashJoinRel) ChangeMapping(mapping ...int32) error {
-	newMapping, err := ChangeMapping(hr, mapping)
+func (hr *HashJoinRel) Remap(mapping ...int32) error {
+	newMapping, err := RemapHelper(hr, mapping)
 	hr.mapping = newMapping
 	return err
 }
@@ -1726,8 +1726,8 @@ func (mr *MergeJoinRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newIn
 	return &merge, nil
 }
 
-func (mr *MergeJoinRel) ChangeMapping(mapping ...int32) error {
-	newMapping, err := ChangeMapping(mr, mapping)
+func (mr *MergeJoinRel) Remap(mapping ...int32) error {
+	newMapping, err := RemapHelper(mr, mapping)
 	mr.mapping = newMapping
 	return err
 }
@@ -1843,8 +1843,8 @@ func (wr *NamedTableWriteRel) CopyWithExpressionRewrite(_ RewriteFunc, newInputs
 	return wr.Copy(newInputs...)
 }
 
-func (wr *NamedTableWriteRel) ChangeMapping(mapping ...int32) error {
-	newMapping, err := ChangeMapping(wr, mapping)
+func (wr *NamedTableWriteRel) Remap(mapping ...int32) error {
+	newMapping, err := RemapHelper(wr, mapping)
 	wr.mapping = newMapping
 	return err
 }

--- a/plan/relations_test.go
+++ b/plan/relations_test.go
@@ -382,7 +382,7 @@ func (f *fakeRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInputs .
 	panic("unused")
 }
 
-func (f *fakeRel) ChangeMapping(mapping ...int32) error {
+func (f *fakeRel) Remap(mapping ...int32) error {
 	panic("unused")
 }
 
@@ -395,7 +395,7 @@ func TestProjectRecordType(t *testing.T) {
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
 
-	err := rel.ChangeMapping(0)
+	err := rel.Remap(0)
 	assert.NoError(t, err)
 	expected = *types.NewRecordTypeFromTypes([]types.Type{&types.Int64Type{}})
 	result = rel.RecordType()
@@ -411,7 +411,7 @@ func TestExtensionSingleRecordType(t *testing.T) {
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
 
-	err := rel.ChangeMapping(0)
+	err := rel.Remap(0)
 	assert.NoError(t, err)
 	expected = *types.NewRecordTypeFromTypes([]types.Type{&types.Int64Type{}})
 	result = rel.RecordType()
@@ -425,7 +425,7 @@ func TestExtensionLeafRecordType(t *testing.T) {
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
 
-	err := rel.ChangeMapping(0)
+	err := rel.Remap(0)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 }
 
@@ -436,7 +436,7 @@ func TestExtensionMultiRecordType(t *testing.T) {
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
 
-	err := rel.ChangeMapping(0)
+	err := rel.Remap(0)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 }
 
@@ -452,7 +452,7 @@ func TestHashJoinRecordType(t *testing.T) {
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
 
-	err := rel.ChangeMapping(0)
+	err := rel.Remap(0)
 	assert.NoError(t, err)
 	expected = *types.NewRecordTypeFromTypes([]types.Type{&types.Int64Type{}})
 	result = rel.RecordType()
@@ -471,7 +471,7 @@ func TestMergeJoinRecordType(t *testing.T) {
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
 
-	err := rel.ChangeMapping(0)
+	err := rel.Remap(0)
 	assert.NoError(t, err)
 	expected = *types.NewRecordTypeFromTypes(
 		[]types.Type{&types.Int64Type{}})
@@ -489,6 +489,6 @@ func TestNamedTableWriteRecordType(t *testing.T) {
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
 
-	err := rel.ChangeMapping(0)
+	err := rel.Remap(0)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 }

--- a/plan/relations_test.go
+++ b/plan/relations_test.go
@@ -422,6 +422,30 @@ func TestExtensionSingleRecordType(t *testing.T) {
 	assert.Equal(t, expected, result)
 }
 
+func TestExtensionLeafRecordType(t *testing.T) {
+	var rel ExtensionLeafRel
+
+	rel.ClearMapping()
+	expected := *types.NewRecordTypeFromTypes(nil)
+	result := rel.RecordType()
+	assert.Equal(t, expected, result)
+
+	err := rel.ChangeMapping([]int32{0})
+	assert.ErrorContains(t, err, "output mapping index out of range")
+}
+
+func TestExtensionMultiRecordType(t *testing.T) {
+	var rel ExtensionMultiRel
+
+	rel.ClearMapping()
+	expected := *types.NewRecordTypeFromTypes(nil)
+	result := rel.RecordType()
+	assert.Equal(t, expected, result)
+
+	err := rel.ChangeMapping([]int32{0})
+	assert.ErrorContains(t, err, "output mapping index out of range")
+}
+
 func TestHashJoinRecordType(t *testing.T) {
 	var rel HashJoinRel
 	rel.left = &fakeRel{outputType: *types.NewRecordTypeFromTypes(

--- a/plan/relations_test.go
+++ b/plan/relations_test.go
@@ -486,3 +486,18 @@ func TestMergeJoinRecordType(t *testing.T) {
 	result = rel.RecordType()
 	assert.Equal(t, expected, result)
 }
+
+func TestNamedTableWriteRecordType(t *testing.T) {
+	var rel NamedTableWriteRel
+	rel.input = &fakeRel{outputType: *types.NewRecordTypeFromTypes(
+		[]types.Type{&types.Int64Type{}, &types.StringType{}})}
+	rel.outputMode = proto.WriteRel_OUTPUT_MODE_MODIFIED_RECORDS
+
+	rel.ClearMapping()
+	expected := *types.NewRecordTypeFromTypes(nil)
+	result := rel.RecordType()
+	assert.Equal(t, expected, result)
+
+	err := rel.ChangeMapping([]int32{0})
+	assert.ErrorContains(t, err, "output mapping index out of range")
+}

--- a/plan/relations_test.go
+++ b/plan/relations_test.go
@@ -382,6 +382,12 @@ func (f *fakeRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInputs .
 	panic("unused")
 }
 
+func (f *fakeRel) ChangeMapping(mapping []int32) error {
+	newMapping, err := ChangeMapping(f, mapping)
+	f.mapping = newMapping
+	return err
+}
+
 func TestProjectRecordType(t *testing.T) {
 	var rel ProjectRel
 	rel.input = &fakeRel{outputType: *types.NewRecordTypeFromTypes(

--- a/plan/relations_test.go
+++ b/plan/relations_test.go
@@ -383,9 +383,7 @@ func (f *fakeRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInputs .
 }
 
 func (f *fakeRel) ChangeMapping(mapping []int32) error {
-	newMapping, err := ChangeMapping(f, mapping)
-	f.mapping = newMapping
-	return err
+	panic("unused")
 }
 
 func TestProjectRecordType(t *testing.T) {

--- a/plan/relations_test.go
+++ b/plan/relations_test.go
@@ -391,7 +391,6 @@ func TestProjectRecordType(t *testing.T) {
 	rel.input = &fakeRel{outputType: *types.NewRecordTypeFromTypes(
 		[]types.Type{&types.Int64Type{}, &types.Int64Type{}})}
 
-	rel.ClearMapping()
 	expected := *types.NewRecordTypeFromTypes([]types.Type{&types.Int64Type{}, &types.Int64Type{}})
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
@@ -408,7 +407,6 @@ func TestExtensionSingleRecordType(t *testing.T) {
 	rel.input = &fakeRel{outputType: *types.NewRecordTypeFromTypes(
 		[]types.Type{&types.Int64Type{}, &types.Int64Type{}})}
 
-	rel.ClearMapping()
 	expected := *types.NewRecordTypeFromTypes([]types.Type{&types.Int64Type{}, &types.Int64Type{}})
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
@@ -423,7 +421,6 @@ func TestExtensionSingleRecordType(t *testing.T) {
 func TestExtensionLeafRecordType(t *testing.T) {
 	var rel ExtensionLeafRel
 
-	rel.ClearMapping()
 	expected := *types.NewRecordTypeFromTypes(nil)
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
@@ -435,7 +432,6 @@ func TestExtensionLeafRecordType(t *testing.T) {
 func TestExtensionMultiRecordType(t *testing.T) {
 	var rel ExtensionMultiRel
 
-	rel.ClearMapping()
 	expected := *types.NewRecordTypeFromTypes(nil)
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
@@ -451,7 +447,6 @@ func TestHashJoinRecordType(t *testing.T) {
 	rel.right = &fakeRel{outputType: *types.NewRecordTypeFromTypes(
 		[]types.Type{&types.StringType{}, &types.StringType{}})}
 
-	rel.ClearMapping()
 	expected := *types.NewRecordTypeFromTypes(
 		[]types.Type{&types.Int64Type{}, &types.Int64Type{}, &types.StringType{}, &types.StringType{}})
 	result := rel.RecordType()
@@ -471,7 +466,6 @@ func TestMergeJoinRecordType(t *testing.T) {
 	rel.right = &fakeRel{outputType: *types.NewRecordTypeFromTypes(
 		[]types.Type{&types.StringType{}, &types.StringType{}})}
 
-	rel.ClearMapping()
 	expected := *types.NewRecordTypeFromTypes(
 		[]types.Type{&types.Int64Type{}, &types.Int64Type{}, &types.StringType{}, &types.StringType{}})
 	result := rel.RecordType()
@@ -491,7 +485,6 @@ func TestNamedTableWriteRecordType(t *testing.T) {
 		[]types.Type{&types.Int64Type{}, &types.StringType{}})}
 	rel.outputMode = proto.WriteRel_OUTPUT_MODE_MODIFIED_RECORDS
 
-	rel.ClearMapping()
 	expected := *types.NewRecordTypeFromTypes(nil)
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)

--- a/plan/relations_test.go
+++ b/plan/relations_test.go
@@ -382,7 +382,7 @@ func (f *fakeRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInputs .
 	panic("unused")
 }
 
-func (f *fakeRel) Remap(mapping ...int32) error {
+func (f *fakeRel) Remap(mapping ...int32) (Rel, error) {
 	panic("unused")
 }
 
@@ -395,10 +395,10 @@ func TestProjectRecordType(t *testing.T) {
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
 
-	err := rel.Remap(0)
+	newRel, err := rel.Remap(0)
 	assert.NoError(t, err)
 	expected = *types.NewRecordTypeFromTypes([]types.Type{&types.Int64Type{}})
-	result = rel.RecordType()
+	result = newRel.RecordType()
 	assert.Equal(t, expected, result)
 }
 
@@ -411,10 +411,10 @@ func TestExtensionSingleRecordType(t *testing.T) {
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
 
-	err := rel.Remap(0)
+	newRel, err := rel.Remap(0)
 	assert.NoError(t, err)
 	expected = *types.NewRecordTypeFromTypes([]types.Type{&types.Int64Type{}})
-	result = rel.RecordType()
+	result = newRel.RecordType()
 	assert.Equal(t, expected, result)
 }
 
@@ -425,7 +425,7 @@ func TestExtensionLeafRecordType(t *testing.T) {
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
 
-	err := rel.Remap(0)
+	_, err := rel.Remap(0)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 }
 
@@ -436,7 +436,7 @@ func TestExtensionMultiRecordType(t *testing.T) {
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
 
-	err := rel.Remap(0)
+	_, err := rel.Remap(0)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 }
 
@@ -452,10 +452,10 @@ func TestHashJoinRecordType(t *testing.T) {
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
 
-	err := rel.Remap(0)
+	newRel, err := rel.Remap(0)
 	assert.NoError(t, err)
 	expected = *types.NewRecordTypeFromTypes([]types.Type{&types.Int64Type{}})
-	result = rel.RecordType()
+	result = newRel.RecordType()
 	assert.Equal(t, expected, result)
 }
 
@@ -471,11 +471,11 @@ func TestMergeJoinRecordType(t *testing.T) {
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
 
-	err := rel.Remap(0)
+	newRel, err := rel.Remap(0)
 	assert.NoError(t, err)
 	expected = *types.NewRecordTypeFromTypes(
 		[]types.Type{&types.Int64Type{}})
-	result = rel.RecordType()
+	result = newRel.RecordType()
 	assert.Equal(t, expected, result)
 }
 
@@ -489,6 +489,6 @@ func TestNamedTableWriteRecordType(t *testing.T) {
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
 
-	err := rel.Remap(0)
+	_, err := rel.Remap(0)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 }

--- a/plan/relations_test.go
+++ b/plan/relations_test.go
@@ -393,12 +393,13 @@ func TestProjectRecordType(t *testing.T) {
 	rel.input = &fakeRel{outputType: *types.NewRecordTypeFromTypes(
 		[]types.Type{&types.Int64Type{}, &types.Int64Type{}})}
 
-	rel.mapping = nil
+	rel.ClearMapping()
 	expected := *types.NewRecordTypeFromTypes([]types.Type{&types.Int64Type{}, &types.Int64Type{}})
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
 
-	rel.mapping = []int32{0}
+	err := rel.ChangeMapping([]int32{0})
+	assert.NoError(t, err)
 	expected = *types.NewRecordTypeFromTypes([]types.Type{&types.Int64Type{}})
 	result = rel.RecordType()
 	assert.Equal(t, expected, result)
@@ -409,12 +410,13 @@ func TestExtensionSingleRecordType(t *testing.T) {
 	rel.input = &fakeRel{outputType: *types.NewRecordTypeFromTypes(
 		[]types.Type{&types.Int64Type{}, &types.Int64Type{}})}
 
-	rel.mapping = nil
+	rel.ClearMapping()
 	expected := *types.NewRecordTypeFromTypes([]types.Type{&types.Int64Type{}, &types.Int64Type{}})
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
 
-	rel.mapping = []int32{0}
+	err := rel.ChangeMapping([]int32{0})
+	assert.NoError(t, err)
 	expected = *types.NewRecordTypeFromTypes([]types.Type{&types.Int64Type{}})
 	result = rel.RecordType()
 	assert.Equal(t, expected, result)
@@ -427,13 +429,14 @@ func TestHashJoinRecordType(t *testing.T) {
 	rel.right = &fakeRel{outputType: *types.NewRecordTypeFromTypes(
 		[]types.Type{&types.StringType{}, &types.StringType{}})}
 
-	rel.mapping = nil
+	rel.ClearMapping()
 	expected := *types.NewRecordTypeFromTypes(
 		[]types.Type{&types.Int64Type{}, &types.Int64Type{}, &types.StringType{}, &types.StringType{}})
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
 
-	rel.mapping = []int32{0}
+	err := rel.ChangeMapping([]int32{0})
+	assert.NoError(t, err)
 	expected = *types.NewRecordTypeFromTypes([]types.Type{&types.Int64Type{}})
 	result = rel.RecordType()
 	assert.Equal(t, expected, result)
@@ -446,13 +449,14 @@ func TestMergeJoinRecordType(t *testing.T) {
 	rel.right = &fakeRel{outputType: *types.NewRecordTypeFromTypes(
 		[]types.Type{&types.StringType{}, &types.StringType{}})}
 
-	rel.mapping = nil
+	rel.ClearMapping()
 	expected := *types.NewRecordTypeFromTypes(
 		[]types.Type{&types.Int64Type{}, &types.Int64Type{}, &types.StringType{}, &types.StringType{}})
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
 
-	rel.mapping = []int32{0}
+	err := rel.ChangeMapping([]int32{0})
+	assert.NoError(t, err)
 	expected = *types.NewRecordTypeFromTypes(
 		[]types.Type{&types.Int64Type{}})
 	result = rel.RecordType()

--- a/plan/relations_test.go
+++ b/plan/relations_test.go
@@ -382,7 +382,7 @@ func (f *fakeRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInputs .
 	panic("unused")
 }
 
-func (f *fakeRel) ChangeMapping(mapping []int32) error {
+func (f *fakeRel) ChangeMapping(mapping ...int32) error {
 	panic("unused")
 }
 
@@ -396,7 +396,7 @@ func TestProjectRecordType(t *testing.T) {
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
 
-	err := rel.ChangeMapping([]int32{0})
+	err := rel.ChangeMapping(0)
 	assert.NoError(t, err)
 	expected = *types.NewRecordTypeFromTypes([]types.Type{&types.Int64Type{}})
 	result = rel.RecordType()
@@ -413,7 +413,7 @@ func TestExtensionSingleRecordType(t *testing.T) {
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
 
-	err := rel.ChangeMapping([]int32{0})
+	err := rel.ChangeMapping(0)
 	assert.NoError(t, err)
 	expected = *types.NewRecordTypeFromTypes([]types.Type{&types.Int64Type{}})
 	result = rel.RecordType()
@@ -428,7 +428,7 @@ func TestExtensionLeafRecordType(t *testing.T) {
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
 
-	err := rel.ChangeMapping([]int32{0})
+	err := rel.ChangeMapping(0)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 }
 
@@ -440,7 +440,7 @@ func TestExtensionMultiRecordType(t *testing.T) {
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
 
-	err := rel.ChangeMapping([]int32{0})
+	err := rel.ChangeMapping(0)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 }
 
@@ -457,7 +457,7 @@ func TestHashJoinRecordType(t *testing.T) {
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
 
-	err := rel.ChangeMapping([]int32{0})
+	err := rel.ChangeMapping(0)
 	assert.NoError(t, err)
 	expected = *types.NewRecordTypeFromTypes([]types.Type{&types.Int64Type{}})
 	result = rel.RecordType()
@@ -477,7 +477,7 @@ func TestMergeJoinRecordType(t *testing.T) {
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
 
-	err := rel.ChangeMapping([]int32{0})
+	err := rel.ChangeMapping(0)
 	assert.NoError(t, err)
 	expected = *types.NewRecordTypeFromTypes(
 		[]types.Type{&types.Int64Type{}})
@@ -496,6 +496,6 @@ func TestNamedTableWriteRecordType(t *testing.T) {
 	result := rel.RecordType()
 	assert.Equal(t, expected, result)
 
-	err := rel.ChangeMapping([]int32{0})
+	err := rel.ChangeMapping(0)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 }


### PR DESCRIPTION
Remap() is an alternative to the current Remap variants currently found on the Builder interface.  It preserves the existing behavior including checking the proposed mapping for validity.  It also modifies the relation instead of returning a copy.  All of the existing Remap function variants have been marked as deprecated in favor of Remap.

