### PR TITLE
fix: return errors for unregistered types and functions in builders

### DIFF
--- a/expr/builder_test.go
+++ b/expr/builder_test.go
@@ -160,9 +160,12 @@ window_functions:
 
 	planBuilder := plan.NewBuilder(&collection)
 
-	customType1 := planBuilder.UserDefinedType("extension:test:custom", "custom_type1")
-	customType2 := planBuilder.UserDefinedType("extension:test:custom", "custom_type2")
-	customType3 := planBuilder.UserDefinedType("extension:test:custom", "custom_type3")
+	customType1, err := planBuilder.UserDefinedType("extension:test:custom", "custom_type1")
+	require.NoError(t, err)
+	customType2, err := planBuilder.UserDefinedType("extension:test:custom", "custom_type2")
+	require.NoError(t, err)
+	customType3, err := planBuilder.UserDefinedType("extension:test:custom", "custom_type3")
+	require.NoError(t, err)
 
 	anyVal, err := anypb.New(expr.NewPrimitiveLiteral("foo", false).ToProto())
 	require.NoError(t, err)

--- a/plan/builders.go
+++ b/plan/builders.go
@@ -26,12 +26,16 @@ type Builder interface {
 	// function identified by its namespace and function name. This also
 	// ensures that any plans built from this builder will contain this
 	// function anchor in its extensions section.
-	GetFunctionRef(nameSpace, key string) types.FunctionRef
+	//
+	// Returns an error if the function does not exist in the extension collection.
+	GetFunctionRef(nameSpace, key string) (types.FunctionRef, error)
 
 	// Construct a user-defined type from the extension namespace and typename,
 	// along with optional type parameters. It will add the type to the internal
 	// extension set if it doesn't already exist and assign it a type reference.
-	UserDefinedType(nameSpace, typeName string, params ...types.TypeParam) types.UserDefinedType
+	//
+	// Returns an error if the type does not exist in the extension collection.
+	UserDefinedType(nameSpace, typeName string, params ...types.TypeParam) (types.UserDefinedType, error)
 	// RootFieldRef constructs a Root Field Reference to the column of the input
 	// relation indicated by the passed in index. This will ensure the output
 	// type is properly propagated based on the reference.
@@ -225,17 +229,27 @@ func (b *builder) GetExprBuilder() *expr.ExprBuilder {
 	}
 }
 
