### PR TITLE
fix(expr): initialize MapLiteral KeyValue entries before use

### DIFF
--- a/expr/literals.go
+++ b/expr/literals.go
@@ -374,8 +374,10 @@ func (t *MapLiteral) ToProtoLiteral() *proto.Expression_Literal {
 	} else {
 		kv := make([]*proto.Expression_Literal_Map_KeyValue, len(t.Value))
 		for i, v := range t.Value {
-			kv[i].Key = v.Key.ToProtoLiteral()
-			kv[i].Value = v.Value.ToProtoLiteral()
+			kv[i] = &proto.Expression_Literal_Map_KeyValue{
+				Key:   v.Key.ToProtoLiteral(),
+				Value: v.Value.ToProtoLiteral(),
+			}
 		}
 
 		lit.LiteralType = &proto.Expression_Literal_Map_{

--- a/expr/proto_literals_test.go
+++ b/expr/proto_literals_test.go
@@ -39,6 +39,30 @@ func TestToProtoLiteral(t *testing.T) {
 	}
 }
 
+func TestMapLiteralToProtoLiteral(t *testing.T) {
+	mapLit := NewNestedLiteral(MapLiteralValue{
+		{
+			Key:   NewPrimitiveLiteral("foo", false),
+			Value: NewPrimitiveLiteral[int32](1, false),
+		},
+		{
+			Key:   NewPrimitiveLiteral("bar", false),
+			Value: NewPrimitiveLiteral[int32](2, false),
+		},
+	}, false)
+
+	got := mapLit.ToProtoLiteral()
+
+	mapProto := got.GetMap()
+	assert.NotNil(t, mapProto, "expected Map literal type, got %T", got.LiteralType)
+	assert.Len(t, mapProto.KeyValues, 2)
+	for i, kv := range mapProto.KeyValues {
+		assert.NotNil(t, kv, "key-value entry %d is nil", i)
+		assert.NotNil(t, kv.Key, "key at %d is nil", i)
+		assert.NotNil(t, kv.Value, "value at %d is nil", i)
+	}
+}
+
 func TestLiteralFromProtoLiteral(t *testing.T) {
 	intDayToSecVal := &proto.Expression_Literal_IntervalDayToSecond{Days: 1, Seconds: 2, PrecisionMode: &proto.Expression_Literal_IntervalDayToSecond_Precision{Precision: 5}}
 	for _, tc := range []struct {

--- a/expr/proto_literals_test.go
+++ b/expr/proto_literals_test.go
@@ -52,14 +52,25 @@ func TestMapLiteralToProtoLiteral(t *testing.T) {
 	}, false)
 
 	got := mapLit.ToProtoLiteral()
+	expected := &proto.Expression_Literal{
+		LiteralType: &proto.Expression_Literal_Map_{
+			Map: &proto.Expression_Literal_Map{
+				KeyValues: []*proto.Expression_Literal_Map_KeyValue{
+					{
+						Key:   NewPrimitiveLiteral("foo", false).ToProtoLiteral(),
+						Value: NewPrimitiveLiteral[int32](1, false).ToProtoLiteral(),
+					},
+					{
+						Key:   NewPrimitiveLiteral("bar", false).ToProtoLiteral(),
+						Value: NewPrimitiveLiteral[int32](2, false).ToProtoLiteral(),
+					},
+				},
+			},
+		},
+	}
 
-	mapProto := got.GetMap()
-	assert.NotNil(t, mapProto, "expected Map literal type, got %T", got.LiteralType)
-	assert.Len(t, mapProto.KeyValues, 2)
-	for i, kv := range mapProto.KeyValues {
-		assert.NotNil(t, kv, "key-value entry %d is nil", i)
-		assert.NotNil(t, kv.Key, "key at %d is nil", i)
-		assert.NotNil(t, kv.Value, "value at %d is nil", i)
+	if diff := cmp.Diff(got, expected, protocmp.Transform()); diff != "" {
+		t.Errorf("proto didn't match, diff:\n%v", diff)
 	}
 }
 


### PR DESCRIPTION
`MapLiteral.ToProtoLiteral` allocated `kv := make([]*proto.Expression_Literal_Map_KeyValue, len(t.Value))` (a slice of nil pointers) and then wrote to `kv[i].Key` / `kv[i].Value` without creating each element. Any non-empty map literal panicked with a nil pointer dereference when serialized.