### PR TITLE
feat: support aggregate functions in window contexts

### DIFF
--- a/expr/binding_test.go
+++ b/expr/binding_test.go
@@ -39,6 +39,9 @@ var (
 	ntileID = extensions.ID{
 		URI:  extensions.SubstraitDefaultURIPrefix + "functions_arithmetic.yaml",
 		Name: "ntile"}
+	sumID = extensions.ID{
+		URI:  extensions.SubstraitDefaultURIPrefix + "functions_arithmetic.yaml",
+		Name: "sum"}
 
 	boringSchema = types.NamedStruct{
 		Names: []string{

--- a/expr/builder_test.go
+++ b/expr/builder_test.go
@@ -72,6 +72,11 @@ func TestExprBuilder(t *testing.T) {
 				b.Wrap(expr.NewLiteral(int32(3), false))).
 				Phase(types.AggPhaseInitialToResult).
 				Partitions(b.RootRef(expr.NewStructFieldRef(0))), ""},
+		{"agg as window", "sum(i32?(42); partitions: [.field(0) => boolean]; phase: AGGREGATION_PHASE_INITIAL_TO_RESULT, invocation: AGGREGATION_INVOCATION_UNSPECIFIED) => i64?",
+			b.AggregateAsWindowFunc(sumID).Args(
+				b.Wrap(expr.NewLiteral(int32(42), true))).
+				Phase(types.AggPhaseInitialToResult).
+				Partitions(b.RootRef(expr.NewStructFieldRef(0))), ""},
 		{"nested funcs", "add(extract(YEAR, date(2000-01-01)) => i64, rank(; phase: AGGREGATION_PHASE_INITIAL_TO_RESULT, invocation: AGGREGATION_INVOCATION_ALL) => i64?) => i64?",
 			b.ScalarFunc(addID).Args(
 				b.ScalarFunc(extractID).Args(b.Enum("YEAR"),


### PR DESCRIPTION
Aggregate functions, such as `SUM`, can be used in window context: `SUM(x) OVER(PARTITION BY ...)`.

Prior to this PR it was impossible to construct such function since attempt to construct window function would fail (sum is an aggregate), and attempts to set window attributes (partitition, etc) on an aggregate would fail too.

Extend this library to support this use case.