### PR TITLE
bugfix: Fix ReturnType resolution for ParameterizedListType

### DIFF
--- a/types/any_type_test.go
+++ b/types/any_type_test.go
@@ -2,7 +2,7 @@ package types_test
 
 import (
 	"testing"
-
+	
 	"github.com/stretchr/testify/require"
 	. "github.com/substrait-io/substrait-go/v3/types"
 )
@@ -20,6 +20,7 @@ func TestAnyType(t *testing.T) {
 		expectedString     string
 	}{
 		{"any", "any", []FuncDefArgType{&AnyType{Name: "any"}}, []Type{decP30S9}, decP30S9, NullabilityNullable, "any?"},
+		{"List<any>", "any", []FuncDefArgType{&AnyType{Name: "any"}}, []Type{&ListType{Type: decP30S9}}, &ListType{Type: decP30S9}, NullabilityNullable, "any?"},
 		{"anyrequired", "any2", []FuncDefArgType{&Int16Type{}, &AnyType{Name: "any2"}}, []Type{&Int16Type{}, &Int64Type{}}, &Int64Type{}, NullabilityRequired, "any2"},
 		{"anyOtherName", "any1", []FuncDefArgType{&AnyType{Name: "any1"}, &Int32Type{}}, []Type{varchar37, &Int32Type{}}, varchar37, NullabilityNullable, "any1?"},
 		{"T name", "T", []FuncDefArgType{&AnyType{Name: "U"}}, []Type{varchar37}, nil, NullabilityNullable, "T?"},

--- a/types/parameterized_list_type.go
+++ b/types/parameterized_list_type.go
@@ -64,8 +64,10 @@ func (m *ParameterizedListType) ShortString() string {
 	return "list"
 }
 
-func (m *ParameterizedListType) ReturnType([]FuncDefArgType, []Type) (Type, error) {
-	elemType, err := m.Type.ReturnType(nil, nil)
+func (m *ParameterizedListType) ReturnType(
+	funcParams []FuncDefArgType, argTypes []Type,
+) (Type, error) {
+	elemType, err := m.Type.ReturnType(funcParams, argTypes)
 	if err != nil {
 		return nil, err
 	}

--- a/types/parameterized_list_type_test.go
+++ b/types/parameterized_list_type_test.go
@@ -4,7 +4,7 @@ package types_test
 
 import (
 	"testing"
-
+	
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/substrait-io/substrait-go/v3/types"
@@ -29,8 +29,9 @@ func TestParameterizedListType(t *testing.T) {
 		expectedParameterizedParams    []interface{}
 		expectedReturnType             types.Type
 	}{
-		{"parameterized param", decimalType, []any{dec30PS5}, "list?<decimal<P,S>>", "list<decimal<P,S>>", true, []interface{}{decimalType}, nil},
+		{"parameterized param", decimalType, []any{dec30PS5}, "list?<decimal<P,S>>", "list<decimal<P,S>>", true, []interface{}{decimalType}, &types.ListType{Nullability: types.NullabilityRequired, Type: dec30PS5}},
 		{"concrete param", int8Type, []any{int8Type}, "list?<i8>", "list<i8>", false, nil, &types.ListType{Nullability: types.NullabilityRequired, Type: int8Type}},
+		{"list<any>", &types.AnyType{Name: "any"}, []any{int8Type}, "list?<any>", "list<any>", false, nil, &types.ListType{Nullability: types.NullabilityRequired, Type: int8Type}},
 	} {
 		t.Run(td.name, func(t *testing.T) {
 			pd := &types.ParameterizedListType{Type: td.param}
@@ -41,7 +42,7 @@ func TestParameterizedListType(t *testing.T) {
 			require.Equal(t, td.expectedHasParameterizedParam, pd.HasParameterizedParam())
 			require.Equal(t, td.expectedParameterizedParams, pd.GetParameterizedParams())
 			assert.Equal(t, "list", pd.ShortString())
-			retType, err := pd.ReturnType(nil, nil)
+			retType, err := pd.ReturnType([]types.FuncDefArgType{td.param}, []types.Type{td.args[0].(types.Type)})
 			if td.expectedReturnType == nil {
 				assert.Error(t, err)
 				require.True(t, pd.HasParameterizedParam())


### PR DESCRIPTION
Pass required information when resolving the return type of parameterized list type.