### PR TITLE
fix(testcases): support SUBSTRAIT_DEPENDENCY header and string-as-enum args

### DIFF
--- a/expr/functions.go
+++ b/expr/functions.go
@@ -368,6 +368,8 @@ func getArgTypes(args []types.FuncArg) []types.Type {
 	argTypes := make([]types.Type, len(args))
 	for i, arg := range args {
 		switch a := arg.(type) {
+		case types.Enum:
+			argTypes[i] = types.CommonEnumType
 		case Expression:
 			argTypes[i] = a.GetType()
 		case types.Type:

--- a/testcases/parser/nodes.go
+++ b/testcases/parser/nodes.go
@@ -102,9 +102,10 @@ func (c *CaseLiteral) updateLiteralType() error {
 }
 
 type TestFileHeader struct {
-	Version     string
-	FuncType    TestFuncType
-	IncludedURI string
+	Version        string
+	FuncType       TestFuncType
+	IncludedURI    string
+	DependencyURIs []string
 }
 
 type TestCase struct {
@@ -356,7 +357,62 @@ func (tc *TestCase) GetScalarFunctionInvocation(reg *expr.ExtensionRegistry, fun
 			return expr.NewScalarFunc(*reg, function.ID(), tc.GetFunctionOptions(), args...)
 		}
 	}
+
+	// Try again, coercing string literal args to enum at positions where the variant
+	// defines an enum parameter. The test case format uses 'VALUE'::str for enum args.
+	for _, function := range funcVariants {
+		if function.ID().URN != id.URN {
+			continue
+		}
+		coercedArgs, coerced := coerceEnumStringArgs(tc.Args, function)
+		if !coerced {
+			continue
+		}
+		coercedTypes := make([]types.Type, len(tc.Args))
+		for i, a := range coercedArgs {
+			if _, isEnum := a.(types.Enum); isEnum {
+				coercedTypes[i] = types.CommonEnumType
+			} else {
+				coercedTypes[i] = tc.Args[i].Type
+			}
+		}
+		isMatch, err1 := function.Match(coercedTypes)
+		if err1 == nil && isMatch {
+			invocation, err2 := expr.NewScalarFunc(*reg, function.ID(), tc.GetFunctionOptions(), coercedArgs...)
+			if err2 == nil {
+				// Update the test case arg types to reflect the coercion so that
+				// subsequent calls to GetArgTypes return consistent results.
+				for i, a := range coercedArgs {
+					if _, isEnum := a.(types.Enum); isEnum {
+						tc.Args[i].Type = types.CommonEnumType
+					}
+				}
+				return invocation, nil
+			}
+		}
+	}
 	return nil, fmt.Errorf("%w: no matching function found  or %s", substraitgo.ErrNotFound, id)
+}
+
+// coerceEnumStringArgs converts string-typed CaseLiteral args to types.Enum values at
+// positions where the function variant expects an EnumArg. Returns the new arg slice
+// and whether any coercions were made.
+func coerceEnumStringArgs(caseLiterals []*CaseLiteral, function *extensions.ScalarFunctionVariant) ([]types.FuncArg, bool) {
+	params := function.Args()
+	coerced := false
+	result := make([]types.FuncArg, len(caseLiterals))
+	for i, lit := range caseLiterals {
+		result[i] = lit.Value
+		if i < len(params) {
+			if _, isEnum := params[i].(extensions.EnumArg); isEnum {
+				if _, isStr := lit.Type.(*types.StringType); isStr {
+					result[i] = types.Enum(lit.Value.ValueString())
+					coerced = true
+				}
+			}
+		}
+	}
+	return result, coerced
 }
 
 func (tc *TestCase) GetAggregateFunctionInvocation(reg *expr.ExtensionRegistry, funcRegistry functions.FunctionRegistry) (*expr.AggregateFunction, error) {

--- a/testcases/parser/parse_test.go
+++ b/testcases/parser/parse_test.go
@@ -926,6 +926,22 @@ func TestParseTestCaseFile(t *testing.T) {
 	assert.Len(t, testFile.TestCases, 13)
 }
 
+func TestParseSubstraitDependency(t *testing.T) {
+	// Verify that SUBSTRAIT_DEPENDENCY headers are parsed and stored on the header.
+	// The arithmetic extension is used here since the function registry supports it;
+	// the dependency URI is just checked for correct parsing.
+	header := "### SUBSTRAIT_SCALAR_TEST: v1.0\n" +
+		"### SUBSTRAIT_INCLUDE: '/extensions/functions_arithmetic.yaml'\n" +
+		"### SUBSTRAIT_DEPENDENCY: '/extensions/functions_comparison.yaml'\n\n"
+	tests := "# basic\nadd(1::i32, 2::i32) = 3::i32\n"
+	testFile, err := ParseTestCasesFromString(header + tests)
+	require.NoError(t, err)
+	require.NotNil(t, testFile)
+	assert.Equal(t, "/extensions/functions_arithmetic.yaml", testFile.Header.IncludedURI)
+	assert.Equal(t, []string{"/extensions/functions_comparison.yaml"}, testFile.Header.DependencyURIs)
+	assert.Len(t, testFile.TestCases, 1)
+}
+
 func TestLoadAllSubstraitTestFiles(t *testing.T) {
 	got := substrait.GetSubstraitTestsFS()
 	filePaths, err := listFiles(got, ".")
@@ -935,9 +951,6 @@ func TestLoadAllSubstraitTestFiles(t *testing.T) {
 	for _, filePath := range filePaths {
 		t.Run(filePath, func(t *testing.T) {
 			switch filePath {
-			case "tests/cases/datetime/extract.test":
-				// TODO deal with enum arguments in testcase
-				t.Skip("Skipping extract.test")
 			case "tests/cases/list/all_match.test",
 				"tests/cases/list/any_match.test",
 				"tests/cases/list/filter.test",

--- a/testcases/parser/visitor.go
+++ b/testcases/parser/visitor.go
@@ -71,7 +71,14 @@ func (v *TestCaseVisitor) VisitDoc(ctx *baseparser.DocContext) interface{} {
 func (v *TestCaseVisitor) VisitHeader(ctx *baseparser.HeaderContext) interface{} {
 	header := v.Visit(ctx.Version()).(*TestFileHeader)
 	header.IncludedURI = v.Visit(ctx.Include()).(string)
+	for _, dep := range ctx.AllDependency() {
+		header.DependencyURIs = append(header.DependencyURIs, v.Visit(dep).(string))
+	}
 	return header
+}
+
+func (v *TestCaseVisitor) VisitDependency(ctx *baseparser.DependencyContext) interface{} {
+	return getRawStringFromStringLiteral(ctx.StringLiteral().GetText())
 }
 
 func (v *TestCaseVisitor) VisitVersion(ctx *baseparser.VersionContext) interface{} {


### PR DESCRIPTION
The test case parser's visitor was ignoring `SUBSTRAIT_DEPENDENCY` header directives even though the ANTLR grammar already parsed the token correctly. `TestFileHeader` now has a `DependencyURIs []string` field, `VisitDependency` is implemented, and `VisitHeader` collects all dependency URIs.

The 23 `extract` test cases were skipped because the `functions_datetime` test file passes enum component arguments as string literals (`'YEAR'::str`), while the function definition uses `EnumArg`. `GetScalarFunctionInvocation` now has a final fallback that coerces string literal args to `types.Enum` at positions where the matched variant defines an `EnumArg`. `getArgTypes` in `expr/functions.go` is also corrected to return `types.CommonEnumType` for `types.Enum` args rather than `nil`.

Closes #226

---
Note: This PR was developed with AI assistance. All changes have been reviewed, and I take full responsibility for this contribution.