### PR TITLE
fix: avoid duplication of variants in registry when function name is overloaded

### DIFF
--- a/functions/registries.go
+++ b/functions/registries.go
@@ -95,6 +95,13 @@ const (
 	POSTFIX
 )
 
+type localFunctionVariant interface {
+	extensions.FunctionVariant
+	LocalName() string
+	Notation() FunctionNotation
+	IsOptionSupported(name string, value string) bool
+}
+
 type LocalFunctionVariant struct {
 	localName        string
 	supportedOptions map[string]extensions.Option


### PR DESCRIPTION
this happens with count_star, where same substrait function name is used for two different functions in the extension