### PR TITLE
feat: Add a way to get an expr.ExprBuilder from a plan.Builder

### DIFF
--- a/plan/builders.go
+++ b/plan/builders.go
@@ -123,6 +123,10 @@ type Builder interface {
 	// that may be in use with this plan for advanced extensions, optimizations,
 	// and so on.
 	PlanWithTypes(root Rel, rootNames []string, expectedTypeURLs []string, others ...Rel) (*Plan, error)
+
+	// GetExprBuilder returns an expr.ExprBuilder that shares the extension
+	// registry that this Builder uses.
+	GetExprBuilder() *expr.ExprBuilder
 }
 
 const FETCH_COUNT_ALL_RECORDS = -1
@@ -150,6 +154,13 @@ type builder struct {
 	extSet extensions.Set
 
 	reg expr.ExtensionRegistry
+}
+
+func (b *builder) GetExprBuilder() *expr.ExprBuilder {
+	return &expr.ExprBuilder{
+		Reg:        b.reg,
+		BaseSchema: nil,
+	}
 }
 
 func (b *builder) GetFunctionRef(nameSpace, key string) types.FunctionRef {

--- a/plan/plan_builder_test.go
+++ b/plan/plan_builder_test.go
@@ -1115,6 +1115,9 @@ func TestProjectExpressions(t *testing.T) {
 								}
 							}
 							],
+							"options":  [
+							  {}
+							],
 							"outputType": {
 							"fp32": {
 								"nullability": "NULLABILITY_REQUIRED"
@@ -1144,7 +1147,10 @@ func TestProjectExpressions(t *testing.T) {
 	abs, err := b.ScalarFn(arithmeticURI, "abs", nil, ref)
 	require.NoError(t, err)
 
-	add, err := b.ScalarFn(arithmeticURI, "add", nil, abs, ref)
+	add, err := b.GetExprBuilder().ScalarFunc(
+		extensions.ID{URI: arithmeticURI, Name: "add"}, nil).Args(
+		b.GetExprBuilder().Expression(abs),
+		b.GetExprBuilder().Expression(ref)).Build()
 	require.NoError(t, err)
 
 	project, err := b.Project(scan, add)


### PR DESCRIPTION
By creating an`expr.ExprBuilder` directly from the `plan.Builder` the two can share the same extension registry.
