### PR TITLE
chore(deps): remove use of deprecated golang.org/x/exp/slices

### DIFF
--- a/expr/expression.go
+++ b/expr/expression.go
@@ -4,13 +4,13 @@ package expr
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	substraitgo "github.com/substrait-io/substrait-go/v8"
 	"github.com/substrait-io/substrait-go/v8/extensions"
 	"github.com/substrait-io/substrait-go/v8/types"
 	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
-	"golang.org/x/exp/slices"
 )
 
 // MustExpr is a helper function to avoid having it get written and

--- a/expr/field_reference.go
+++ b/expr/field_reference.go
@@ -4,12 +4,12 @@ package expr
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	substraitgo "github.com/substrait-io/substrait-go/v8"
 	"github.com/substrait-io/substrait-go/v8/types"
 	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
-	"golang.org/x/exp/slices"
 )
 
 // RootRefType is a marker interface for types that can be used as a Root

--- a/expr/functions.go
+++ b/expr/functions.go
@@ -4,13 +4,13 @@ package expr
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	substraitgo "github.com/substrait-io/substrait-go/v8"
 	"github.com/substrait-io/substrait-go/v8/extensions"
 	"github.com/substrait-io/substrait-go/v8/types"
 	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
-	"golang.org/x/exp/slices"
 	pb "google.golang.org/protobuf/proto"
 )
 

--- a/expr/literals.go
+++ b/expr/literals.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -17,15 +18,13 @@ import (
 	substraitgo "github.com/substrait-io/substrait-go/v8"
 	"github.com/substrait-io/substrait-go/v8/types"
 	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
-	"golang.org/x/exp/slices"
 )
 
 // PrimitiveLiteralValue is a type constraint that represents
 // any of the non-nested literal types which are also easily comparable
 // via ==
 type PrimitiveLiteralValue interface {
-	bool | int8 | int16 | ~int32 | ~int64 |
-		float32 | float64 | ~string
+	bool | int8 | int16 | ~int32 | ~int64 | float32 | float64 | ~string
 }
 
 type nestedLiteral interface {
@@ -779,8 +778,7 @@ func getNullability(nullable bool) types.Nullability {
 
 // A PrimitiveLiteral is a literal with one of the types specified in this interface
 type newPrimitiveLiteralTypes interface {
-	bool | int8 | int16 | ~int32 | ~int64 |
-		float32 | float64 | string
+	bool | int8 | int16 | ~int32 | ~int64 | float32 | float64 | string
 }
 
 func NewPrimitiveLiteral[T newPrimitiveLiteralTypes](val T, nullable bool) Literal {

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/substrait-io/substrait v0.87.0
 	github.com/substrait-io/substrait-protobuf/go v0.85.0
-	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0
 	google.golang.org/protobuf v1.36.6
 )
 
@@ -27,6 +26,7 @@ require (
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
+	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/plan/builders.go
+++ b/plan/builders.go
@@ -4,12 +4,12 @@ package plan
 
 import (
 	"fmt"
+	"slices"
 
 	substraitgo "github.com/substrait-io/substrait-go/v8"
 	"github.com/substrait-io/substrait-go/v8/expr"
 	"github.com/substrait-io/substrait-go/v8/extensions"
 	"github.com/substrait-io/substrait-go/v8/types"
-	"golang.org/x/exp/slices"
 	"google.golang.org/protobuf/types/known/anypb"
 )
 

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -7,6 +7,7 @@ package plan
 import (
 	"fmt"
 	"runtime/debug"
+	"slices"
 	"strings"
 
 	substraitgo "github.com/substrait-io/substrait-go/v8"
@@ -15,7 +16,6 @@ import (
 	"github.com/substrait-io/substrait-go/v8/plan/internal"
 	"github.com/substrait-io/substrait-go/v8/types"
 	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
-	"golang.org/x/exp/slices"
 	"google.golang.org/protobuf/types/known/anypb"
 )
 

--- a/plan/relations.go
+++ b/plan/relations.go
@@ -4,13 +4,13 @@ package plan
 
 import (
 	"fmt"
+	"slices"
 
 	substraitgo "github.com/substrait-io/substrait-go/v8"
 	"github.com/substrait-io/substrait-go/v8/expr"
 	"github.com/substrait-io/substrait-go/v8/extensions"
 	"github.com/substrait-io/substrait-go/v8/types"
 	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
-	"golang.org/x/exp/slices"
 	"google.golang.org/protobuf/types/known/anypb"
 )
 


### PR DESCRIPTION
go1.21 added a slices package in stdlib, deprecating the experimental golang.org/x/exp/slice.

This patch replaces the use of the deprecated package in favor of the implementation in stdlib.