### PR TITLE
feat: add a way to set `AdvancedExtension`s for relations

### DIFF
--- a/plan/common.go
+++ b/plan/common.go
@@ -3,6 +3,8 @@
 package plan
 
 import (
+	"fmt"
+
 	"github.com/substrait-io/substrait-go/v4/extensions"
 	"github.com/substrait-io/substrait-go/v4/types"
 	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
@@ -63,6 +65,14 @@ func (rc *RelCommon) setMapping(mapping []int32) {
 
 func (rc *RelCommon) GetAdvancedExtension() *extensions.AdvancedExtension {
 	return rc.advExtension
+}
+
+func (rc *RelCommon) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) error {
+	if rc.advExtension != nil {
+		return fmt.Errorf("AdvancedExtension is already set")
+	}
+	rc.advExtension = advExtension
+	return nil
 }
 
 func (rc *RelCommon) Hint() *Hint {

--- a/plan/common.go
+++ b/plan/common.go
@@ -3,8 +3,6 @@
 package plan
 
 import (
-	"fmt"
-
 	"github.com/substrait-io/substrait-go/v4/extensions"
 	"github.com/substrait-io/substrait-go/v4/types"
 	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
@@ -67,12 +65,10 @@ func (rc *RelCommon) GetAdvancedExtension() *extensions.AdvancedExtension {
 	return rc.advExtension
 }
 
-func (rc *RelCommon) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) error {
-	if rc.advExtension != nil {
-		return fmt.Errorf("AdvancedExtension is already set")
-	}
+func (rc *RelCommon) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) *extensions.AdvancedExtension {
+	existing := rc.advExtension
 	rc.advExtension = advExtension
-	return nil
+	return existing
 }
 
 func (rc *RelCommon) Hint() *Hint {

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -323,7 +323,8 @@ type Rel interface {
 	RecordType() types.RecordType
 
 	GetAdvancedExtension() *extensions.AdvancedExtension
-	SetAdvancedExtension(extension *extensions.AdvancedExtension) error
+	// SetAdvancedExtension sets an AdvancedExtension on this Rel, returning any existing one on this Rel. Use `nil` to remove any existing AdvancedExtension.
+	SetAdvancedExtension(extension *extensions.AdvancedExtension) (existing *extensions.AdvancedExtension)
 
 	ToProto() *proto.Rel
 	ToProtoPlanRel() *proto.PlanRel

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -323,6 +323,8 @@ type Rel interface {
 	RecordType() types.RecordType
 
 	GetAdvancedExtension() *extensions.AdvancedExtension
+	SetAdvancedExtension(extension *extensions.AdvancedExtension) error
+
 	ToProto() *proto.Rel
 	ToProtoPlanRel() *proto.PlanRel
 

--- a/plan/relations.go
+++ b/plan/relations.go
@@ -104,12 +104,10 @@ func (b *baseReadRel) Filter() expr.Expression                             { ret
 func (b *baseReadRel) BestEffortFilter() expr.Expression                   { return b.bestEffortFilter }
 func (b *baseReadRel) Projection() *expr.MaskExpression                    { return b.projection }
 func (b *baseReadRel) GetAdvancedExtension() *extensions.AdvancedExtension { return b.advExtension }
-func (b *baseReadRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) error {
-	if b.advExtension != nil {
-		return fmt.Errorf("AdvancedExtension is already set")
-	}
+func (b *baseReadRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) *extensions.AdvancedExtension {
+	existing := b.advExtension
 	b.advExtension = advExtension
-	return nil
+	return existing
 }
 
 func (b *baseReadRel) SetProjection(p *expr.MaskExpression) {
@@ -639,12 +637,10 @@ func (lf *LocalFileReadRel) GetAdvancedExtension() *extensions.AdvancedExtension
 	return lf.advExtension
 }
 
-func (lf *LocalFileReadRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) error {
-	if lf.advExtension != nil {
-		return fmt.Errorf("AdvancedExtension is already set")
-	}
+func (lf *LocalFileReadRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) *extensions.AdvancedExtension {
+	existing := lf.advExtension
 	lf.advExtension = advExtension
-	return nil
+	return existing
 }
 
 func (lf *LocalFileReadRel) ToProto() *proto.Rel {
@@ -725,12 +721,10 @@ func (p *ProjectRel) Expressions() []expr.Expression { return p.exprs }
 func (p *ProjectRel) GetAdvancedExtension() *extensions.AdvancedExtension {
 	return p.advExtension
 }
-func (p *ProjectRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) error {
-	if p.advExtension != nil {
-		return fmt.Errorf("AdvancedExtension is already set")
-	}
+func (p *ProjectRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) *extensions.AdvancedExtension {
+	existing := p.advExtension
 	p.advExtension = advExtension
-	return nil
+	return existing
 }
 
 func (p *ProjectRel) ToProto() *proto.Rel {
@@ -884,12 +878,10 @@ func (j *JoinRel) Type() JoinType { return j.joinType }
 func (j *JoinRel) GetAdvancedExtension() *extensions.AdvancedExtension {
 	return j.advExtension
 }
-func (j *JoinRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) error {
-	if j.advExtension != nil {
-		return fmt.Errorf("AdvancedExtension is already set")
-	}
+func (j *JoinRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) *extensions.AdvancedExtension {
+	existing := j.advExtension
 	j.advExtension = advExtension
-	return nil
+	return existing
 }
 
 func (j *JoinRel) ToProto() *proto.Rel {
@@ -978,12 +970,10 @@ func (c *CrossRel) Right() Rel { return c.right }
 func (c *CrossRel) GetAdvancedExtension() *extensions.AdvancedExtension {
 	return c.advExtension
 }
-func (c *CrossRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) error {
-	if c.advExtension != nil {
-		return fmt.Errorf("AdvancedExtension is already set")
-	}
+func (c *CrossRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) *extensions.AdvancedExtension {
+	existing := c.advExtension
 	c.advExtension = advExtension
-	return nil
+	return existing
 }
 
 func (c *CrossRel) ToProto() *proto.Rel {
@@ -1051,12 +1041,10 @@ func (f *FetchRel) Count() int64  { return f.count }
 func (f *FetchRel) GetAdvancedExtension() *extensions.AdvancedExtension {
 	return f.advExtension
 }
-func (f *FetchRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) error {
-	if f.advExtension != nil {
-		return fmt.Errorf("AdvancedExtension is already set")
-	}
+func (f *FetchRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) *extensions.AdvancedExtension {
+	existing := f.advExtension
 	f.advExtension = advExtension
-	return nil
+	return existing
 }
 
 func (f *FetchRel) ToProto() *proto.Rel {
@@ -1174,12 +1162,10 @@ func (ar *AggregateRel) Measures() []AggRelMeasure              { return ar.meas
 func (ar *AggregateRel) GetAdvancedExtension() *extensions.AdvancedExtension {
 	return ar.advExtension
 }
-func (ar *AggregateRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) error {
-	if ar.advExtension != nil {
-		return fmt.Errorf("AdvancedExtension is already set")
-	}
+func (ar *AggregateRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) *extensions.AdvancedExtension {
+	existing := ar.advExtension
 	ar.advExtension = advExtension
-	return nil
+	return existing
 }
 
 func (ar *AggregateRel) ToProto() *proto.Rel {
@@ -1347,12 +1333,10 @@ func (sr *SortRel) Sorts() []expr.SortField { return sr.sorts }
 func (sr *SortRel) GetAdvancedExtension() *extensions.AdvancedExtension {
 	return sr.advExtension
 }
-func (sr *SortRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) error {
-	if sr.advExtension != nil {
-		return fmt.Errorf("AdvancedExtension is already set")
-	}
+func (sr *SortRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) *extensions.AdvancedExtension {
+	existing := sr.advExtension
 	sr.advExtension = advExtension
-	return nil
+	return existing
 }
 
 func (sr *SortRel) ToProto() *proto.Rel {
@@ -1439,12 +1423,10 @@ func (fr *FilterRel) Condition() expr.Expression { return fr.cond }
 func (fr *FilterRel) GetAdvancedExtension() *extensions.AdvancedExtension {
 	return fr.advExtension
 }
-func (fr *FilterRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) error {
-	if fr.advExtension != nil {
-		return fmt.Errorf("AdvancedExtension is already set")
-	}
+func (fr *FilterRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) *extensions.AdvancedExtension {
+	existing := fr.advExtension
 	fr.advExtension = advExtension
-	return nil
+	return existing
 }
 
 func (fr *FilterRel) ToProto() *proto.Rel {
@@ -1532,12 +1514,10 @@ func (s *SetRel) Op() SetOp     { return s.op }
 func (s *SetRel) GetAdvancedExtension() *extensions.AdvancedExtension {
 	return s.advExtension
 }
-func (s *SetRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) error {
-	if s.advExtension != nil {
-		return fmt.Errorf("AdvancedExtension is already set")
-	}
+func (s *SetRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) *extensions.AdvancedExtension {
+	existing := s.advExtension
 	s.advExtension = advExtension
-	return nil
+	return existing
 }
 
 func (s *SetRel) ToProto() *proto.Rel {
@@ -1804,12 +1784,10 @@ func (hr *HashJoinRel) Type() HashMergeJoinType { return hr.joinType }
 func (hr *HashJoinRel) GetAdvancedExtension() *extensions.AdvancedExtension {
 	return hr.advExtension
 }
-func (hr *HashJoinRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) error {
-	if hr.advExtension != nil {
-		return fmt.Errorf("AdvancedExtension is already set")
-	}
+func (hr *HashJoinRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) *extensions.AdvancedExtension {
+	existing := hr.advExtension
 	hr.advExtension = advExtension
-	return nil
+	return existing
 }
 
 func (hr *HashJoinRel) ToProto() *proto.Rel {
@@ -1919,12 +1897,10 @@ func (mr *MergeJoinRel) Type() HashMergeJoinType { return mr.joinType }
 func (mr *MergeJoinRel) GetAdvancedExtension() *extensions.AdvancedExtension {
 	return mr.advExtension
 }
-func (mr *MergeJoinRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) error {
-	if mr.advExtension != nil {
-		return fmt.Errorf("AdvancedExtension is already set")
-	}
+func (mr *MergeJoinRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) *extensions.AdvancedExtension {
+	existing := mr.advExtension
 	mr.advExtension = advExtension
-	return nil
+	return existing
 }
 
 func (mr *MergeJoinRel) ToProto() *proto.Rel {

--- a/plan/relations.go
+++ b/plan/relations.go
@@ -104,6 +104,13 @@ func (b *baseReadRel) Filter() expr.Expression                             { ret
 func (b *baseReadRel) BestEffortFilter() expr.Expression                   { return b.bestEffortFilter }
 func (b *baseReadRel) Projection() *expr.MaskExpression                    { return b.projection }
 func (b *baseReadRel) GetAdvancedExtension() *extensions.AdvancedExtension { return b.advExtension }
+func (b *baseReadRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) error {
+	if b.advExtension != nil {
+		return fmt.Errorf("AdvancedExtension is already set")
+	}
+	b.advExtension = advExtension
+	return nil
+}
 
 func (b *baseReadRel) SetProjection(p *expr.MaskExpression) {
 	b.projection = p
@@ -632,6 +639,14 @@ func (lf *LocalFileReadRel) GetAdvancedExtension() *extensions.AdvancedExtension
 	return lf.advExtension
 }
 
+func (lf *LocalFileReadRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) error {
+	if lf.advExtension != nil {
+		return fmt.Errorf("AdvancedExtension is already set")
+	}
+	lf.advExtension = advExtension
+	return nil
+}
+
 func (lf *LocalFileReadRel) ToProto() *proto.Rel {
 	items := make([]*proto.ReadRel_LocalFiles_FileOrFiles, len(lf.items))
 	for i, f := range lf.items {
@@ -709,6 +724,13 @@ func (p *ProjectRel) Input() Rel                     { return p.input }
 func (p *ProjectRel) Expressions() []expr.Expression { return p.exprs }
 func (p *ProjectRel) GetAdvancedExtension() *extensions.AdvancedExtension {
 	return p.advExtension
+}
+func (p *ProjectRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) error {
+	if p.advExtension != nil {
+		return fmt.Errorf("AdvancedExtension is already set")
+	}
+	p.advExtension = advExtension
+	return nil
 }
 
 func (p *ProjectRel) ToProto() *proto.Rel {
@@ -862,6 +884,13 @@ func (j *JoinRel) Type() JoinType { return j.joinType }
 func (j *JoinRel) GetAdvancedExtension() *extensions.AdvancedExtension {
 	return j.advExtension
 }
+func (j *JoinRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) error {
+	if j.advExtension != nil {
+		return fmt.Errorf("AdvancedExtension is already set")
+	}
+	j.advExtension = advExtension
+	return nil
+}
 
 func (j *JoinRel) ToProto() *proto.Rel {
 	outRel := &proto.JoinRel{
@@ -949,6 +978,13 @@ func (c *CrossRel) Right() Rel { return c.right }
 func (c *CrossRel) GetAdvancedExtension() *extensions.AdvancedExtension {
 	return c.advExtension
 }
+func (c *CrossRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) error {
+	if c.advExtension != nil {
+		return fmt.Errorf("AdvancedExtension is already set")
+	}
+	c.advExtension = advExtension
+	return nil
+}
 
 func (c *CrossRel) ToProto() *proto.Rel {
 	return &proto.Rel{
@@ -1014,6 +1050,13 @@ func (f *FetchRel) Offset() int64 { return f.offset }
 func (f *FetchRel) Count() int64  { return f.count }
 func (f *FetchRel) GetAdvancedExtension() *extensions.AdvancedExtension {
 	return f.advExtension
+}
+func (f *FetchRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) error {
+	if f.advExtension != nil {
+		return fmt.Errorf("AdvancedExtension is already set")
+	}
+	f.advExtension = advExtension
+	return nil
 }
 
 func (f *FetchRel) ToProto() *proto.Rel {
@@ -1130,6 +1173,13 @@ func (ar *AggregateRel) GroupingReferences() [][]uint32         { return ar.grou
 func (ar *AggregateRel) Measures() []AggRelMeasure              { return ar.measures }
 func (ar *AggregateRel) GetAdvancedExtension() *extensions.AdvancedExtension {
 	return ar.advExtension
+}
+func (ar *AggregateRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) error {
+	if ar.advExtension != nil {
+		return fmt.Errorf("AdvancedExtension is already set")
+	}
+	ar.advExtension = advExtension
+	return nil
 }
 
 func (ar *AggregateRel) ToProto() *proto.Rel {
@@ -1297,6 +1347,13 @@ func (sr *SortRel) Sorts() []expr.SortField { return sr.sorts }
 func (sr *SortRel) GetAdvancedExtension() *extensions.AdvancedExtension {
 	return sr.advExtension
 }
+func (sr *SortRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) error {
+	if sr.advExtension != nil {
+		return fmt.Errorf("AdvancedExtension is already set")
+	}
+	sr.advExtension = advExtension
+	return nil
+}
 
 func (sr *SortRel) ToProto() *proto.Rel {
 	sorts := make([]*proto.SortField, len(sr.sorts))
@@ -1381,6 +1438,13 @@ func (fr *FilterRel) Input() Rel                 { return fr.input }
 func (fr *FilterRel) Condition() expr.Expression { return fr.cond }
 func (fr *FilterRel) GetAdvancedExtension() *extensions.AdvancedExtension {
 	return fr.advExtension
+}
+func (fr *FilterRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) error {
+	if fr.advExtension != nil {
+		return fmt.Errorf("AdvancedExtension is already set")
+	}
+	fr.advExtension = advExtension
+	return nil
 }
 
 func (fr *FilterRel) ToProto() *proto.Rel {
@@ -1467,6 +1531,13 @@ func (s *SetRel) Inputs() []Rel { return s.inputs }
 func (s *SetRel) Op() SetOp     { return s.op }
 func (s *SetRel) GetAdvancedExtension() *extensions.AdvancedExtension {
 	return s.advExtension
+}
+func (s *SetRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) error {
+	if s.advExtension != nil {
+		return fmt.Errorf("AdvancedExtension is already set")
+	}
+	s.advExtension = advExtension
+	return nil
 }
 
 func (s *SetRel) ToProto() *proto.Rel {
@@ -1733,6 +1804,13 @@ func (hr *HashJoinRel) Type() HashMergeJoinType { return hr.joinType }
 func (hr *HashJoinRel) GetAdvancedExtension() *extensions.AdvancedExtension {
 	return hr.advExtension
 }
+func (hr *HashJoinRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) error {
+	if hr.advExtension != nil {
+		return fmt.Errorf("AdvancedExtension is already set")
+	}
+	hr.advExtension = advExtension
+	return nil
+}
 
 func (hr *HashJoinRel) ToProto() *proto.Rel {
 	keysLeft := make([]*proto.Expression_FieldReference, len(hr.leftKeys))
@@ -1840,6 +1918,13 @@ func (mr *MergeJoinRel) PostJoinFilter() expr.Expression {
 func (mr *MergeJoinRel) Type() HashMergeJoinType { return mr.joinType }
 func (mr *MergeJoinRel) GetAdvancedExtension() *extensions.AdvancedExtension {
 	return mr.advExtension
+}
+func (mr *MergeJoinRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtension) error {
+	if mr.advExtension != nil {
+		return fmt.Errorf("AdvancedExtension is already set")
+	}
+	mr.advExtension = advExtension
+	return nil
 }
 
 func (mr *MergeJoinRel) ToProto() *proto.Rel {

--- a/plan/relations_test.go
+++ b/plan/relations_test.go
@@ -479,7 +479,7 @@ func TestRelations_AdvancedExtensions(t *testing.T) {
 		Enhancement:  val1,
 	}
 
-	val2, err := anypb.New(expr.NewPrimitiveLiteral("foo", false).ToProto())
+	val2, err := anypb.New(expr.NewPrimitiveLiteral("bar", false).ToProto())
 	assert.NoError(t, err)
 
 	exampleAdvancedExtension2 := &extensions.AdvancedExtension{

--- a/plan/relations_test.go
+++ b/plan/relations_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/substrait-io/substrait-go/v4/extensions"
 	"github.com/substrait-io/substrait-go/v4/types"
 	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 func noOpRewrite(e expr.Expression) (expr.Expression, error) {
@@ -410,6 +411,99 @@ func TestRelations_Copy(t *testing.T) {
 				assert.Equal(t, tc.expectedRel, got)
 			}
 		})
+	}
+}
+
+func TestRelations_AdvancedExtensions(t *testing.T) {
+	extReg := expr.NewExtensionRegistry(extensions.NewSet(), extensions.GetDefaultCollectionWithNoError())
+	aggregateFnID := extensions.ID{
+		URI:  extensions.SubstraitDefaultURIPrefix + "functions_arithmetic.yaml",
+		Name: "avg",
+	}
+	aggregateFn, err := expr.NewAggregateFunc(extReg,
+		aggregateFnID, nil, types.AggInvocationAll,
+		types.AggPhaseInitialToResult, nil, createPrimitiveFloat(1.0))
+	require.NoError(t, err)
+
+	aggregateRel := &AggregateRel{input: createVirtualTableReadRel(1),
+		groupingExpressions: []expr.Expression{createPrimitiveFloat(1.0)},
+		groupingReferences:  [][]uint32{{0}},
+		measures:            []AggRelMeasure{{measure: aggregateFn, filter: expr.NewPrimitiveLiteral(false, false)}}}
+	crossRel := &CrossRel{left: createVirtualTableReadRel(1), right: createVirtualTableReadRel(2)}
+	extensionLeafRel := &ExtensionLeafRel{}
+	extensionMultiRel := &ExtensionMultiRel{inputs: []Rel{createVirtualTableReadRel(1), createVirtualTableReadRel(2)}}
+	fetchRel := &FetchRel{input: createVirtualTableReadRel(1), offset: 1, count: 2}
+	filterRel := &FilterRel{input: createVirtualTableReadRel(1), cond: expr.NewPrimitiveLiteral(true, false)}
+	hashJoinRel := &HashJoinRel{left: createVirtualTableReadRel(1), right: createVirtualTableReadRel(2), joinType: HashMergeInner, leftKeys: []*expr.FieldReference{}, rightKeys: []*expr.FieldReference{}, postJoinFilter: expr.NewPrimitiveLiteral(true, false)}
+	joinRel := &JoinRel{left: createVirtualTableReadRel(1), right: createVirtualTableReadRel(2), joinType: JoinTypeInner, expr: expr.NewPrimitiveLiteral(true, false), postJoinFilter: expr.NewPrimitiveLiteral(true, false)}
+	localFileReadRel := &LocalFileReadRel{items: []FileOrFiles{{Path: "path"}}, baseReadRel: baseReadRel{filter: expr.NewPrimitiveLiteral(true, false), bestEffortFilter: expr.NewPrimitiveLiteral(true, false)}}
+	mergeJoinRel := &MergeJoinRel{left: createVirtualTableReadRel(1), right: createVirtualTableReadRel(2), joinType: HashMergeInner, leftKeys: []*expr.FieldReference{}, rightKeys: []*expr.FieldReference{}, postJoinFilter: expr.NewPrimitiveLiteral(true, false)}
+	namedTableReadRel := &NamedTableReadRel{names: []string{"mytest"}, baseReadRel: baseReadRel{filter: expr.NewPrimitiveLiteral(true, false), bestEffortFilter: expr.NewPrimitiveLiteral(true, false)}}
+	projectRel := &ProjectRel{input: createVirtualTableReadRel(1), exprs: []expr.Expression{createPrimitiveFloat(1.0), createPrimitiveFloat(2.0)}}
+	setRel := &SetRel{inputs: []Rel{createVirtualTableReadRel(1), createVirtualTableReadRel(2), createVirtualTableReadRel(3)}, op: SetOpUnionAll}
+	sortRel := &SortRel{input: createVirtualTableReadRel(1), sorts: []expr.SortField{{Expr: createPrimitiveFloat(1.0), Kind: types.SortAscNullsFirst}}}
+	virtualTableReadRel := &VirtualTableReadRel{values: []expr.VirtualTableExpressionValue{[]expr.Expression{&expr.PrimitiveLiteral[int64]{Value: 1}}}}
+	namedTableWriteRel := &NamedTableWriteRel{input: namedTableReadRel}
+	icebergTableReadRel := &IcebergTableReadRel{
+		baseReadRel: baseReadRel{filter: expr.NewPrimitiveLiteral(true, false)},
+		tableType: &Direct{
+			MetadataUri: "s3://bucket/path/to/metadata.json",
+		},
+	}
+
+	relations := []Rel{
+		aggregateRel,
+		crossRel,
+		extensionLeafRel,
+		extensionMultiRel,
+		fetchRel,
+		filterRel,
+		hashJoinRel,
+		joinRel,
+		localFileReadRel,
+		mergeJoinRel,
+		namedTableReadRel,
+		projectRel,
+		setRel,
+		sortRel,
+		virtualTableReadRel,
+		namedTableWriteRel,
+		icebergTableReadRel,
+	}
+
+	val1, err := anypb.New(expr.NewPrimitiveLiteral("foo", false).ToProto())
+	assert.NoError(t, err)
+
+	exampleAdvancedExtension1 := &extensions.AdvancedExtension{
+		Optimization: []*anypb.Any{val1},
+		Enhancement:  val1,
+	}
+
+	val2, err := anypb.New(expr.NewPrimitiveLiteral("foo", false).ToProto())
+	assert.NoError(t, err)
+
+	exampleAdvancedExtension2 := &extensions.AdvancedExtension{
+		Optimization: []*anypb.Any{val2},
+		Enhancement:  val2,
+	}
+
+	for _, relation := range relations {
+		// setting an extension should return the old/existing extension
+		// setting an extension for the first time means the old extension should be nil
+		oldExtension := relation.SetAdvancedExtension(exampleAdvancedExtension1)
+		assert.Nil(t, oldExtension)
+		assert.Equal(t, exampleAdvancedExtension1, relation.GetAdvancedExtension())
+
+		// setting it again
+		oldExtension = relation.SetAdvancedExtension(exampleAdvancedExtension2)
+		assert.Equal(t, exampleAdvancedExtension1, oldExtension)
+		assert.Equal(t, exampleAdvancedExtension2, relation.GetAdvancedExtension())
+
+		// setting it to nil
+		oldExtension = relation.SetAdvancedExtension(nil)
+		assert.Equal(t, exampleAdvancedExtension2, oldExtension)
+		assert.Nil(t, relation.GetAdvancedExtension())
+
 	}
 }
 


### PR DESCRIPTION
In the substrait-go relation `Rel` interface, advanced extensions for each relation can be read with the `GetAdvancedExtension` method, but there is no way to assign advanced extensions to the relations directly. This PR defines a `SetAdvancedExtension` to do this on the interface, and implements it for all the existing relations in substrait-go to enable this feature.