### PR TITLE
chore(deps): remove use of deprecated gopkg.in/yaml/v3

### DIFF
--- a/expr/expressions_test.go
+++ b/expr/expressions_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/substrait-io/substrait-go/v8/expr"
@@ -21,7 +22,6 @@ import (
 	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
 	"google.golang.org/protobuf/encoding/protojson"
 	pb "google.golang.org/protobuf/proto"
-	"gopkg.in/yaml.v3"
 )
 
 const sampleYAML = `---

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/substrait-io/substrait-protobuf/go v0.85.0
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0
 	google.golang.org/protobuf v1.36.6
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -29,4 +28,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
The gopkg.in/yaml/v3 module has been archived and maintenance moved to a fork maintained by the YAML org.

This module already uses github.com/goccy/go-yaml as a dependency, which can be used as a replacement for these tests so that the direct dependency can be removed.