-func (b *builder) GetFunctionRef(nameSpace, key string) types.FunctionRef {
-	return types.FunctionRef(b.extSet.GetFuncAnchor(extensions.ID{URN: nameSpace, Name: key}))
+func (b *builder) GetFunctionRef(nameSpace, key string) (types.FunctionRef, error) {
+	id := extensions.ID{URN: nameSpace, Name: key}
+	_, scalarOk := b.ext.GetScalarFunc(id)
+	_, aggregateOk := b.ext.GetAggregateFunc(id)
+	_, windowOk := b.ext.GetWindowFunc(id)
+	if !scalarOk && !aggregateOk && !windowOk {
+		return 0, fmt.Errorf("%w: could not find function %s in %s", substraitgo.ErrNotFound, key, nameSpace)
+	}
+	return types.FunctionRef(b.extSet.GetFuncAnchor(id)), nil
 }
 
-func (b *builder) UserDefinedType(nameSpace, typeName string, params ...types.TypeParam) types.UserDefinedType {
+func (b *builder) UserDefinedType(nameSpace, typeName string, params ...types.TypeParam) (types.UserDefinedType, error) {
 	id := extensions.ID{URN: nameSpace, Name: typeName}
+	if _, ok := b.ext.GetType(id); !ok {
+		return types.UserDefinedType{}, fmt.Errorf("%w: could not find type %s in %s", substraitgo.ErrNotFound, typeName, nameSpace)
+	}
 	return types.UserDefinedType{
 		Nullability:    types.NullabilityNullable,
 		TypeReference:  b.extSet.GetTypeAnchor(id),
 		TypeParameters: params,
-	}
+	}, nil
 }
 
 func (b *builder) JoinedRecordFieldRef(left, right Rel, index int32) (*expr.FieldReference, error) {

--- a/plan/ctas_plan_test.go
+++ b/plan/ctas_plan_test.go
@@ -86,7 +86,8 @@ func makeConditionExprForLike(t *testing.T, b plan.Builder, scan plan.Rel, colId
 		URN:  "extension:io.substrait:functions_string",
 		Name: "contains:str_str",
 	}
-	b.GetFunctionRef(id.URN, id.Name)
+	_, err := b.GetFunctionRef(id.URN, id.Name)
+	require.NoError(t, err)
 	colIdRef, err := b.RootFieldRef(scan, int32(colId))
 	require.NoError(t, err)
 	scalarExpr, err := b.ScalarFn(id.URN, id.Name, nil, colIdRef, valueLiteral)

--- a/plan/plan_builder_test.go
+++ b/plan/plan_builder_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1078,7 +1079,10 @@ func TestSortRelationKeyEqual(t *testing.T) {
 	ref, err := b.RootFieldRef(scan, 0)
 	require.NoError(t, err)
 
-	sort, err := b.Sort(scan, expr.SortField{Expr: ref, Kind: b.GetFunctionRef(extensions.SubstraitDefaultURNPrefix+"functions_comparison", "equal")})
+	funcRef, err := b.GetFunctionRef(extensions.SubstraitDefaultURNPrefix+"functions_comparison", "equal")
+	require.NoError(t, err)
+
+	sort, err := b.Sort(scan, expr.SortField{Expr: ref, Kind: funcRef})
 	require.NoError(t, err)
 
 	p, err := b.Plan(sort, []string{"a", "b"})
@@ -2411,4 +2415,45 @@ func TestExtensionBuildersErrors(t *testing.T) {
 	_, err = b.ExtensionMulti([]plan.Rel{scan}, nil)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidArg)
 	assert.ErrorContains(t, err, "definition must not be nil")
+}
+
+func TestGetFunctionRefErrors(t *testing.T) {
+	b := plan.NewBuilderDefault()
+
+	t.Run("non-existent function returns error", func(t *testing.T) {
+		_, err := b.GetFunctionRef("nonexistent_namespace", "nonexistent_func:i32")
+		assert.ErrorIs(t, err, substraitgo.ErrNotFound)
+		assert.ErrorContains(t, err, "nonexistent_func:i32")
+	})
+
+	t.Run("existing function succeeds", func(t *testing.T) {
+		ref, err := b.GetFunctionRef(extensions.SubstraitDefaultURNPrefix+"functions_comparison", "equal")
+		assert.NoError(t, err)
+		assert.NotZero(t, ref)
+	})
+}
+
+func TestUserDefinedTypeErrors(t *testing.T) {
+	b := plan.NewBuilderDefault()
+
+	t.Run("non-existent type returns error", func(t *testing.T) {
+		_, err := b.UserDefinedType("nonexistent_namespace", "nonexistent_type")
+		assert.ErrorIs(t, err, substraitgo.ErrNotFound)
+		assert.ErrorContains(t, err, "nonexistent_type")
+	})
+
+	t.Run("existing type succeeds", func(t *testing.T) {
+		collection := extensions.Collection{}
+		err := collection.Load("custom", strings.NewReader(`%YAML 1.2
+---
+urn: extension:test:custom
+types:
+  - name: "my_type"
+`))
+		require.NoError(t, err)
+		cb := plan.NewBuilder(&collection)
+		udt, err := cb.UserDefinedType("extension:test:custom", "my_type")
+		assert.NoError(t, err)
+		assert.NotZero(t, udt.TypeReference)
+	})
 }

--- a/plan/virtual_table_from_expr_test.go
+++ b/plan/virtual_table_from_expr_test.go
@@ -22,7 +22,8 @@ func makeAddExpr(t *testing.T, b plan.Builder, val1, val2 expr.Literal) expr.Exp
 		URN:  "extension:io.substrait:functions_arithmetic",
 		Name: "add:i32_i32",
 	}
-	b.GetFunctionRef(id.URN, id.Name)
+	_, err := b.GetFunctionRef(id.URN, id.Name)
+	require.NoError(t, err)
 	scalarExpr, err := b.ScalarFn(id.URN, id.Name, nil, val1, val2)
 	require.NoError(t, err)
 	return scalarExpr


### PR DESCRIPTION
UserDefinedType and GetFunctionRef silently return nil/zero for non-existent types/functions, now they return errors matching ScalarFn and AggregateFn

this changes the Builder interface signatures to return (value, error) — callers that reference functions or types by URN without loading the extension YAML will need to either load the definitions or use the lower-level extSet directly

closes #203