### PR TITLE
feat:  Add expression wrapper to ExprBuilder

### DIFF
--- a/expr/builder.go
+++ b/expr/builder.go
@@ -42,8 +42,8 @@ type ExprBuilder struct {
 
 // Literal returns a wrapped literal that can be passed as an argument
 // to any of the other expression builders such as ScalarFunc.Args.
-func (e *ExprBuilder) Literal(l Literal) literalWrapper {
-	return literalWrapper{l, nil}
+func (e *ExprBuilder) Literal(l Literal) exprWrapper {
+	return exprWrapper{l, nil}
 }
 
 // Expression returns a wrapped expression that can be passed as an argument
@@ -52,18 +52,11 @@ func (e *ExprBuilder) Expression(expr Expression) exprWrapper {
 	return exprWrapper{expr, nil}
 }
 
-// Wrap is like Literal but allows propagating an error (such as
-// when calling expr.NewLiteral) that will bubble up when attempting
+// Wrap is like Literal or Expression but allows propagating an error
+// (such as when calling expr.NewLiteral) that will bubble up when attempting
 // to build an expression so it doesn't get swallowed or force a panic.
-func (e *ExprBuilder) Wrap(l Literal, err error) literalWrapper {
-	return literalWrapper{l, err}
-}
-
-// WrapExpression is like Expression but allows propagating an error (such as
-// when calling expr.NewLiteral) that will bubble up when attempting
-// to build an expression so it doesn't get swallowed or force a panic.
-func (e *ExprBuilder) WrapExpression(expr Expression, err error) exprWrapper {
-	return exprWrapper{expr, err}
+func (e *ExprBuilder) Wrap(l Literal, err error) exprWrapper {
+	return exprWrapper{l, err}
 }
 
 // Enum wraps a string representing an Enum argument to a function being
@@ -154,14 +147,6 @@ func (e *ExprBuilder) Cast(from Builder, to types.Type) *castBuilder {
 		toType: to, input: from,
 	}
 }
-
-type literalWrapper struct {
-	wrapped Literal
-	err     error
-}
-
-func (l literalWrapper) BuildFuncArg() (types.FuncArg, error) { return l.wrapped, l.err }
-func (l literalWrapper) BuildExpr() (Expression, error)       { return l.wrapped, l.err }
 
 type exprWrapper struct {
 	expression Expression

--- a/expr/builder.go
+++ b/expr/builder.go
@@ -46,11 +46,24 @@ func (e *ExprBuilder) Literal(l Literal) literalWrapper {
 	return literalWrapper{l, nil}
 }
 
+// Expression returns a wrapped expression that can be passed as an argument
+// to any of the other expression builders such as ScalarFunc.Args.
+func (e *ExprBuilder) Expression(expr Expression) exprWrapper {
+	return exprWrapper{expr, nil}
+}
+
 // Wrap is like Literal but allows propagating an error (such as
 // when calling expr.NewLiteral) that will bubble up when attempting
 // to build an expression so it doesn't get swallowed or force a panic.
 func (e *ExprBuilder) Wrap(l Literal, err error) literalWrapper {
 	return literalWrapper{l, err}
+}
+
+// WrapExpression is like Expression but allows propagating an error (such as
+// when calling expr.NewLiteral) that will bubble up when attempting
+// to build an expression so it doesn't get swallowed or force a panic.
+func (e *ExprBuilder) WrapExpression(expr Expression, err error) exprWrapper {
+	return exprWrapper{expr, err}
 }
 
 // Enum wraps a string representing an Enum argument to a function being
@@ -149,6 +162,14 @@ type literalWrapper struct {
 
 func (l literalWrapper) BuildFuncArg() (types.FuncArg, error) { return l.wrapped, l.err }
 func (l literalWrapper) BuildExpr() (Expression, error)       { return l.wrapped, l.err }
+
+type exprWrapper struct {
+	expression Expression
+	err        error
+}
+
+func (e exprWrapper) BuildFuncArg() (types.FuncArg, error) { return e.expression, e.err }
+func (e exprWrapper) BuildExpr() (Expression, error)       { return e.expression, e.err }
 
 type enumWrapper string
 

--- a/expr/builder_test.go
+++ b/expr/builder_test.go
@@ -17,6 +17,7 @@ func TestExprBuilder(t *testing.T) {
 		Reg:        expr.NewEmptyExtensionRegistry(&extensions.DefaultCollection),
 		BaseSchema: &boringSchema.Struct,
 	}
+	precomputedExpression, _ := expr.NewLiteral(int32(3), false)
 
 	tests := []struct {
 		name     string
@@ -47,6 +48,12 @@ func TestExprBuilder(t *testing.T) {
 				b.Cast(b.RootRef(expr.NewStructFieldRef(6)), &types.Int32Type{}).
 					FailBehavior(types.BehaviorThrowException),
 			), ""},
+		{"expression", "subtract(.field(3) => i32, i32(3)) => i32",
+			b.ScalarFunc(subID).Args(b.RootRef(expr.NewStructFieldRef(3)),
+				b.Expression(precomputedExpression)), ""},
+		{"wrap expression", "subtract(.field(3) => i32, i32(3)) => i32",
+			b.ScalarFunc(subID).Args(b.RootRef(expr.NewStructFieldRef(3)),
+				b.WrapExpression(expr.NewLiteral(int32(3), false))), ""},
 		{"window func", "",
 			b.WindowFunc(rankID), "invalid expression: non-decomposable window or agg function '{https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml rank}' must use InitialToResult phase"},
 		{"window func", "rank(; phase: AGGREGATION_PHASE_INITIAL_TO_RESULT, invocation: AGGREGATION_INVOCATION_UNSPECIFIED) => i64?",


### PR DESCRIPTION
This will allow previously calcuated Expression objects to be used as function arguments.