### PR TITLE
fix: set Partitions in windowFuncBuilder Build() method

### DIFF
--- a/expr/binding_test.go
+++ b/expr/binding_test.go
@@ -30,6 +30,9 @@ var (
 	rankID = extensions.ID{
 		URI:  extensions.SubstraitDefaultURIPrefix + "functions_arithmetic.yaml",
 		Name: "rank"}
+	firstValueID = extensions.ID{
+		URI:  extensions.SubstraitDefaultURIPrefix + "functions_arithmetic.yaml",
+		Name: "first_value"}
 	extractID = extensions.ID{
 		URI:  extensions.SubstraitDefaultURIPrefix + "functions_datetime.yaml",
 		Name: "extract"}

--- a/expr/builder.go
+++ b/expr/builder.go
@@ -74,7 +74,9 @@ func (e *ExprBuilder) Enum(val string) enumWrapper { return enumWrapper(val) }
 // can be called before actually loading the extensions as long as the
 // extension identified by the ID is loaded into the registry *before*
 // `Build` is called.
-func (e *ExprBuilder) ScalarFunc(id extensions.ID, opts ...*types.FunctionOption) *scalarFuncBuilder {
+func (e *ExprBuilder) ScalarFunc(
+	id extensions.ID, opts ...*types.FunctionOption,
+) *scalarFuncBuilder {
 	return &scalarFuncBuilder{
 		b:    e,
 		id:   id,
@@ -95,7 +97,9 @@ func (e *ExprBuilder) ScalarFunc(id extensions.ID, opts ...*types.FunctionOption
 // can be called before actually loading the extensions as long as the
 // extension identified by the ID is loaded into the registry *before*
 // `Build` is called.
-func (e *ExprBuilder) WindowFunc(id extensions.ID, opts ...*types.FunctionOption) *windowFuncBuilder {
+func (e *ExprBuilder) WindowFunc(
+	id extensions.ID, opts ...*types.FunctionOption,
+) *windowFuncBuilder {
 	return &windowFuncBuilder{
 		b:    e,
 		id:   id,
@@ -116,7 +120,9 @@ func (e *ExprBuilder) WindowFunc(id extensions.ID, opts ...*types.FunctionOption
 // can be called before actually loading the extensions as long as the
 // extension identified by the ID is loaded into the registry *before*
 // `Build` is called.
-func (e *ExprBuilder) AggFunc(id extensions.ID, opts ...*types.FunctionOption) *aggregateFuncBuilder {
+func (e *ExprBuilder) AggFunc(
+	id extensions.ID, opts ...*types.FunctionOption,
+) *aggregateFuncBuilder {
 	return &aggregateFuncBuilder{
 		b:    e,
 		id:   id,
@@ -264,6 +270,7 @@ func (wb *windowFuncBuilder) Build() (*WindowFunction, error) {
 	}
 
 	wf.Sorts, wf.LowerBound, wf.UpperBound = wb.sortList, wb.lowerBound, wb.upperBound
+	wf.Partitions = parts
 	return wf, nil
 }
 

--- a/expr/builder_test.go
+++ b/expr/builder_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/substrait-io/substrait-go/v4/expr"
 	"github.com/substrait-io/substrait-go/v4/extensions"
 	"github.com/substrait-io/substrait-go/v4/types"
+	"github.com/substrait-io/substrait-protobuf/go/substraitpb"
 )
 
 func TestExprBuilder(t *testing.T) {
@@ -64,6 +65,12 @@ func TestExprBuilder(t *testing.T) {
 			b.WindowFunc(rankID), "invalid expression: non-decomposable window or agg function '{https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml rank}' must use InitialToResult phase"},
 		{"window func", "rank(; phase: AGGREGATION_PHASE_INITIAL_TO_RESULT, invocation: AGGREGATION_INVOCATION_UNSPECIFIED) => i64?",
 			b.WindowFunc(rankID).Phase(types.AggPhaseInitialToResult), ""},
+		{"window func",
+			"first_value(i32(3); partitions: [.field(0) => boolean]; phase: AGGREGATION_PHASE_INITIAL_TO_RESULT, invocation: AGGREGATION_INVOCATION_UNSPECIFIED) => i32",
+			b.WindowFunc(firstValueID).Args(
+				b.Wrap(expr.NewLiteral(int32(3), false))).
+				Phase(types.AggPhaseInitialToResult).
+				Partitions(b.RootRef(expr.NewStructFieldRef(0))), ""},
 		{"nested funcs", "add(extract(YEAR, date(2000-01-01)) => i64, rank(; phase: AGGREGATION_PHASE_INITIAL_TO_RESULT, invocation: AGGREGATION_INVOCATION_ALL) => i64?) => i64?",
 			b.ScalarFunc(addID).Args(
 				b.ScalarFunc(extractID).Args(b.Enum("YEAR"),
@@ -94,6 +101,71 @@ func TestExprBuilder(t *testing.T) {
 				e.ToProto()
 			} else {
 				assert.EqualError(t, err, tt.err)
+			}
+		})
+	}
+}
+
+func TestBoundFromProto(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		proto       *substraitpb.Expression_WindowFunction_Bound
+		expected    expr.Bound
+		expectedStr string
+	}{
+		{
+			name: "nil",
+		},
+		{
+			name:  "nil kind",
+			proto: &substraitpb.Expression_WindowFunction_Bound{},
+		},
+		{
+			name: "unbounded",
+			proto: &substraitpb.Expression_WindowFunction_Bound{
+				Kind: &substraitpb.Expression_WindowFunction_Bound_Unbounded_{},
+			},
+			expected:    expr.Unbounded{},
+			expectedStr: "UNBOUNDED",
+		},
+		{
+			name: "current row",
+			proto: &substraitpb.Expression_WindowFunction_Bound{
+				Kind: &substraitpb.Expression_WindowFunction_Bound_CurrentRow_{},
+			},
+			expected:    expr.CurrentRow{},
+			expectedStr: "CURRENT ROW",
+		},
+		{
+			name: "preceding 42",
+			proto: &substraitpb.Expression_WindowFunction_Bound{
+				Kind: &substraitpb.Expression_WindowFunction_Bound_Preceding_{
+					Preceding: &substraitpb.Expression_WindowFunction_Bound_Preceding{
+						Offset: 42,
+					},
+				},
+			},
+			expected:    expr.PrecedingBound(42),
+			expectedStr: "42 PRECEDING",
+		},
+		{
+			name: "following 42",
+			proto: &substraitpb.Expression_WindowFunction_Bound{
+				Kind: &substraitpb.Expression_WindowFunction_Bound_Following_{
+					Following: &substraitpb.Expression_WindowFunction_Bound_Following{
+						Offset: 42,
+					},
+				},
+			},
+			expected:    expr.FollowingBound(42),
+			expectedStr: "42 FOLLOWING",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bound := expr.BoundFromProto(tc.proto)
+			require.Equal(t, tc.expected, bound)
+			if bound != nil {
+				require.Equal(t, tc.expectedStr, bound.String())
 			}
 		})
 	}

--- a/expr/testdata/expressions.yaml
+++ b/expr/testdata/expressions.yaml
@@ -50,7 +50,7 @@ cases:
     __test:
       type: i32?
       string: |
-        ntile(.field(1) => i8; sort: [{expr: <IfThen>((.field(0) => i32) ?.field(1) => i8)<Else>(i32(1)), SORT_DIRECTION_CLUSTERED}]; [options: {DECOMPOSABLE => [NONE]}]; partitions: [.field(2) => i16]; phase: AGGREGATION_PHASE_INITIAL_TO_RESULT, invocation: AGGREGATION_INVOCATION_ALL) => i32?
+        ntile(.field(1) => i8; sort: [{expr: <IfThen>((.field(0) => i32) ?.field(1) => i8)<Else>(i32(1)), SORT_DIRECTION_CLUSTERED}]; [options: {DECOMPOSABLE => [NONE]}]; partitions: [.field(2) => i16]; bounds: [UNBOUNDED, CURRENT ROW]; phase: AGGREGATION_PHASE_INITIAL_TO_RESULT, invocation: AGGREGATION_INVOCATION_ALL) => i32?
     expression:
       windowFunction:
         functionReference: 5


### PR DESCRIPTION
Window function builder was incorrectly omitting partitions. Fix this.

Add `fmt.Stringer` implementation for window function `Bound` implementations.  Fix nil panic when constructing Bound from proto; Add `BoundFromProto` tests.