### PR TITLE
feat(plan): add ExtensionTable method to Builder interface

### DIFF
--- a/plan/builders.go
+++ b/plan/builders.go
@@ -5,13 +5,12 @@ package plan
 import (
 	"fmt"
 
-	"google.golang.org/protobuf/types/known/anypb"
-
 	substraitgo "github.com/substrait-io/substrait-go/v8"
 	"github.com/substrait-io/substrait-go/v8/expr"
 	"github.com/substrait-io/substrait-go/v8/extensions"
 	"github.com/substrait-io/substrait-go/v8/types"
 	"golang.org/x/exp/slices"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 // Builder is the base object for constructing the various elements of a plan.

--- a/plan/builders.go
+++ b/plan/builders.go
@@ -5,6 +5,8 @@ package plan
 import (
 	"fmt"
 
+	"google.golang.org/protobuf/types/known/anypb"
+
 	substraitgo "github.com/substrait-io/substrait-go/v8"
 	"github.com/substrait-io/substrait-go/v8/expr"
 	"github.com/substrait-io/substrait-go/v8/extensions"
@@ -125,6 +127,7 @@ type Builder interface {
 	VirtualTableFromExprRemap(fieldNames []string, remap []int32, values ...expr.VirtualTableExpressionValue) (*VirtualTableReadRel, error)
 	VirtualTableFromExpr(fieldNames []string, values ...expr.VirtualTableExpressionValue) (*VirtualTableReadRel, error)
 	EmptyVirtualTable(fieldNames []string, types []types.Type) (*VirtualTableReadRel, error)
+	ExtensionTable(detail *anypb.Any, schema types.NamedStruct) *ExtensionTableReadRel
 	IcebergTableFromMetadataFile(metadataURI string, snapshot IcebergSnapshot, schema types.NamedStruct) (*IcebergTableReadRel, error)
 	// Deprecated: Use Sort(...).Remap() instead.
 	SortRemap(input Rel, remap []int32, sorts ...expr.SortField) (*SortRel, error)
@@ -637,6 +640,15 @@ func (b *builder) EmptyVirtualTable(fieldNames []string, typeList []types.Type) 
 			baseSchema: baseSchema,
 		},
 	}, nil
+}
+
+func (b *builder) ExtensionTable(detail *anypb.Any, schema types.NamedStruct) *ExtensionTableReadRel {
+	return &ExtensionTableReadRel{
+		baseReadRel: baseReadRel{
+			baseSchema: schema,
+		},
+		detail: detail,
+	}
 }
 
 func (b *builder) IcebergTableFromMetadataFile(metadataURI string, snapshot IcebergSnapshot, schema types.NamedStruct) (*IcebergTableReadRel, error) {

--- a/plan/plan_builder_test.go
+++ b/plan/plan_builder_test.go
@@ -2451,7 +2451,7 @@ func TestExtensionTable(t *testing.T) {
 	require.NoError(t, err)
 
 	schema := types.NamedStruct{
-		Names:  []string{"a"},
+		Names: []string{"a"},
 		Struct: types.StructType{
 			Nullability: types.NullabilityRequired,
 			Types:       []types.Type{&types.Int32Type{Nullability: types.NullabilityRequired}},

--- a/plan/plan_builder_test.go
+++ b/plan/plan_builder_test.go
@@ -2412,3 +2412,55 @@ func TestExtensionBuildersErrors(t *testing.T) {
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidArg)
 	assert.ErrorContains(t, err, "definition must not be nil")
 }
+
+func TestExtensionTable(t *testing.T) {
+	const expectedJSON = `{
+		` + versionStruct + `,
+		"relations": [
+			{
+				"root": {
+					"input": {
+						"read": {
+							"common": {"direct":{}},
+							"baseSchema": {
+								"names": ["a"],
+								"struct": {
+									"types": [
+										{"i32": {"nullability": "NULLABILITY_REQUIRED"}}
+									],
+									"nullability": "NULLABILITY_REQUIRED"
+								}
+							},
+							"extensionTable": {
+								"detail": {
+									"@type": "type.googleapis.com/google.protobuf.StringValue",
+									"value": "my_custom_table"
+								}
+							}
+						}
+					},
+					"names": ["a"]
+				}
+			}
+		]
+	}`
+
+	b := plan.NewBuilderDefault()
+
+	detail, err := anypb.New(wrapperspb.String("my_custom_table"))
+	require.NoError(t, err)
+
+	schema := types.NamedStruct{
+		Names:  []string{"a"},
+		Struct: types.StructType{
+			Nullability: types.NullabilityRequired,
+			Types:       []types.Type{&types.Int32Type{Nullability: types.NullabilityRequired}},
+		},
+	}
+
+	ext := b.ExtensionTable(detail, schema)
+	p, err := b.Plan(ext, []string{"a"})
+	require.NoError(t, err)
+
+	checkRoundTrip(t, expectedJSON, p)
+}


### PR DESCRIPTION
Adds an ExtensionTable builder method so ExtensionTableReadRel can be constructed programmatically. Previously it was only obtainable via protobuf deserialization.