### PR TITLE
feat: update to latest core Substrait

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.9.0
-	github.com/substrait-io/substrait v0.61.0
+	github.com/substrait-io/substrait v0.62.0
 	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842
 	google.golang.org/protobuf v1.33.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/substrait-io/substrait v0.61.0 h1:0kPnocQc+VxZt7GXIRXvWJ8yfjhFhTzRK18sG0At2jQ=
-github.com/substrait-io/substrait v0.61.0/go.mod h1:MPFNw6sToJgpD5Z2rj0rQrdP/Oq8HG7Z2t3CAEHtkHw=
+github.com/substrait-io/substrait v0.62.0 h1:olgrvRKwzKBQJymbbXKopgAE0wZER9U/uVZviL33A0s=
+github.com/substrait-io/substrait v0.62.0/go.mod h1:MPFNw6sToJgpD5Z2rj0rQrdP/Oq8HG7Z2t3CAEHtkHw=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/testcases/parser/parse.go
+++ b/testcases/parser/parse.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"embed"
 	"fmt"
 	"io"
 	"io/fs"
@@ -11,7 +10,7 @@ import (
 	"github.com/substrait-io/substrait-go/types/parser/util"
 )
 
-func ParseTestCaseFileFromFS(fs embed.FS, s string) (*TestFile, error) {
+func ParseTestCaseFileFromFS(fs fs.FS, s string) (*TestFile, error) {
 	file, err := fs.Open(s)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR pulls in the latest testcase changes from Substrait core.

It also modifies the signature of ParseTestCaseFileFromFS so it can additionally be used on other filesystems (including os.DirFS).