### PR TITLE
feat: change ArgumentList name to FuncParameterList

### DIFF
--- a/expr/functions.go
+++ b/expr/functions.go
@@ -181,7 +181,7 @@ func resolveVariant[T variant](id extensions.ID, reg ExtensionRegistry, getter f
 	for _, arg := range args {
 		switch a := arg.(type) {
 		case types.Enum:
-			argTypes = append(argTypes, nil)
+			argTypes = append(argTypes, types.CommonEnumType)
 		case Expression:
 			argTypes = append(argTypes, a.GetType())
 		}
@@ -192,9 +192,9 @@ func resolveVariant[T variant](id extensions.ID, reg ExtensionRegistry, getter f
 		if strings.IndexByte(id.Name, ':') == -1 {
 			sigs := make([]string, len(argTypes))
 			for i, t := range argTypes {
-				if t == nil {
+				if t == types.CommonEnumType {
 					// enum value
-					sigs[i] = "req"
+					sigs[i] = extensions.EnumTypeString
 				} else if ud, ok := t.(*types.UserDefinedType); ok {
 					id, found := reg.DecodeType(ud.TypeReference)
 					if !found {

--- a/extensions/simple_extension.go
+++ b/extensions/simple_extension.go
@@ -47,6 +47,7 @@ type TypeVariationFunctions string
 const (
 	TypeVariationInheritsFuncs TypeVariationFunctions = "INHERITS"
 	TypeVariationSeparateFuncs TypeVariationFunctions = "SEPARATE"
+	EnumTypeString                                    = "req" // TODO change this to "enum"
 )
 
 type TypeVariation struct {
@@ -68,7 +69,7 @@ type EnumArg struct {
 }
 
 func (EnumArg) toTypeString() string {
-	return "req"
+	return EnumTypeString
 }
 
 func (v EnumArg) GetTypeExpression() types.FuncDefArgType {

--- a/extensions/simple_extension.go
+++ b/extensions/simple_extension.go
@@ -59,6 +59,7 @@ type TypeVariation struct {
 
 type FuncParameter interface {
 	toTypeString() string
+	argumentMarker() // unexported marker method
 	GetTypeExpression() types.FuncDefArgType
 }
 
@@ -71,6 +72,8 @@ type EnumArg struct {
 func (EnumArg) toTypeString() string {
 	return EnumTypeString
 }
+
+func (v EnumArg) argumentMarker() {}
 
 func (v EnumArg) GetTypeExpression() types.FuncDefArgType {
 	return &types.EnumType{Name: v.Name, Options: v.Options}
@@ -87,6 +90,8 @@ func (v ValueArg) toTypeString() string {
 	return v.Value.ValueType.ShortString()
 }
 
+func (v ValueArg) argumentMarker() {}
+
 func (v ValueArg) GetTypeExpression() types.FuncDefArgType {
 	return v.Value.ValueType
 }
@@ -98,6 +103,8 @@ type TypeArg struct {
 }
 
 func (TypeArg) toTypeString() string { return "type" }
+
+func (v TypeArg) argumentMarker() {}
 
 func (v TypeArg) GetTypeExpression() types.FuncDefArgType {
 	return v.Type.ValueType

--- a/extensions/simple_extension_test.go
+++ b/extensions/simple_extension_test.go
@@ -68,7 +68,7 @@ scalar_functions:
 	assert.IsType(t, extensions.ValueArg{}, f.ScalarFunctions[0].Impls[0].Args[0])
 	arg1 := f.ScalarFunctions[0].Impls[0].Args[0].(extensions.ValueArg)
 	assert.Equal(t, "u!customtype1", arg1.Value.ValueType.String())
-	typ, err := arg1.Value.ValueType.ReturnType()
+	typ, err := arg1.Value.ValueType.ReturnType(nil, nil)
 	assert.NoError(t, err)
 	assert.IsType(t, &types.UserDefinedType{}, typ)
 	assert.Equal(t, proto.Type_NULLABILITY_REQUIRED, typ.GetNullability(), "expected NULLABILITY_REQUIRED")
@@ -77,7 +77,7 @@ scalar_functions:
 	assert.IsType(t, extensions.ValueArg{}, f.ScalarFunctions[1].Impls[0].Args[0])
 	ret := f.ScalarFunctions[1].Impls[0].Return
 	assert.Equal(t, "u!customtype2?", ret.ValueType.String())
-	typ, err = ret.ValueType.ReturnType()
+	typ, err = ret.ValueType.ReturnType(nil, nil)
 	assert.NoError(t, err)
 	assert.IsType(t, &types.UserDefinedType{}, typ)
 	assert.Equal(t, proto.Type_NULLABILITY_NULLABLE, typ.GetNullability(), "expected NULLABILITY_NULLABLE")

--- a/extensions/variants.go
+++ b/extensions/variants.go
@@ -16,7 +16,7 @@ type FunctionVariant interface {
 	Name() string
 	CompoundName() string
 	Description() string
-	Args() ArgumentList
+	Args() FuncParameterList
 	Options() map[string]Option
 	URI() string
 	ResolveType(argTypes []types.Type) (types.Type, error)
@@ -40,9 +40,9 @@ type FunctionVariant interface {
 	MaxArgumentCount() int
 }
 
-func validateType(arg Argument, actual types.Type, idx int, nullHandling NullabilityHandling) (bool, error) {
+func validateType(funcParameter FuncParameter, actual types.Type, idx int, nullHandling NullabilityHandling) (bool, error) {
 	allNonNull := true
-	switch p := arg.(type) {
+	switch p := funcParameter.(type) {
 	case EnumArg:
 		if actual != nil {
 			return allNonNull, fmt.Errorf("%w: arg #%d (%s) should be an enum",
@@ -72,33 +72,38 @@ func validateType(arg Argument, actual types.Type, idx int, nullHandling Nullabi
 	return allNonNull, nil
 }
 
-func EvaluateTypeExpression(nullHandling NullabilityHandling, expr types.FuncDefArgType, paramTypeList ArgumentList, variadic *VariadicBehavior, actualTypes []types.Type) (types.Type, error) {
-	if len(paramTypeList) != len(actualTypes) {
+// EvaluateTypeExpression evaluates the function return type given the input argumentTypes
+//
+//	funcParameters: the function parameters as defined in the function signature in the extension
+//	argumentTypes: the actual argument types provided to the function
+func EvaluateTypeExpression(nullHandling NullabilityHandling, returnTypeExpr types.FuncDefArgType,
+	funcParameters FuncParameterList, variadic *VariadicBehavior, argumentTypes []types.Type) (types.Type, error) {
+	if len(funcParameters) != len(argumentTypes) {
 		if variadic == nil {
 			return nil, fmt.Errorf("%w: mismatch in number of arguments provided. got %d, expected %d",
-				substraitgo.ErrInvalidExpr, len(actualTypes), len(paramTypeList))
+				substraitgo.ErrInvalidExpr, len(argumentTypes), len(funcParameters))
 		}
 
-		if !variadic.IsValidArgumentCount(len(actualTypes) - len(paramTypeList) - 1) {
+		if !variadic.IsValidArgumentCount(len(argumentTypes) - len(funcParameters) - 1) {
 			return nil, fmt.Errorf("%w: mismatch in number of arguments provided, invalid number of variadic params. got %d total",
-				substraitgo.ErrInvalidExpr, len(actualTypes))
+				substraitgo.ErrInvalidExpr, len(argumentTypes))
 		}
 	}
 
 	allNonNull := true
-	for i, p := range paramTypeList {
-		nonNull, err := validateType(p, actualTypes[i], i, nullHandling)
+	for i, p := range funcParameters {
+		nonNull, err := validateType(p, argumentTypes[i], i, nullHandling)
 		if err != nil {
 			return nil, err
 		}
 		allNonNull = allNonNull && nonNull
 	}
 
-	// validate varidic argument consistency
-	if variadic != nil && len(actualTypes) > len(paramTypeList) && variadic.ParameterConsistency == ConsistentParams {
-		nparams := len(paramTypeList)
-		lastParam := paramTypeList[nparams-1]
-		for i, actual := range actualTypes[nparams:] {
+	// validate variadic argument consistency
+	if variadic != nil && len(argumentTypes) > len(funcParameters) && variadic.ParameterConsistency == ConsistentParams {
+		nparams := len(funcParameters)
+		lastParam := funcParameters[nparams-1]
+		for i, actual := range argumentTypes[nparams:] {
 			nonNull, err := validateType(lastParam, actual, nparams+i, nullHandling)
 			if err != nil {
 				return nil, err
@@ -107,7 +112,11 @@ func EvaluateTypeExpression(nullHandling NullabilityHandling, expr types.FuncDef
 		}
 	}
 
-	outType, err := expr.ReturnType()
+	funcParameterTypes := make([]types.FuncDefArgType, len(funcParameters))
+	for i, p := range funcParameters {
+		funcParameterTypes[i] = p.GetTypeExpression()
+	}
+	outType, err := returnTypeExpr.ReturnType(funcParameterTypes, argumentTypes)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +131,7 @@ func EvaluateTypeExpression(nullHandling NullabilityHandling, expr types.FuncDef
 	return outType, nil
 }
 
-func matchArguments(nullability NullabilityHandling, paramTypeList ArgumentList, variadicBehavior *VariadicBehavior, actualTypes []types.Type) (bool, error) {
+func matchArguments(nullability NullabilityHandling, paramTypeList FuncParameterList, variadicBehavior *VariadicBehavior, actualTypes []types.Type) (bool, error) {
 	if variadicBehavior == nil && len(actualTypes) != len(paramTypeList) {
 		return false, nil
 	} else if variadicBehavior != nil && !validateVariadicBehaviorForMatch(variadicBehavior, actualTypes) {
@@ -146,7 +155,7 @@ func matchArguments(nullability NullabilityHandling, paramTypeList ArgumentList,
 	return true, nil
 }
 
-func matchArgumentAt(actualType types.Type, argPos int, nullability NullabilityHandling, paramTypeList ArgumentList, variadicBehavior *VariadicBehavior) (bool, error) {
+func matchArgumentAt(actualType types.Type, argPos int, nullability NullabilityHandling, paramTypeList FuncParameterList, variadicBehavior *VariadicBehavior) (bool, error) {
 	if argPos < 0 {
 		return false, fmt.Errorf("non-zero argument position")
 	}
@@ -204,7 +213,7 @@ func validateVariadicBehaviorForMatch(variadicBehavior *VariadicBehavior, actual
 	return true
 }
 
-func getFuncDefFromArgList(paramTypeList ArgumentList) ([]types.FuncDefArgType, error) {
+func getFuncDefFromArgList(paramTypeList FuncParameterList) ([]types.FuncDefArgType, error) {
 	var out []types.FuncDefArgType
 	for argPos, param := range paramTypeList {
 		switch paramType := param.(type) {
@@ -221,7 +230,7 @@ func getFuncDefFromArgList(paramTypeList ArgumentList) ([]types.FuncDefArgType, 
 	return out, nil
 }
 
-func parseFuncName(compoundName string) (name string, args ArgumentList) {
+func parseFuncName(compoundName string) (name string, args FuncParameterList) {
 	name, argsStr, _ := strings.Cut(compoundName, ":")
 	if len(argsStr) == 0 {
 		return name, nil
@@ -239,14 +248,14 @@ func parseFuncName(compoundName string) (name string, args ArgumentList) {
 	return name, args
 }
 
-func minArgumentCount(paramTypeList ArgumentList, variadicBehavior *VariadicBehavior) int {
+func minArgumentCount(paramTypeList FuncParameterList, variadicBehavior *VariadicBehavior) int {
 	if variadicBehavior == nil {
 		return len(paramTypeList)
 	}
 	return len(paramTypeList) + variadicBehavior.Min
 }
 
-func maxArgumentCount(paramTypeList ArgumentList, variadicBehavior *VariadicBehavior) int {
+func maxArgumentCount(paramTypeList FuncParameterList, variadicBehavior *VariadicBehavior) int {
 	if variadicBehavior == nil {
 		return len(paramTypeList)
 	}
@@ -294,7 +303,7 @@ type ScalarFunctionVariant struct {
 
 func (s *ScalarFunctionVariant) Name() string                     { return s.name }
 func (s *ScalarFunctionVariant) Description() string              { return s.description }
-func (s *ScalarFunctionVariant) Args() ArgumentList               { return s.impl.Args }
+func (s *ScalarFunctionVariant) Args() FuncParameterList          { return s.impl.Args }
 func (s *ScalarFunctionVariant) Options() map[string]Option       { return s.impl.Options }
 func (s *ScalarFunctionVariant) Variadic() *VariadicBehavior      { return s.impl.Variadic }
 func (s *ScalarFunctionVariant) Deterministic() bool              { return s.impl.Deterministic }
@@ -406,7 +415,7 @@ type AggregateFunctionVariant struct {
 
 func (s *AggregateFunctionVariant) Name() string                     { return s.name }
 func (s *AggregateFunctionVariant) Description() string              { return s.description }
-func (s *AggregateFunctionVariant) Args() ArgumentList               { return s.impl.Args }
+func (s *AggregateFunctionVariant) Args() FuncParameterList          { return s.impl.Args }
 func (s *AggregateFunctionVariant) Options() map[string]Option       { return s.impl.Options }
 func (s *AggregateFunctionVariant) Variadic() *VariadicBehavior      { return s.impl.Variadic }
 func (s *AggregateFunctionVariant) Deterministic() bool              { return s.impl.Deterministic }
@@ -526,7 +535,7 @@ func NewWindowFuncVariantOpts(id ID, opts WindowVariantOpts) *WindowFunctionVari
 
 func (s *WindowFunctionVariant) Name() string                     { return s.name }
 func (s *WindowFunctionVariant) Description() string              { return s.description }
-func (s *WindowFunctionVariant) Args() ArgumentList               { return s.impl.Args }
+func (s *WindowFunctionVariant) Args() FuncParameterList          { return s.impl.Args }
 func (s *WindowFunctionVariant) Options() map[string]Option       { return s.impl.Options }
 func (s *WindowFunctionVariant) Variadic() *VariadicBehavior      { return s.impl.Variadic }
 func (s *WindowFunctionVariant) Deterministic() bool              { return s.impl.Deterministic }

--- a/extensions/variants_test.go
+++ b/extensions/variants_test.go
@@ -24,31 +24,31 @@ func TestEvaluateTypeExpression(t *testing.T) {
 		name     string
 		nulls    extensions.NullabilityHandling
 		ret      types.FuncDefArgType
-		extArgs  extensions.ArgumentList
+		extArgs  extensions.FuncParameterList
 		args     []types.Type
 		expected types.Type
 		err      string
 	}{
-		{"defaults", "", i64NonNull, extensions.ArgumentList{
+		{"defaults", "", i64NonNull, extensions.FuncParameterList{
 			extensions.ValueArg{Value: &parser.TypeExpression{ValueType: i64Null}}},
 			[]types.Type{&types.Int64Type{Nullability: types.NullabilityNullable}},
 			&types.Int64Type{Nullability: types.NullabilityNullable}, ""},
-		{"arg mismatch", "", strNull, extensions.ArgumentList{extensions.ValueArg{Value: &parser.TypeExpression{ValueType: strNull}}},
+		{"arg mismatch", "", strNull, extensions.FuncParameterList{extensions.ValueArg{Value: &parser.TypeExpression{ValueType: strNull}}},
 			[]types.Type{}, nil, "invalid expression: mismatch in number of arguments provided. got 0, expected 1"},
-		{"missing enum arg", "", i64Null, extensions.ArgumentList{
+		{"missing enum arg", "", i64Null, extensions.FuncParameterList{
 			extensions.ValueArg{Value: &parser.TypeExpression{ValueType: i64NonNull}}, extensions.EnumArg{Name: "foo"}},
 			[]types.Type{&types.Int64Type{}, &types.Int64Type{}}, nil, "invalid type: arg #1 (foo) should be an enum"},
-		{"discrete null handling", extensions.DiscreteNullability, strNull, extensions.ArgumentList{
+		{"discrete null handling", extensions.DiscreteNullability, strNull, extensions.FuncParameterList{
 			extensions.ValueArg{Value: &parser.TypeExpression{ValueType: strNull}}},
 			[]types.Type{&types.StringType{Nullability: types.NullabilityRequired}},
 			nil, "invalid type: discrete nullability did not match for arg #0"},
-		{"mirror", extensions.MirrorNullability, strNull, extensions.ArgumentList{
+		{"mirror", extensions.MirrorNullability, strNull, extensions.FuncParameterList{
 			extensions.ValueArg{Value: &parser.TypeExpression{ValueType: i64NonNull}}, extensions.ValueArg{Value: &parser.TypeExpression{ValueType: i64Null}}},
 			[]types.Type{
 				&types.Int64Type{Nullability: types.NullabilityRequired},
 				&types.Int64Type{Nullability: types.NullabilityRequired}},
 			&types.StringType{Nullability: types.NullabilityRequired}, ""},
-		{"declared output", extensions.DeclaredOutputNullability, strNull, extensions.ArgumentList{
+		{"declared output", extensions.DeclaredOutputNullability, strNull, extensions.FuncParameterList{
 			extensions.ValueArg{Value: &parser.TypeExpression{ValueType: strNull}}},
 			[]types.Type{&types.StringType{Nullability: types.NullabilityRequired}},
 			&types.StringType{Nullability: types.NullabilityNullable}, ""},
@@ -77,20 +77,20 @@ func TestVariantWithVariadic(t *testing.T) {
 		name     string
 		nulls    extensions.NullabilityHandling
 		ret      types.FuncDefArgType
-		extArgs  extensions.ArgumentList
+		extArgs  extensions.FuncParameterList
 		args     []types.Type
 		expected types.Type
 		variadic extensions.VariadicBehavior
 		err      string
 	}{
-		{"basic", "", i64NonNull, extensions.ArgumentList{
+		{"basic", "", i64NonNull, extensions.FuncParameterList{
 			extensions.ValueArg{Value: &parser.TypeExpression{ValueType: i64Null}}},
 			[]types.Type{&types.Int64Type{Nullability: types.NullabilityNullable},
 				&types.Int64Type{Nullability: types.NullabilityNullable}},
 			&types.Int64Type{Nullability: types.NullabilityNullable},
 			extensions.VariadicBehavior{
 				Min: 0, ParameterConsistency: extensions.ConsistentParams}, ""},
-		{"bad arg count", "", i64NonNull, extensions.ArgumentList{
+		{"bad arg count", "", i64NonNull, extensions.FuncParameterList{
 			extensions.ValueArg{Value: &parser.TypeExpression{ValueType: i64Null}}},
 			[]types.Type{&types.Int64Type{Nullability: types.NullabilityNullable},
 				&types.Int64Type{Nullability: types.NullabilityNullable}},

--- a/functions/dialect_test.go
+++ b/functions/dialect_test.go
@@ -1212,7 +1212,7 @@ scalar_functions:
 	fv := localRegistry.GetScalarFunctions(LocalFunctionName("func_testvariadic"), 2)
 
 	// one type is int32 and other int64, since concrete type is not consistent so match should fail
-	argTypes := []types.Type{dec38_2, dec38_5}
+	argTypes := []types.Type{dec38_2, dec38_2, dec38_5}
 	require.Len(t, fv, 1)
 	match, err := fv[0].Match(argTypes)
 	require.NoError(t, err)

--- a/plan/ctas_plan_test.go
+++ b/plan/ctas_plan_test.go
@@ -126,7 +126,7 @@ func getProjectionForTest2(t *testing.T, b plan.Builder) plan.Rel {
 	// column 0 from the output of namedScanRel is role
 	// Build the filter with condition `role LIKE 'Engineer'`
 	l := literal.NewString("Engineer")
-	roleLikeEngineer := makeConditionExprForLike(t, b, namedScanRel, 0, l)
+	roleLikeEngineer := makeConditionExprForLike(t, b, namedScanRel, 1, l)
 	filterRel := makeFilterRel(t, b, namedScanRel, roleLikeEngineer)
 
 	// projectRel output employee_id, name, department_id, salary, role

--- a/plan/testdata/ctas_with_filter.json
+++ b/plan/testdata/ctas_with_filter.json
@@ -151,7 +151,7 @@
                         "functionReference": 1,
                         "outputType": {
                           "bool": {
-                            "nullability": "NULLABILITY_REQUIRED"
+                            "nullability": "NULLABILITY_NULLABLE"
                           }
                         },
                         "arguments": [
@@ -160,7 +160,7 @@
                               "selection": {
                                 "directReference": {
                                   "structField": {
-                                    "field": 0
+                                    "field": 1
                                   }
                                 },
                                 "rootReference": {}

--- a/types/any_type.go
+++ b/types/any_type.go
@@ -49,6 +49,6 @@ func (m AnyType) ShortString() string {
 	return "any"
 }
 
-func (m AnyType) ReturnType() (Type, error) {
+func (m AnyType) ReturnType([]FuncDefArgType, []Type) (Type, error) {
 	return nil, nil
 }

--- a/types/parameterized_decimal_type.go
+++ b/types/parameterized_decimal_type.go
@@ -72,7 +72,7 @@ func (m *ParameterizedDecimalType) ShortString() string {
 	return "dec"
 }
 
-func (m *ParameterizedDecimalType) ReturnType() (Type, error) {
+func (m *ParameterizedDecimalType) ReturnType([]FuncDefArgType, []Type) (Type, error) {
 	precision, perr := m.Precision.(*integer_parameters.ConcreteIntParam)
 	scale, serr := m.Scale.(*integer_parameters.ConcreteIntParam)
 	if !perr || !serr {

--- a/types/parameterized_decimal_type_test.go
+++ b/types/parameterized_decimal_type_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	. "github.com/substrait-io/substrait-go/types"
+	"github.com/substrait-io/substrait-go/types"
 	"github.com/substrait-io/substrait-go/types/integer_parameters"
 )
 
@@ -23,17 +23,17 @@ func TestParameterizedDecimalType(t *testing.T) {
 		expectedNullableRequiredString string
 		expectedHasParameterizedParam  bool
 		expectedParameterizedParams    []interface{}
-		expectedReturnType             Type
+		expectedReturnType             types.Type
 	}{
 		{"both parameterized", precision_P, scale_S, "decimal?<P,S>", "decimal<P,S>", true, []interface{}{precision_P, scale_S}, nil},
 		{"precision concrete", precision_38, scale_S, "decimal?<38,S>", "decimal<38,S>", true, []interface{}{scale_S}, nil},
 		{"scale concrete", precision_P, scale_5, "decimal?<P,5>", "decimal<P,5>", true, []interface{}{precision_P}, nil},
-		{"both concrete", precision_38, scale_5, "decimal?<38,5>", "decimal<38,5>", false, nil, &DecimalType{Precision: 38, Scale: 5, Nullability: NullabilityRequired}},
+		{"both concrete", precision_38, scale_5, "decimal?<38,5>", "decimal<38,5>", false, nil, &types.DecimalType{Precision: 38, Scale: 5, Nullability: types.NullabilityRequired}},
 	} {
 		t.Run(td.name, func(t *testing.T) {
-			pd := &ParameterizedDecimalType{Precision: td.precision, Scale: td.scale}
-			require.Equal(t, td.expectedNullableString, pd.SetNullability(NullabilityNullable).String())
-			require.Equal(t, td.expectedNullableRequiredString, pd.SetNullability(NullabilityRequired).String())
+			pd := &types.ParameterizedDecimalType{Precision: td.precision, Scale: td.scale}
+			require.Equal(t, td.expectedNullableString, pd.SetNullability(types.NullabilityNullable).String())
+			require.Equal(t, td.expectedNullableRequiredString, pd.SetNullability(types.NullabilityRequired).String())
 			require.Equal(t, td.expectedHasParameterizedParam, pd.HasParameterizedParam())
 			require.Equal(t, td.expectedParameterizedParams, pd.GetParameterizedParams())
 			retType, err := pd.ReturnType(nil, nil)

--- a/types/parameterized_decimal_type_test.go
+++ b/types/parameterized_decimal_type_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/substrait-io/substrait-go/types"
+	. "github.com/substrait-io/substrait-go/types"
 	"github.com/substrait-io/substrait-go/types/integer_parameters"
 )
 
@@ -23,20 +23,20 @@ func TestParameterizedDecimalType(t *testing.T) {
 		expectedNullableRequiredString string
 		expectedHasParameterizedParam  bool
 		expectedParameterizedParams    []interface{}
-		expectedReturnType             types.Type
+		expectedReturnType             Type
 	}{
 		{"both parameterized", precision_P, scale_S, "decimal?<P,S>", "decimal<P,S>", true, []interface{}{precision_P, scale_S}, nil},
 		{"precision concrete", precision_38, scale_S, "decimal?<38,S>", "decimal<38,S>", true, []interface{}{scale_S}, nil},
 		{"scale concrete", precision_P, scale_5, "decimal?<P,5>", "decimal<P,5>", true, []interface{}{precision_P}, nil},
-		{"both concrete", precision_38, scale_5, "decimal?<38,5>", "decimal<38,5>", false, nil, &types.DecimalType{Precision: 38, Scale: 5, Nullability: types.NullabilityRequired}},
+		{"both concrete", precision_38, scale_5, "decimal?<38,5>", "decimal<38,5>", false, nil, &DecimalType{Precision: 38, Scale: 5, Nullability: NullabilityRequired}},
 	} {
 		t.Run(td.name, func(t *testing.T) {
-			pd := &types.ParameterizedDecimalType{Precision: td.precision, Scale: td.scale}
-			require.Equal(t, td.expectedNullableString, pd.SetNullability(types.NullabilityNullable).String())
-			require.Equal(t, td.expectedNullableRequiredString, pd.SetNullability(types.NullabilityRequired).String())
+			pd := &ParameterizedDecimalType{Precision: td.precision, Scale: td.scale}
+			require.Equal(t, td.expectedNullableString, pd.SetNullability(NullabilityNullable).String())
+			require.Equal(t, td.expectedNullableRequiredString, pd.SetNullability(NullabilityRequired).String())
 			require.Equal(t, td.expectedHasParameterizedParam, pd.HasParameterizedParam())
 			require.Equal(t, td.expectedParameterizedParams, pd.GetParameterizedParams())
-			retType, err := pd.ReturnType()
+			retType, err := pd.ReturnType(nil, nil)
 			if td.expectedReturnType == nil {
 				require.Error(t, err)
 				require.True(t, pd.HasParameterizedParam())

--- a/types/parameterized_list_type.go
+++ b/types/parameterized_list_type.go
@@ -64,8 +64,8 @@ func (m *ParameterizedListType) ShortString() string {
 	return "list"
 }
 
-func (m *ParameterizedListType) ReturnType() (Type, error) {
-	elemType, err := m.Type.ReturnType()
+func (m *ParameterizedListType) ReturnType([]FuncDefArgType, []Type) (Type, error) {
+	elemType, err := m.Type.ReturnType(nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/types/parameterized_list_type_test.go
+++ b/types/parameterized_list_type_test.go
@@ -7,39 +7,39 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/substrait-io/substrait-go/types"
+	. "github.com/substrait-io/substrait-go/types"
 	"github.com/substrait-io/substrait-go/types/integer_parameters"
 )
 
 func TestParameterizedListType(t *testing.T) {
-	decimalType := &types.ParameterizedDecimalType{
+	decimalType := &ParameterizedDecimalType{
 		Precision:   integer_parameters.NewVariableIntParam("P"),
 		Scale:       integer_parameters.NewVariableIntParam("S"),
-		Nullability: types.NullabilityRequired,
+		Nullability: NullabilityRequired,
 	}
-	int8Type := &types.Int8Type{}
+	int8Type := &Int8Type{}
 	for _, td := range []struct {
 		name                           string
-		param                          types.FuncDefArgType
+		param                          FuncDefArgType
 		expectedNullableString         string
 		expectedNullableRequiredString string
 		expectedHasParameterizedParam  bool
 		expectedParameterizedParams    []interface{}
-		expectedReturnType             types.Type
+		expectedReturnType             Type
 	}{
 		{"parameterized param", decimalType, "list?<decimal<P,S>>", "list<decimal<P,S>>", true, []interface{}{decimalType}, nil},
-		{"concrete param", int8Type, "list?<i8>", "list<i8>", false, nil, &types.ListType{Nullability: types.NullabilityRequired, Type: int8Type}},
+		{"concrete param", int8Type, "list?<i8>", "list<i8>", false, nil, &ListType{Nullability: NullabilityRequired, Type: int8Type}},
 	} {
 		t.Run(td.name, func(t *testing.T) {
-			pd := &types.ParameterizedListType{Type: td.param}
-			assert.Equal(t, types.NullabilityUnspecified, pd.GetNullability())
-			require.Equal(t, td.expectedNullableString, pd.SetNullability(types.NullabilityNullable).String())
-			require.Equal(t, td.expectedNullableRequiredString, pd.SetNullability(types.NullabilityRequired).String())
-			assert.Equal(t, types.NullabilityRequired, pd.GetNullability())
+			pd := &ParameterizedListType{Type: td.param}
+			assert.Equal(t, NullabilityUnspecified, pd.GetNullability())
+			require.Equal(t, td.expectedNullableString, pd.SetNullability(NullabilityNullable).String())
+			require.Equal(t, td.expectedNullableRequiredString, pd.SetNullability(NullabilityRequired).String())
+			assert.Equal(t, NullabilityRequired, pd.GetNullability())
 			require.Equal(t, td.expectedHasParameterizedParam, pd.HasParameterizedParam())
 			require.Equal(t, td.expectedParameterizedParams, pd.GetParameterizedParams())
 			assert.Equal(t, "list", pd.ShortString())
-			retType, err := pd.ReturnType()
+			retType, err := pd.ReturnType(nil, nil)
 			if td.expectedReturnType == nil {
 				assert.Error(t, err)
 				require.True(t, pd.HasParameterizedParam())

--- a/types/parameterized_list_type_test.go
+++ b/types/parameterized_list_type_test.go
@@ -7,35 +7,35 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	. "github.com/substrait-io/substrait-go/types"
+	"github.com/substrait-io/substrait-go/types"
 	"github.com/substrait-io/substrait-go/types/integer_parameters"
 )
 
 func TestParameterizedListType(t *testing.T) {
-	decimalType := &ParameterizedDecimalType{
+	decimalType := &types.ParameterizedDecimalType{
 		Precision:   integer_parameters.NewVariableIntParam("P"),
 		Scale:       integer_parameters.NewVariableIntParam("S"),
-		Nullability: NullabilityRequired,
+		Nullability: types.NullabilityRequired,
 	}
-	int8Type := &Int8Type{}
+	int8Type := &types.Int8Type{}
 	for _, td := range []struct {
 		name                           string
-		param                          FuncDefArgType
+		param                          types.FuncDefArgType
 		expectedNullableString         string
 		expectedNullableRequiredString string
 		expectedHasParameterizedParam  bool
 		expectedParameterizedParams    []interface{}
-		expectedReturnType             Type
+		expectedReturnType             types.Type
 	}{
 		{"parameterized param", decimalType, "list?<decimal<P,S>>", "list<decimal<P,S>>", true, []interface{}{decimalType}, nil},
-		{"concrete param", int8Type, "list?<i8>", "list<i8>", false, nil, &ListType{Nullability: NullabilityRequired, Type: int8Type}},
+		{"concrete param", int8Type, "list?<i8>", "list<i8>", false, nil, &types.ListType{Nullability: types.NullabilityRequired, Type: int8Type}},
 	} {
 		t.Run(td.name, func(t *testing.T) {
-			pd := &ParameterizedListType{Type: td.param}
-			assert.Equal(t, NullabilityUnspecified, pd.GetNullability())
-			require.Equal(t, td.expectedNullableString, pd.SetNullability(NullabilityNullable).String())
-			require.Equal(t, td.expectedNullableRequiredString, pd.SetNullability(NullabilityRequired).String())
-			assert.Equal(t, NullabilityRequired, pd.GetNullability())
+			pd := &types.ParameterizedListType{Type: td.param}
+			assert.Equal(t, types.NullabilityUnspecified, pd.GetNullability())
+			require.Equal(t, td.expectedNullableString, pd.SetNullability(types.NullabilityNullable).String())
+			require.Equal(t, td.expectedNullableRequiredString, pd.SetNullability(types.NullabilityRequired).String())
+			assert.Equal(t, types.NullabilityRequired, pd.GetNullability())
 			require.Equal(t, td.expectedHasParameterizedParam, pd.HasParameterizedParam())
 			require.Equal(t, td.expectedParameterizedParams, pd.GetParameterizedParams())
 			assert.Equal(t, "list", pd.ShortString())

--- a/types/parameterized_map_type.go
+++ b/types/parameterized_map_type.go
@@ -69,12 +69,12 @@ func (m *ParameterizedMapType) ShortString() string {
 	return "map"
 }
 
-func (m *ParameterizedMapType) ReturnType() (Type, error) {
-	keyType, kerr := m.Key.ReturnType()
+func (m *ParameterizedMapType) ReturnType([]FuncDefArgType, []Type) (Type, error) {
+	keyType, kerr := m.Key.ReturnType(nil, nil)
 	if kerr != nil {
 		return nil, fmt.Errorf("error in getting key type: %w", kerr)
 	}
-	valueType, verr := m.Value.ReturnType()
+	valueType, verr := m.Value.ReturnType(nil, nil)
 	if verr != nil {
 		return nil, fmt.Errorf("error in getting value type: %w", kerr)
 	}

--- a/types/parameterized_map_type_test.go
+++ b/types/parameterized_map_type_test.go
@@ -7,40 +7,40 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	. "github.com/substrait-io/substrait-go/types"
+	"github.com/substrait-io/substrait-go/types"
 	"github.com/substrait-io/substrait-go/types/integer_parameters"
 )
 
 func TestParameterizedMapType(t *testing.T) {
-	decimalType := &ParameterizedDecimalType{
+	decimalType := &types.ParameterizedDecimalType{
 		Precision:   integer_parameters.NewVariableIntParam("P"),
 		Scale:       integer_parameters.NewVariableIntParam("S"),
-		Nullability: NullabilityRequired,
+		Nullability: types.NullabilityRequired,
 	}
-	int8Type := &Int8Type{Nullability: NullabilityNullable}
-	listType := &ParameterizedListType{Type: decimalType, Nullability: NullabilityNullable}
+	int8Type := &types.Int8Type{Nullability: types.NullabilityNullable}
+	listType := &types.ParameterizedListType{Type: decimalType, Nullability: types.NullabilityNullable}
 	for _, td := range []struct {
 		name                           string
-		Key                            FuncDefArgType
-		Value                          FuncDefArgType
+		Key                            types.FuncDefArgType
+		Value                          types.FuncDefArgType
 		expectedNullableString         string
 		expectedNullableRequiredString string
 		expectedHasParameterizedParam  bool
 		expectedParameterizedParams    []interface{}
-		expectedReturnType             Type
+		expectedReturnType             types.Type
 	}{
 		{"parameterized kv", decimalType, listType, "map?<decimal<P,S>, list?<decimal<P,S>>>", "map<decimal<P,S>, list?<decimal<P,S>>>", true, []interface{}{decimalType, listType}, nil},
 		{"concrete key", int8Type, listType, "map?<i8?, list?<decimal<P,S>>>", "map<i8?, list?<decimal<P,S>>>", true, []interface{}{listType}, nil},
 		{"concrete value", decimalType, int8Type, "map?<decimal<P,S>, i8?>", "map<decimal<P,S>, i8?>", true, []interface{}{decimalType}, nil},
-		{"no parameterized param", int8Type, int8Type, "map?<i8?, i8?>", "map<i8?, i8?>", false, nil, &MapType{Nullability: NullabilityRequired, Key: int8Type, Value: int8Type}},
+		{"no parameterized param", int8Type, int8Type, "map?<i8?, i8?>", "map<i8?, i8?>", false, nil, &types.MapType{Nullability: types.NullabilityRequired, Key: int8Type, Value: int8Type}},
 	} {
 		t.Run(td.name, func(t *testing.T) {
-			pd := &ParameterizedMapType{Key: td.Key, Value: td.Value}
-			assert.Equal(t, NullabilityUnspecified, pd.GetNullability())
-			require.Equal(t, td.expectedNullableString, pd.SetNullability(NullabilityNullable).String())
-			assert.Equal(t, NullabilityNullable, pd.GetNullability())
-			require.Equal(t, td.expectedNullableRequiredString, pd.SetNullability(NullabilityRequired).String())
-			assert.Equal(t, NullabilityRequired, pd.GetNullability())
+			pd := &types.ParameterizedMapType{Key: td.Key, Value: td.Value}
+			assert.Equal(t, types.NullabilityUnspecified, pd.GetNullability())
+			require.Equal(t, td.expectedNullableString, pd.SetNullability(types.NullabilityNullable).String())
+			assert.Equal(t, types.NullabilityNullable, pd.GetNullability())
+			require.Equal(t, td.expectedNullableRequiredString, pd.SetNullability(types.NullabilityRequired).String())
+			assert.Equal(t, types.NullabilityRequired, pd.GetNullability())
 			require.Equal(t, td.expectedHasParameterizedParam, pd.HasParameterizedParam())
 			require.Equal(t, td.expectedParameterizedParams, pd.GetParameterizedParams())
 			retType, err := pd.ReturnType(nil, nil)

--- a/types/parameterized_map_type_test.go
+++ b/types/parameterized_map_type_test.go
@@ -7,43 +7,43 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/substrait-io/substrait-go/types"
+	. "github.com/substrait-io/substrait-go/types"
 	"github.com/substrait-io/substrait-go/types/integer_parameters"
 )
 
 func TestParameterizedMapType(t *testing.T) {
-	decimalType := &types.ParameterizedDecimalType{
+	decimalType := &ParameterizedDecimalType{
 		Precision:   integer_parameters.NewVariableIntParam("P"),
 		Scale:       integer_parameters.NewVariableIntParam("S"),
-		Nullability: types.NullabilityRequired,
+		Nullability: NullabilityRequired,
 	}
-	int8Type := &types.Int8Type{Nullability: types.NullabilityNullable}
-	listType := &types.ParameterizedListType{Type: decimalType, Nullability: types.NullabilityNullable}
+	int8Type := &Int8Type{Nullability: NullabilityNullable}
+	listType := &ParameterizedListType{Type: decimalType, Nullability: NullabilityNullable}
 	for _, td := range []struct {
 		name                           string
-		Key                            types.FuncDefArgType
-		Value                          types.FuncDefArgType
+		Key                            FuncDefArgType
+		Value                          FuncDefArgType
 		expectedNullableString         string
 		expectedNullableRequiredString string
 		expectedHasParameterizedParam  bool
 		expectedParameterizedParams    []interface{}
-		expectedReturnType             types.Type
+		expectedReturnType             Type
 	}{
 		{"parameterized kv", decimalType, listType, "map?<decimal<P,S>, list?<decimal<P,S>>>", "map<decimal<P,S>, list?<decimal<P,S>>>", true, []interface{}{decimalType, listType}, nil},
 		{"concrete key", int8Type, listType, "map?<i8?, list?<decimal<P,S>>>", "map<i8?, list?<decimal<P,S>>>", true, []interface{}{listType}, nil},
 		{"concrete value", decimalType, int8Type, "map?<decimal<P,S>, i8?>", "map<decimal<P,S>, i8?>", true, []interface{}{decimalType}, nil},
-		{"no parameterized param", int8Type, int8Type, "map?<i8?, i8?>", "map<i8?, i8?>", false, nil, &types.MapType{Nullability: types.NullabilityRequired, Key: int8Type, Value: int8Type}},
+		{"no parameterized param", int8Type, int8Type, "map?<i8?, i8?>", "map<i8?, i8?>", false, nil, &MapType{Nullability: NullabilityRequired, Key: int8Type, Value: int8Type}},
 	} {
 		t.Run(td.name, func(t *testing.T) {
-			pd := &types.ParameterizedMapType{Key: td.Key, Value: td.Value}
-			assert.Equal(t, types.NullabilityUnspecified, pd.GetNullability())
-			require.Equal(t, td.expectedNullableString, pd.SetNullability(types.NullabilityNullable).String())
-			assert.Equal(t, types.NullabilityNullable, pd.GetNullability())
-			require.Equal(t, td.expectedNullableRequiredString, pd.SetNullability(types.NullabilityRequired).String())
-			assert.Equal(t, types.NullabilityRequired, pd.GetNullability())
+			pd := &ParameterizedMapType{Key: td.Key, Value: td.Value}
+			assert.Equal(t, NullabilityUnspecified, pd.GetNullability())
+			require.Equal(t, td.expectedNullableString, pd.SetNullability(NullabilityNullable).String())
+			assert.Equal(t, NullabilityNullable, pd.GetNullability())
+			require.Equal(t, td.expectedNullableRequiredString, pd.SetNullability(NullabilityRequired).String())
+			assert.Equal(t, NullabilityRequired, pd.GetNullability())
 			require.Equal(t, td.expectedHasParameterizedParam, pd.HasParameterizedParam())
 			require.Equal(t, td.expectedParameterizedParams, pd.GetParameterizedParams())
-			retType, err := pd.ReturnType()
+			retType, err := pd.ReturnType(nil, nil)
 			if td.expectedReturnType == nil {
 				assert.Error(t, err)
 				require.True(t, pd.HasParameterizedParam())

--- a/types/parameterized_single_integer_param_type.go
+++ b/types/parameterized_single_integer_param_type.go
@@ -98,7 +98,7 @@ func (m *parameterizedTypeSingleIntegerParam[T]) getNewInstance() T {
 	return reflect.New(tType).Interface().(T)
 }
 
-func (m *parameterizedTypeSingleIntegerParam[T]) ReturnType() (Type, error) {
+func (m *parameterizedTypeSingleIntegerParam[T]) ReturnType([]FuncDefArgType, []Type) (Type, error) {
 	concreteIntParam, ok := m.IntegerOption.(*integer_parameters.ConcreteIntParam)
 	if !ok {
 		return nil, substraitgo.ErrNotImplemented

--- a/types/parameterized_single_integer_param_type_test.go
+++ b/types/parameterized_single_integer_param_type_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	. "github.com/substrait-io/substrait-go/types"
+	"github.com/substrait-io/substrait-go/types"
 	"github.com/substrait-io/substrait-go/types/integer_parameters"
 )
 
@@ -17,30 +17,30 @@ func TestParameterizedSingleIntegerType(t *testing.T) {
 	concreteLeafParam_5 := integer_parameters.NewConcreteIntParam(5)
 	for _, td := range []struct {
 		name                           string
-		typ                            FuncDefArgType
+		typ                            types.FuncDefArgType
 		expectedNullableString         string
 		expectedNullableRequiredString string
 		expectedShortString            string
 		expectedIsParameterized        bool
 		expectedAbstractParams         []interface{}
-		expectedReturnType             Type
+		expectedReturnType             types.Type
 	}{
-		{"nullable parameterized varchar", &ParameterizedVarCharType{IntegerOption: abstractLeafParam_L1}, "varchar?<L1>", "varchar<L1>", "vchar", true, []interface{}{abstractLeafParam_L1}, nil},
-		{"nullable concrete varchar", &ParameterizedVarCharType{IntegerOption: concreteLeafParam_38}, "varchar?<38>", "varchar<38>", "vchar", false, nil, &VarCharType{Length: 38, Nullability: NullabilityRequired}},
-		{"nullable fixChar", &ParameterizedFixedCharType{IntegerOption: abstractLeafParam_L1}, "char?<L1>", "char<L1>", "fchar", true, []interface{}{abstractLeafParam_L1}, nil},
-		{"nullable concrete fixChar", &ParameterizedFixedCharType{IntegerOption: concreteLeafParam_38}, "char?<38>", "char<38>", "fchar", false, nil, &FixedCharType{Length: 38, Nullability: NullabilityRequired}},
-		{"nullable fixBinary", &ParameterizedFixedBinaryType{IntegerOption: abstractLeafParam_L1}, "fixedbinary?<L1>", "fixedbinary<L1>", "fbin", true, []interface{}{abstractLeafParam_L1}, nil},
-		{"nullable concrete fixBinary", &ParameterizedFixedBinaryType{IntegerOption: concreteLeafParam_38}, "fixedbinary?<38>", "fixedbinary<38>", "fbin", false, nil, &FixedBinaryType{Length: 38, Nullability: NullabilityRequired}},
-		{"nullable precisionTimeStamp", &ParameterizedPrecisionTimestampType{IntegerOption: abstractLeafParam_L1}, "precision_timestamp?<L1>", "precision_timestamp<L1>", "prets", true, []interface{}{abstractLeafParam_L1}, nil},
-		{"nullable concrete precisionTimeStamp", &ParameterizedPrecisionTimestampType{IntegerOption: concreteLeafParam_38}, "precision_timestamp?<38>", "precision_timestamp<38>", "prets", false, nil, &PrecisionTimestampType{Precision: 38, Nullability: NullabilityRequired}},
-		{"nullable precisionTimeStampTz", &ParameterizedPrecisionTimestampTzType{IntegerOption: abstractLeafParam_L1}, "precision_timestamp_tz?<L1>", "precision_timestamp_tz<L1>", "pretstz", true, []interface{}{abstractLeafParam_L1}, nil},
-		{"nullable concrete precisionTimeStampTz", &ParameterizedPrecisionTimestampTzType{IntegerOption: concreteLeafParam_38}, "precision_timestamp_tz?<38>", "precision_timestamp_tz<38>", "pretstz", false, nil, &PrecisionTimestampTzType{PrecisionTimestampType: PrecisionTimestampType{Precision: 38, Nullability: NullabilityRequired}}},
-		{"nullable interval day", &ParameterizedIntervalDayType{IntegerOption: abstractLeafParam_L1}, "interval_day?<L1>", "interval_day<L1>", "iday", true, []interface{}{abstractLeafParam_L1}, nil},
-		{"nullable concrete interval day", &ParameterizedIntervalDayType{IntegerOption: concreteLeafParam_5}, "interval_day?<5>", "interval_day<5>", "iday", false, nil, &IntervalDayType{Precision: 5, Nullability: NullabilityRequired}},
+		{"nullable parameterized varchar", &types.ParameterizedVarCharType{IntegerOption: abstractLeafParam_L1}, "varchar?<L1>", "varchar<L1>", "vchar", true, []interface{}{abstractLeafParam_L1}, nil},
+		{"nullable concrete varchar", &types.ParameterizedVarCharType{IntegerOption: concreteLeafParam_38}, "varchar?<38>", "varchar<38>", "vchar", false, nil, &types.VarCharType{Length: 38, Nullability: types.NullabilityRequired}},
+		{"nullable fixChar", &types.ParameterizedFixedCharType{IntegerOption: abstractLeafParam_L1}, "char?<L1>", "char<L1>", "fchar", true, []interface{}{abstractLeafParam_L1}, nil},
+		{"nullable concrete fixChar", &types.ParameterizedFixedCharType{IntegerOption: concreteLeafParam_38}, "char?<38>", "char<38>", "fchar", false, nil, &types.FixedCharType{Length: 38, Nullability: types.NullabilityRequired}},
+		{"nullable fixBinary", &types.ParameterizedFixedBinaryType{IntegerOption: abstractLeafParam_L1}, "fixedbinary?<L1>", "fixedbinary<L1>", "fbin", true, []interface{}{abstractLeafParam_L1}, nil},
+		{"nullable concrete fixBinary", &types.ParameterizedFixedBinaryType{IntegerOption: concreteLeafParam_38}, "fixedbinary?<38>", "fixedbinary<38>", "fbin", false, nil, &types.FixedBinaryType{Length: 38, Nullability: types.NullabilityRequired}},
+		{"nullable precisionTimeStamp", &types.ParameterizedPrecisionTimestampType{IntegerOption: abstractLeafParam_L1}, "precision_timestamp?<L1>", "precision_timestamp<L1>", "prets", true, []interface{}{abstractLeafParam_L1}, nil},
+		{"nullable concrete precisionTimeStamp", &types.ParameterizedPrecisionTimestampType{IntegerOption: concreteLeafParam_38}, "precision_timestamp?<38>", "precision_timestamp<38>", "prets", false, nil, &types.PrecisionTimestampType{Precision: 38, Nullability: types.NullabilityRequired}},
+		{"nullable precisionTimeStampTz", &types.ParameterizedPrecisionTimestampTzType{IntegerOption: abstractLeafParam_L1}, "precision_timestamp_tz?<L1>", "precision_timestamp_tz<L1>", "pretstz", true, []interface{}{abstractLeafParam_L1}, nil},
+		{"nullable concrete precisionTimeStampTz", &types.ParameterizedPrecisionTimestampTzType{IntegerOption: concreteLeafParam_38}, "precision_timestamp_tz?<38>", "precision_timestamp_tz<38>", "pretstz", false, nil, &types.PrecisionTimestampTzType{PrecisionTimestampType: types.PrecisionTimestampType{Precision: 38, Nullability: types.NullabilityRequired}}},
+		{"nullable interval day", &types.ParameterizedIntervalDayType{IntegerOption: abstractLeafParam_L1}, "interval_day?<L1>", "interval_day<L1>", "iday", true, []interface{}{abstractLeafParam_L1}, nil},
+		{"nullable concrete interval day", &types.ParameterizedIntervalDayType{IntegerOption: concreteLeafParam_5}, "interval_day?<5>", "interval_day<5>", "iday", false, nil, &types.IntervalDayType{Precision: 5, Nullability: types.NullabilityRequired}},
 	} {
 		t.Run(td.name, func(t *testing.T) {
-			require.Equal(t, td.expectedNullableString, td.typ.SetNullability(NullabilityNullable).String())
-			require.Equal(t, td.expectedNullableRequiredString, td.typ.SetNullability(NullabilityRequired).String())
+			require.Equal(t, td.expectedNullableString, td.typ.SetNullability(types.NullabilityNullable).String())
+			require.Equal(t, td.expectedNullableRequiredString, td.typ.SetNullability(types.NullabilityRequired).String())
 			require.Equal(t, td.expectedIsParameterized, td.typ.HasParameterizedParam())
 			require.Equal(t, td.expectedAbstractParams, td.typ.GetParameterizedParams())
 			assert.Equal(t, td.expectedShortString, td.typ.ShortString())

--- a/types/parameterized_single_integer_param_type_test.go
+++ b/types/parameterized_single_integer_param_type_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/substrait-io/substrait-go/types"
+	. "github.com/substrait-io/substrait-go/types"
 	"github.com/substrait-io/substrait-go/types/integer_parameters"
 )
 
@@ -17,34 +17,34 @@ func TestParameterizedSingleIntegerType(t *testing.T) {
 	concreteLeafParam_5 := integer_parameters.NewConcreteIntParam(5)
 	for _, td := range []struct {
 		name                           string
-		typ                            types.FuncDefArgType
+		typ                            FuncDefArgType
 		expectedNullableString         string
 		expectedNullableRequiredString string
 		expectedShortString            string
 		expectedIsParameterized        bool
 		expectedAbstractParams         []interface{}
-		expectedReturnType             types.Type
+		expectedReturnType             Type
 	}{
-		{"nullable parameterized varchar", &types.ParameterizedVarCharType{IntegerOption: abstractLeafParam_L1}, "varchar?<L1>", "varchar<L1>", "vchar", true, []interface{}{abstractLeafParam_L1}, nil},
-		{"nullable concrete varchar", &types.ParameterizedVarCharType{IntegerOption: concreteLeafParam_38}, "varchar?<38>", "varchar<38>", "vchar", false, nil, &types.VarCharType{Length: 38, Nullability: types.NullabilityRequired}},
-		{"nullable fixChar", &types.ParameterizedFixedCharType{IntegerOption: abstractLeafParam_L1}, "char?<L1>", "char<L1>", "fchar", true, []interface{}{abstractLeafParam_L1}, nil},
-		{"nullable concrete fixChar", &types.ParameterizedFixedCharType{IntegerOption: concreteLeafParam_38}, "char?<38>", "char<38>", "fchar", false, nil, &types.FixedCharType{Length: 38, Nullability: types.NullabilityRequired}},
-		{"nullable fixBinary", &types.ParameterizedFixedBinaryType{IntegerOption: abstractLeafParam_L1}, "fixedbinary?<L1>", "fixedbinary<L1>", "fbin", true, []interface{}{abstractLeafParam_L1}, nil},
-		{"nullable concrete fixBinary", &types.ParameterizedFixedBinaryType{IntegerOption: concreteLeafParam_38}, "fixedbinary?<38>", "fixedbinary<38>", "fbin", false, nil, &types.FixedBinaryType{Length: 38, Nullability: types.NullabilityRequired}},
-		{"nullable precisionTimeStamp", &types.ParameterizedPrecisionTimestampType{IntegerOption: abstractLeafParam_L1}, "precision_timestamp?<L1>", "precision_timestamp<L1>", "prets", true, []interface{}{abstractLeafParam_L1}, nil},
-		{"nullable concrete precisionTimeStamp", &types.ParameterizedPrecisionTimestampType{IntegerOption: concreteLeafParam_38}, "precision_timestamp?<38>", "precision_timestamp<38>", "prets", false, nil, &types.PrecisionTimestampType{Precision: 38, Nullability: types.NullabilityRequired}},
-		{"nullable precisionTimeStampTz", &types.ParameterizedPrecisionTimestampTzType{IntegerOption: abstractLeafParam_L1}, "precision_timestamp_tz?<L1>", "precision_timestamp_tz<L1>", "pretstz", true, []interface{}{abstractLeafParam_L1}, nil},
-		{"nullable concrete precisionTimeStampTz", &types.ParameterizedPrecisionTimestampTzType{IntegerOption: concreteLeafParam_38}, "precision_timestamp_tz?<38>", "precision_timestamp_tz<38>", "pretstz", false, nil, &types.PrecisionTimestampTzType{PrecisionTimestampType: types.PrecisionTimestampType{Precision: 38, Nullability: types.NullabilityRequired}}},
-		{"nullable interval day", &types.ParameterizedIntervalDayType{IntegerOption: abstractLeafParam_L1}, "interval_day?<L1>", "interval_day<L1>", "iday", true, []interface{}{abstractLeafParam_L1}, nil},
-		{"nullable concrete interval day", &types.ParameterizedIntervalDayType{IntegerOption: concreteLeafParam_5}, "interval_day?<5>", "interval_day<5>", "iday", false, nil, &types.IntervalDayType{Precision: 5, Nullability: types.NullabilityRequired}},
+		{"nullable parameterized varchar", &ParameterizedVarCharType{IntegerOption: abstractLeafParam_L1}, "varchar?<L1>", "varchar<L1>", "vchar", true, []interface{}{abstractLeafParam_L1}, nil},
+		{"nullable concrete varchar", &ParameterizedVarCharType{IntegerOption: concreteLeafParam_38}, "varchar?<38>", "varchar<38>", "vchar", false, nil, &VarCharType{Length: 38, Nullability: NullabilityRequired}},
+		{"nullable fixChar", &ParameterizedFixedCharType{IntegerOption: abstractLeafParam_L1}, "char?<L1>", "char<L1>", "fchar", true, []interface{}{abstractLeafParam_L1}, nil},
+		{"nullable concrete fixChar", &ParameterizedFixedCharType{IntegerOption: concreteLeafParam_38}, "char?<38>", "char<38>", "fchar", false, nil, &FixedCharType{Length: 38, Nullability: NullabilityRequired}},
+		{"nullable fixBinary", &ParameterizedFixedBinaryType{IntegerOption: abstractLeafParam_L1}, "fixedbinary?<L1>", "fixedbinary<L1>", "fbin", true, []interface{}{abstractLeafParam_L1}, nil},
+		{"nullable concrete fixBinary", &ParameterizedFixedBinaryType{IntegerOption: concreteLeafParam_38}, "fixedbinary?<38>", "fixedbinary<38>", "fbin", false, nil, &FixedBinaryType{Length: 38, Nullability: NullabilityRequired}},
+		{"nullable precisionTimeStamp", &ParameterizedPrecisionTimestampType{IntegerOption: abstractLeafParam_L1}, "precision_timestamp?<L1>", "precision_timestamp<L1>", "prets", true, []interface{}{abstractLeafParam_L1}, nil},
+		{"nullable concrete precisionTimeStamp", &ParameterizedPrecisionTimestampType{IntegerOption: concreteLeafParam_38}, "precision_timestamp?<38>", "precision_timestamp<38>", "prets", false, nil, &PrecisionTimestampType{Precision: 38, Nullability: NullabilityRequired}},
+		{"nullable precisionTimeStampTz", &ParameterizedPrecisionTimestampTzType{IntegerOption: abstractLeafParam_L1}, "precision_timestamp_tz?<L1>", "precision_timestamp_tz<L1>", "pretstz", true, []interface{}{abstractLeafParam_L1}, nil},
+		{"nullable concrete precisionTimeStampTz", &ParameterizedPrecisionTimestampTzType{IntegerOption: concreteLeafParam_38}, "precision_timestamp_tz?<38>", "precision_timestamp_tz<38>", "pretstz", false, nil, &PrecisionTimestampTzType{PrecisionTimestampType: PrecisionTimestampType{Precision: 38, Nullability: NullabilityRequired}}},
+		{"nullable interval day", &ParameterizedIntervalDayType{IntegerOption: abstractLeafParam_L1}, "interval_day?<L1>", "interval_day<L1>", "iday", true, []interface{}{abstractLeafParam_L1}, nil},
+		{"nullable concrete interval day", &ParameterizedIntervalDayType{IntegerOption: concreteLeafParam_5}, "interval_day?<5>", "interval_day<5>", "iday", false, nil, &IntervalDayType{Precision: 5, Nullability: NullabilityRequired}},
 	} {
 		t.Run(td.name, func(t *testing.T) {
-			require.Equal(t, td.expectedNullableString, td.typ.SetNullability(types.NullabilityNullable).String())
-			require.Equal(t, td.expectedNullableRequiredString, td.typ.SetNullability(types.NullabilityRequired).String())
+			require.Equal(t, td.expectedNullableString, td.typ.SetNullability(NullabilityNullable).String())
+			require.Equal(t, td.expectedNullableRequiredString, td.typ.SetNullability(NullabilityRequired).String())
 			require.Equal(t, td.expectedIsParameterized, td.typ.HasParameterizedParam())
 			require.Equal(t, td.expectedAbstractParams, td.typ.GetParameterizedParams())
 			assert.Equal(t, td.expectedShortString, td.typ.ShortString())
-			retType, err := td.typ.ReturnType()
+			retType, err := td.typ.ReturnType(nil, nil)
 			if td.expectedReturnType == nil {
 				require.Error(t, err)
 				require.True(t, td.typ.HasParameterizedParam())

--- a/types/parameterized_struct_type.go
+++ b/types/parameterized_struct_type.go
@@ -96,10 +96,10 @@ func (m *ParameterizedStructType) ShortString() string {
 	return "struct"
 }
 
-func (m *ParameterizedStructType) ReturnType() (Type, error) {
+func (m *ParameterizedStructType) ReturnType([]FuncDefArgType, []Type) (Type, error) {
 	var types []Type
 	for _, typ := range m.Types {
-		retType, err := typ.ReturnType()
+		retType, err := typ.ReturnType(nil, nil)
 		if err != nil {
 			return nil, fmt.Errorf("error in struct field type: %w", err)
 		}

--- a/types/parameterized_struct_type_test.go
+++ b/types/parameterized_struct_type_test.go
@@ -39,7 +39,7 @@ func TestParameterizedStructType(t *testing.T) {
 			require.Equal(t, td.expectedHasParameterizedParam, pd.HasParameterizedParam())
 			require.Equal(t, td.expectedParameterizedParams, pd.GetParameterizedParams())
 			assert.Equal(t, "struct", pd.ShortString())
-			retType, err := pd.ReturnType()
+			retType, err := pd.ReturnType(nil, nil)
 			if td.expectedReturnType == nil {
 				assert.Error(t, err)
 				require.True(t, pd.HasParameterizedParam())

--- a/types/parameterized_user_defined_type.go
+++ b/types/parameterized_user_defined_type.go
@@ -26,7 +26,7 @@ func (d *DataTypeUDTParam) String() string {
 }
 
 func (d *DataTypeUDTParam) toTypeParam() (TypeParam, error) {
-	typ, err := d.Type.ReturnType()
+	typ, err := d.Type.ReturnType(nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +191,7 @@ func (m *ParameterizedUserDefinedType) ShortString() string {
 	return fmt.Sprintf("u!%s", m.Name)
 }
 
-func (m *ParameterizedUserDefinedType) ReturnType() (Type, error) {
+func (m *ParameterizedUserDefinedType) ReturnType([]FuncDefArgType, []Type) (Type, error) {
 	var types []TypeParam
 	for _, udtParam := range m.TypeParameters {
 		param, err := udtParam.toTypeParam()

--- a/types/parameterized_user_defined_type_test.go
+++ b/types/parameterized_user_defined_type_test.go
@@ -1,4 +1,4 @@
-package types
+package types_test
 
 import (
 	"fmt"
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	. "github.com/substrait-io/substrait-go/types"
 	"github.com/substrait-io/substrait-go/types/integer_parameters"
 )
 
@@ -43,7 +44,7 @@ func TestParameterizedUserDefinedType(t *testing.T) {
 			require.Equal(t, td.expectedHasParameterizedParam, pd.HasParameterizedParam())
 			require.Equal(t, td.expectedParameterizedParams, pd.GetParameterizedParams())
 			assert.Equal(t, fmt.Sprintf("u!%s", td.name), pd.ShortString())
-			retType, err := pd.ReturnType()
+			retType, err := pd.ReturnType(nil, nil)
 			if td.expectedReturnType == nil {
 				assert.Error(t, err)
 				require.True(t, pd.HasParameterizedParam())

--- a/types/types.go
+++ b/types/types.go
@@ -431,6 +431,10 @@ type (
 	}
 )
 
+var CommonEnumType = &EnumType{}
+
+// EnumType represents an enumeration function parameter.
+// It supports a fixed set of declared string values as constant arguments.
 type EnumType struct {
 	Nullability      Nullability
 	TypeVariationRef uint32
@@ -494,6 +498,9 @@ func (e *EnumType) MatchWithNullability(ot Type) bool {
 }
 
 func (e *EnumType) MatchWithoutNullability(ot Type) bool {
+	if ot == CommonEnumType {
+		return true
+	}
 	if odt, ok := ot.(*EnumType); ok {
 		if e.Name != odt.Name {
 			return false

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -163,6 +163,7 @@ func TestGetShortTypeName(t *testing.T) {
 		{"string", "str"},
 		{"decimal", "dec"},
 		{"unknown", "unknown"},
+		{"enum", "enum"},
 	}
 	for _, tt := range tests {
 		t.Run(string(tt.name), func(t *testing.T) {
@@ -217,6 +218,7 @@ func TestMatchForBasicTypeResultMatch(t *testing.T) {
 		{"timestampTzType", &TimestampTzType{}, &TimestampTzType{}},
 		{"intervalYearType", &IntervalYearType{}, &IntervalYearType{}},
 		{"uuidType", &UUIDType{}, &UUIDType{}},
+		{"enumType", &EnumType{Options: []string{"A", "B", "C"}, Name: "ABC"}, &EnumType{Options: []string{"A", "B", "C"}, Name: "ABC"}},
 	} {
 		t.Run(td.name, func(t *testing.T) {
 			// MatchWithNullability should match exact nullability and not match with different nullability
@@ -319,6 +321,8 @@ func TestMatchParameterizeConcreteTypeResultMismatch(t *testing.T) {
 	concreteInt38 := integer_parameters.NewConcreteIntParam(38)
 	concreteInt2 := integer_parameters.NewConcreteIntParam(2)
 	concreteInt5 := integer_parameters.NewConcreteIntParam(5)
+	enumOptions := []string{"A", "B", "C"}
+	enumType := &EnumType{Options: enumOptions, Name: "ABC"}
 	for _, td := range []struct {
 		name           string
 		paramType      FuncDefArgType
@@ -346,6 +350,7 @@ func TestMatchParameterizeConcreteTypeResultMismatch(t *testing.T) {
 		{"userDefinedType", &ParameterizedUserDefinedType{TypeParameters: []UDTParameter{&IntegerUDTParam{Integer: 10}}, Name: "udt"}, &UserDefinedType{TypeParameters: []TypeParam{&DataTypeParameter{Type: &Int64Type{}}}}},
 		{"userDefinedType", &ParameterizedUserDefinedType{TypeParameters: []UDTParameter{&IntegerUDTParam{Integer: 10}}, Name: "udt"}, &UserDefinedType{TypeParameters: []TypeParam{IntegerParameter(11)}}},
 		{"userDefinedType", &ParameterizedUserDefinedType{TypeParameters: []UDTParameter{&StringUDTParam{StringVal: "L1"}}, Name: "udt"}, &UserDefinedType{TypeParameters: []TypeParam{IntegerParameter(11)}}},
+		{"enumType", &EnumType{Name: "ABCEnum", Options: enumOptions}, enumType},
 	} {
 		t.Run(td.name, func(t *testing.T) {
 			assert.False(t, td.paramType.MatchWithNullability(td.argOfOtherType))
@@ -371,6 +376,9 @@ func TestMatchParameterizedNonNestedTypeResultMatch(t *testing.T) {
 	argIntervalDayType := &IntervalDayType{Precision: 5}
 	paramIntervalDayType := &ParameterizedIntervalDayType{IntegerOption: intParamLen}
 
+	enumOptions := []string{"A", "B", "C"}
+	enumType := &EnumType{Name: "ABCEnum", Options: enumOptions}
+
 	for _, td := range []struct {
 		name      string
 		paramType FuncDefArgType
@@ -383,6 +391,7 @@ func TestMatchParameterizedNonNestedTypeResultMatch(t *testing.T) {
 		{"precisionTimestamp", paramPrecisionTimeStamp, argPrecisionTimeStamp},
 		{"precisionTimestampTz", paramPrecisionTimeStampTz, argPrecisionTimeStampTzType},
 		{"decimalType", paramDecimalType, argDecimalType},
+		{"enumType", &EnumType{Name: "ABCEnum", Options: enumOptions}, enumType},
 	} {
 		t.Run(td.name, func(t *testing.T) {
 			// MatchWithNullability should match exact nullability and not match with different nullability


### PR DESCRIPTION
Fixed bugs in matching variadic arguments.

BREAKING CHANGE: 
- `ArgumentList` has been renamed to `FuncParameterList`. 

BREAKING CHANGE: 
- The `ReturnType` method in the `FuncDefArgType` interface now requires `FuncParameterList` and actual argument types as parameters.

