### PR TITLE
fix(testcases): normalize decimal literal types to declared column type in aggregate args

### DIFF
--- a/testcases/parser/parse_test.go
+++ b/testcases/parser/parse_test.go
@@ -810,6 +810,7 @@ func TestParseTestWithBadAggregateTests(t *testing.T) {
 	}{
 		{"max((-12, +5)::i8) = -7.0::i8", "no viable alternative at input '-7.0::i8'"},
 		{"max((-12, 'arg')::i32) = -7::i8", "invalid column values"},
+		{"max((4.53, 2.2)::dec<38, 1>) = 4.0::dec<38, 1>", "invalid decimal arg"},
 		{
 			`DEFINE t1(fp32, fp32) = ((20, 20), (-3, -3), (1, 1), (10,10), (5,5))
 corr(t1.col0, t2.col1) = 1::fp64`,

--- a/testcases/parser/parse_test.go
+++ b/testcases/parser/parse_test.go
@@ -488,6 +488,27 @@ sum((9223372036854775806, 1, 1, 1, 1, 10000000000)::i64) [overflow:ERROR] = <!ER
 	assert.Equal(t, []types.Type{&types.Int64Type{Nullability: types.NullabilityRequired}}, tc.GetArgTypes())
 }
 
+func TestParseAggregateFuncDecimalPrecision(t *testing.T) {
+	header := makeAggregateTestHeader("v1.0", "/extensions/functions_arithmetic_decimal.yaml")
+	tests := `# basic
+max((20, -3, 1, -10, 0, 5)::dec<2, 0>) = 20::dec<2, 0>`
+
+	testFile, err := ParseTestCasesFromString(header + tests)
+	require.NoError(t, err)
+	require.Len(t, testFile.TestCases, 1)
+
+	tc := testFile.TestCases[0]
+	require.Len(t, tc.AggregateArgs, 1)
+
+	listLiteral, ok := tc.AggregateArgs[0].Argument.Value.(*expr.NestedLiteral[expr.ListLiteralValue])
+	require.True(t, ok)
+
+	dec2x0 := &types.DecimalType{Precision: 2, Scale: 0, Nullability: types.NullabilityRequired}
+	for i, elem := range listLiteral.Value {
+		assert.Equal(t, dec2x0, elem.GetType(), "element %d has wrong type", i)
+	}
+}
+
 func newInt64List(values ...int64) interface{} {
 	list, _ := literal.NewList(newInt64Values(values...), false)
 	return list
@@ -826,10 +847,10 @@ func TestParseAggregateTestWithVariousTypes(t *testing.T) {
 		{testCaseStr: "f5((1.1, 2.2)::fp64?) = 3.3::fp64?"},
 		{testCaseStr: "f5((1, 2)::decimal) = 3::dec", expTestStr: "f5((1, 2)::decimal<38,0>) = 3::decimal<38,0>"},
 		{testCaseStr: "f5((1.1, 2.2)::dec<38,1>) = 3.3::dec<38,1>", expTestStr: "f5((1.1, 2.2)::decimal<38,1>) = 3.3::decimal<38,1>"},
-		{testCaseStr: "f6((1.1, 2.2)::dec<38,10>) = 3.3::dec<38,10>", expTestStr: "f6((1.1, 2.2)::decimal<38,10>) = 3.3000000000::decimal<38,10>"},
-		{testCaseStr: "f7((1.0, 2)::decimal<38,0>) = 3::decimal<38,0>"},
-		{testCaseStr: "f7((1.0, 2)::decimal?<38,0>) = 3::decimal?<38,0>"},
-		{testCaseStr: "f6((1.1, 2.2, null)::dec?<38,10>) = 3.3::dec<38,10>", expTestStr: "f6((1.1, 2.2, null)::decimal?<38,10>) = 3.3000000000::decimal<38,10>"},
+		{testCaseStr: "f6((1.1, 2.2)::dec<38,10>) = 3.3::dec<38,10>", expTestStr: "f6((1.1000000000, 2.2000000000)::decimal<38,10>) = 3.3000000000::decimal<38,10>"},
+		{testCaseStr: "f7((1.0, 2)::decimal<38,0>) = 3::decimal<38,0>", expTestStr: "f7((1, 2)::decimal<38,0>) = 3::decimal<38,0>"},
+		{testCaseStr: "f7((1.0, 2)::decimal?<38,0>) = 3::decimal?<38,0>", expTestStr: "f7((1, 2)::decimal?<38,0>) = 3::decimal?<38,0>"},
+		{testCaseStr: "f6((1.1, 2.2, null)::dec?<38,10>) = 3.3::dec<38,10>", expTestStr: "f6((1.1000000000, 2.2000000000, null)::decimal?<38,10>) = 3.3000000000::decimal<38,10>"},
 		{testCaseStr: "f8(('1991-01-01', '1991-02-02')::date) = '2001-01-01'::date"},
 		{testCaseStr: "f8(('1991-01-01', '1991-02-02')::date?) = '2001-01-01'::date?"},
 		{testCaseStr: "f8(('13:01:01.2345678', '14:01:01.333')::time) = 123456::i64", expTestStr: "f8(('13:01:01.234567', '14:01:01.333000')::time) = 123456::i64"},

--- a/testcases/parser/visitor.go
+++ b/testcases/parser/visitor.go
@@ -286,7 +286,9 @@ func (v *TestCaseVisitor) VisitTableRows(ctx *baseparser.TableRowsContext) inter
 func (v *TestCaseVisitor) VisitColumnValues(ctx *baseparser.ColumnValuesContext) interface{} {
 	values := make([]expr.Literal, 0, len(ctx.AllLiteral()))
 	for _, literalValue := range ctx.AllLiteral() {
-		values = append(values, v.Visit(literalValue).(expr.Literal))
+		if result := v.Visit(literalValue); result != nil {
+			values = append(values, result.(expr.Literal))
+		}
 	}
 	return values
 }
@@ -798,7 +800,7 @@ func (v *TestCaseVisitor) VisitLiteral(ctx *baseparser.LiteralContext) interface
 			// in compactAggregateFuncCall context, the type is not set, full schema of table may not be available
 			return literal.NewString(ctx.NumericLiteral().GetText(), false)
 		}
-		value := v.getLiteralFromString(nil, ctx.NumericLiteral().GetText(), v.getLiteralTypeInContext())
+		value := v.getLiteralFromString(ctx, ctx.NumericLiteral().GetText(), v.getLiteralTypeInContext())
 		if value == nil {
 			v.ErrorListener.ReportVisitError(ctx, fmt.Errorf("invalid numeric arg %v", ctx.GetText()))
 		}

--- a/testcases/parser/visitor.go
+++ b/testcases/parser/visitor.go
@@ -801,9 +801,6 @@ func (v *TestCaseVisitor) VisitLiteral(ctx *baseparser.LiteralContext) interface
 			return literal.NewString(ctx.NumericLiteral().GetText(), false)
 		}
 		value := v.getLiteralFromString(ctx, ctx.NumericLiteral().GetText(), v.getLiteralTypeInContext())
-		if value == nil {
-			v.ErrorListener.ReportVisitError(ctx, fmt.Errorf("invalid numeric arg %v", ctx.GetText()))
-		}
 		return value
 	}
 

--- a/testcases/parser/visitor.go
+++ b/testcases/parser/visitor.go
@@ -471,8 +471,14 @@ func (v *TestCaseVisitor) getLiteralFromString(ctx antlr.ParserRuleContext, valu
 		decimal, err := literal.NewDecimalFromString(value, false)
 		if err != nil {
 			v.ErrorListener.ReportVisitError(ctx, fmt.Errorf("invalid decimal arg %v", err))
+			return nil
 		}
-		return decimal
+		typed, err := decimal.(expr.WithTypeLiteral).WithType(elementType)
+		if err != nil {
+			v.ErrorListener.ReportVisitError(ctx, fmt.Errorf("invalid decimal arg %v", err))
+			return nil
+		}
+		return typed
 	default:
 		return nil
 	}


### PR DESCRIPTION
When parsing aggregate test cases with typed decimal arguments (e.g. `1.00::dec<38,0>`), the decimal literal was created with natural precision/scale but never rescaled to the declared type. This caused type mismatches when building function invocations.

Fix: call `WithType` on the parsed decimal literal to rescale it to the declared `DecimalType` annotation.