### PR TITLE
feat: add EmptyVirtualTable to Builder interface 

### DIFF
--- a/plan/builders.go
+++ b/plan/builders.go
@@ -124,6 +124,7 @@ type Builder interface {
 	// Deprecated: Use VirtualTableFromExpr(...).Remap() instead.
 	VirtualTableFromExprRemap(fieldNames []string, remap []int32, values ...expr.VirtualTableExpressionValue) (*VirtualTableReadRel, error)
 	VirtualTableFromExpr(fieldNames []string, values ...expr.VirtualTableExpressionValue) (*VirtualTableReadRel, error)
+	EmptyVirtualTable(fieldNames []string, types []types.Type) (*VirtualTableReadRel, error)
 	IcebergTableFromMetadataFile(metadataURI string, snapshot IcebergSnapshot, schema types.NamedStruct) (*IcebergTableReadRel, error)
 	// Deprecated: Use Sort(...).Remap() instead.
 	SortRemap(input Rel, remap []int32, sorts ...expr.SortField) (*SortRel, error)
@@ -617,6 +618,21 @@ func (b *builder) VirtualTableFromExprRemap(fieldNames []string, remap []int32, 
 
 func (b *builder) VirtualTable(fields []string, values ...expr.StructLiteralValue) (*VirtualTableReadRel, error) {
 	return b.VirtualTableRemap(fields, nil, values...)
+}
+
+func (b *builder) EmptyVirtualTable(fieldNames []string, typeList []types.Type) (*VirtualTableReadRel, error) {
+	baseSchema := types.NamedStruct{
+		Names: fieldNames,
+		Struct: types.StructType{
+			Nullability: types.NullabilityRequired,
+			Types:       typeList,
+		},
+	}
+	return &VirtualTableReadRel{
+		baseReadRel: baseReadRel{
+			baseSchema: baseSchema,
+		},
+	}, nil
 }
 
 func (b *builder) IcebergTableFromMetadataFile(metadataURI string, snapshot IcebergSnapshot, schema types.NamedStruct) (*IcebergTableReadRel, error) {

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -363,7 +363,7 @@ func RelFromProto(rel *proto.Rel, reg expr.ExtensionRegistry) (Rel, error) {
 			}
 		case *proto.ReadRel_VirtualTable_:
 			if len(readType.VirtualTable.Values) > 0 && len(readType.VirtualTable.Expressions) > 0 {
-				return nil, fmt.Errorf("VirtualTable Value can't have both liternal and expression")
+				return nil, fmt.Errorf("VirtualTable cannot declare both Values and Expressions")
 			}
 			var values []expr.VirtualTableExpressionValue
 			for _, v := range readType.VirtualTable.Values {

--- a/plan/plan_builder_test.go
+++ b/plan/plan_builder_test.go
@@ -1629,7 +1629,7 @@ func TestSetRelations(t *testing.T) {
 	checkRoundTrip(t, expectedJSON, p)
 }
 
-func TestEmptyVirtualTable(t *testing.T) {
+func TestColumnlessVirtualTable(t *testing.T) {
 	const expectedJSON = `{
 		` + versionStruct + `,
 		"relations": [
@@ -1647,24 +1647,7 @@ func TestEmptyVirtualTable(t *testing.T) {
 								"expressions": [
 									{},
 									{},
-									{},
-									{},
-									{},
-									{},
-									{},
-									{},
-									{},
-									{},
-									{},
-									{},
-									{},
-									{},
-									{},
-									{},
-									{},
-									{},
-									{},
-									{}									
+									{}
 								]
 							}
 						}
@@ -1676,10 +1659,49 @@ func TestEmptyVirtualTable(t *testing.T) {
 
 	b := plan.NewBuilderDefault()
 
-	virtual, err := b.VirtualTable(nil, make([]expr.StructLiteralValue, 20)...)
+	virtual, err := b.VirtualTable(nil, make([]expr.StructLiteralValue, 3)...)
 	require.NoError(t, err)
 
 	p, err := b.Plan(virtual, []string{})
+	require.NoError(t, err)
+
+	checkRoundTrip(t, expectedJSON, p)
+}
+
+func TestEmptyVirtualTable(t *testing.T) {
+	const expectedJSON = `{
+		` + versionStruct + `,
+		"relations": [
+			{
+				"root": {
+					"input": {
+						"read": {
+							"common": {"direct":{}},
+							"baseSchema": {
+								"names": ["i"],
+								"struct": {
+									"types": [
+										{"i32": {"nullability": "NULLABILITY_REQUIRED"}}
+									],
+									"nullability": "NULLABILITY_REQUIRED"
+								}
+							},
+							"virtualTable": {}
+						}
+					},
+					"names": ["i"]
+				}
+			}
+		]
+	}`
+
+	b := plan.NewBuilderDefault()
+
+	i32Type := types.Int32Type{Nullability: types.NullabilityRequired}
+	virtual, err := b.EmptyVirtualTable([]string{"i"}, []types.Type{&i32Type})
+	require.NoError(t, err)
+
+	p, err := b.Plan(virtual, []string{"i"})
 	require.NoError(t, err)
 
 	checkRoundTrip(t, expectedJSON, p)


### PR DESCRIPTION
BREAKING CHANGE: Builder interface has new EmptyVirtualTable method