### PR TITLE
fix: EnumType should not have parameterized parameters

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -563,15 +563,11 @@ func (e *EnumType) SetNullability(n Nullability) FuncDefArgType {
 }
 
 func (e *EnumType) HasParameterizedParam() bool {
-	return true
+	return false
 }
 
 func (e *EnumType) GetParameterizedParams() []interface{} {
-	params := make([]interface{}, len(e.Options))
-	for i, p := range e.Options {
-		params[i] = p
-	}
-	return params
+	return nil
 }
 
 func (e *EnumType) MatchWithNullability(ot Type) bool {

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -280,9 +280,39 @@ func TestMatchForBasicTypeResultMisMatch(t *testing.T) {
 		t.Run(td.name, func(t *testing.T) {
 			assert.False(t, td.paramType.MatchWithNullability(td.argOfOtherType))
 			assert.False(t, td.paramType.MatchWithoutNullability(td.argOfOtherType))
+		})
+	}
+}
 
+func TestTypesHaveNoParameterizedParams(t *testing.T) {
+	for _, td := range []struct {
+		name           string
+		paramType      FuncDefArgType
+		argOfOtherType Type
+	}{
+		{"binaryType", &BinaryType{}, &BooleanType{}},
+		{"boolType", &BooleanType{}, &BinaryType{}},
+		{"int8Type", &Int8Type{}, &BinaryType{}},
+		{"int16Type", &Int16Type{}, &BinaryType{}},
+		{"int32Type", &Int32Type{}, &BinaryType{}},
+		{"int64Type", &Int64Type{}, &BinaryType{}},
+		{"float32Type", &Float32Type{}, &BinaryType{}},
+		{"float64Type", &Float64Type{}, &BinaryType{}},
+		{"stringType", &StringType{}, &BinaryType{}},
+		{"timestampType", &TimestampType{}, &BinaryType{}},
+		{"dateType", &DateType{}, &BinaryType{}},
+		{"timeType", &TimeType{}, &BinaryType{}},
+		{"timestampTzType", &TimestampTzType{}, &BinaryType{}},
+		{"intervalYearType", &IntervalYearType{}, &BinaryType{}},
+		{"uuidType", &UUIDType{}, &BinaryType{}},
+		{"enumType", &EnumType{Options: []string{"A", "B", "C"}, Name: "ABC"}, &BinaryType{}},
+	} {
+		t.Run(td.name, func(t *testing.T) {
 			parameters := td.paramType.GetParameterizedParams()
 			assert.Nil(t, parameters)
+
+			hasParameterizedParams := td.paramType.GetParameterizedParams()
+			assert.Nil(t, hasParameterizedParams)
 		})
 	}
 }

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -311,8 +311,8 @@ func TestTypesHaveNoParameterizedParams(t *testing.T) {
 			parameters := td.paramType.GetParameterizedParams()
 			assert.Nil(t, parameters)
 
-			hasParameterizedParams := td.paramType.GetParameterizedParams()
-			assert.Nil(t, hasParameterizedParams)
+			hasParameterizedParams := td.paramType.HasParameterizedParam()
+			assert.False(t, hasParameterizedParams)
 		})
 	}
 }

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -275,6 +275,7 @@ func TestMatchForBasicTypeResultMisMatch(t *testing.T) {
 		{"timestampTzType", &TimestampTzType{}, &BinaryType{}},
 		{"intervalYearType", &IntervalYearType{}, &BinaryType{}},
 		{"uuidType", &UUIDType{}, &BinaryType{}},
+		{"enumType", &EnumType{Options: []string{"A", "B", "C"}, Name: "ABC"}, &BinaryType{}},
 	} {
 		t.Run(td.name, func(t *testing.T) {
 			assert.False(t, td.paramType.MatchWithNullability(td.argOfOtherType))


### PR DESCRIPTION
EnumType was being treated as if its options were parameterized parameters in GetParameterizedParams(), however, GetParameters() returned an empty array. This PR introduces a breaking change - EnumType has no parameterized parameters, and HasParameterizedParams() returns false. 

This inconsistent behavior was causing an issue with resolving return types of functions - see #144 