### PR TITLE
fix: incorrect proto mapping for SortDescNullsFirst

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -161,7 +161,7 @@ const (
 	SortAscNullsFirst  = SortDirection(proto.SortField_SORT_DIRECTION_ASC_NULLS_FIRST)
 	SortAscNullsLast   = SortDirection(proto.SortField_SORT_DIRECTION_ASC_NULLS_LAST)
 	SortDescNullsFirst = SortDirection(proto.SortField_SORT_DIRECTION_DESC_NULLS_FIRST)
-	SortDescNullsLast  = SortDirection(proto.SortField_SORT_DIRECTION_ASC_NULLS_LAST)
+	SortDescNullsLast  = SortDirection(proto.SortField_SORT_DIRECTION_DESC_NULLS_LAST)
 	SortClustered      = SortDirection(proto.SortField_SORT_DIRECTION_CLUSTERED)
 )
 


### PR DESCRIPTION
`SortDescNullsFirst` was set to `SortField_SORT_DIRECTION_ASC_NULLS_LAST`
Replacing it with `SortField_SORT_DIRECTION_DESC_NULLS_LAST`