### PR TITLE
fix(extensions): default ScalarFunctionImpl.Deterministic to true

### DIFF
--- a/extensions/extension_mgr_test.go
+++ b/extensions/extension_mgr_test.go
@@ -336,6 +336,8 @@ func TestCollection_GetAllScalarFunctions(t *testing.T) {
 				assert.Contains(t, scalarFunctions, sf)
 				// verify that default nullability is set to MIRROR
 				assert.Equal(t, extensions.MirrorNullability, sf.Nullability())
+				// verify that deterministic defaults to true (per substrait spec)
+				assert.True(t, sf.Deterministic())
 			}
 			if tt.isAggregate {
 				af, ok := defaultExtensions.GetAggregateFunc(extensions.ID{URN: tt.urn, Name: tt.signature})
@@ -347,6 +349,78 @@ func TestCollection_GetAllScalarFunctions(t *testing.T) {
 				assert.True(t, ok)
 				assert.Contains(t, windowFunctions, wf)
 			}
+		})
+	}
+}
+
+func TestScalarFunctionImpl_DeterministicYAML(t *testing.T) {
+	const uri = "http://localhost/det.yaml"
+	tests := []struct {
+		name     string
+		yaml     string
+		expected bool
+	}{
+		{
+			name: "omitted defaults to true",
+			yaml: `
+urn: extension:test:det_omitted
+scalar_functions:
+  - name: "f"
+    impls:
+      - args:
+          - name: x
+            value: i8
+        return: i8
+`,
+			expected: true,
+		},
+		{
+			name: "explicit true",
+			yaml: `
+urn: extension:test:det_true
+scalar_functions:
+  - name: "f"
+    impls:
+      - args:
+          - name: x
+            value: i8
+        deterministic: true
+        return: i8
+`,
+			expected: true,
+		},
+		{
+			name: "explicit false is preserved",
+			yaml: `
+urn: extension:test:det_false
+scalar_functions:
+  - name: "f"
+    impls:
+      - args:
+          - name: x
+            value: i8
+        deterministic: false
+        return: i8
+`,
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var c extensions.Collection
+			require.NoError(t, c.Load(uri+tt.name, strings.NewReader(tt.yaml)))
+
+			var urn string
+			for _, line := range strings.Split(tt.yaml, "\n") {
+				if strings.HasPrefix(line, "urn:") {
+					urn = strings.TrimSpace(strings.TrimPrefix(line, "urn:"))
+					break
+				}
+			}
+
+			sf, ok := c.GetScalarFunc(extensions.ID{URN: urn, Name: "f:i8"})
+			require.True(t, ok)
+			assert.Equal(t, tt.expected, sf.Deterministic())
 		})
 	}
 }

--- a/extensions/simple_extension.go
+++ b/extensions/simple_extension.go
@@ -261,12 +261,8 @@ type ScalarFunction struct {
 	Metadata    map[string]any       `yaml:"metadata,omitempty"`
 }
 
-// UnmarshalYAML decodes a ScalarFunction and applies the substrait
-// spec default of `deterministic = true` to each impl, but only for
-// impls where the YAML omits the key. Doing this via a custom decode
-// (rather than a `default:"true"` struct tag) avoids clobbering an
-// explicit `deterministic: false`, which would otherwise be overwritten
-// because false is the zero value that creasty/defaults targets.
+// UnmarshalYAML decodes a ScalarFunction and applies the Substrait default
+// for omitted deterministic values.
 func (s *ScalarFunction) UnmarshalYAML(fn func(interface{}) error) error {
 	type rawImpl struct {
 		ScalarFunctionImpl `yaml:",inline"`
@@ -348,9 +344,8 @@ type AggregateFunction struct {
 	Metadata    map[string]any `yaml:"metadata,omitempty"`
 }
 
-// UnmarshalYAML mirrors ScalarFunction.UnmarshalYAML: it preserves
-// explicit `deterministic: false` on each impl while defaulting an
-// omitted key to true per the substrait spec.
+// UnmarshalYAML decodes an AggregateFunction and applies the Substrait default
+// for omitted deterministic values.
 func (s *AggregateFunction) UnmarshalYAML(fn func(interface{}) error) error {
 	type rawImpl struct {
 		AggregateFunctionImpl `yaml:",inline"`
@@ -431,9 +426,8 @@ type WindowFunction struct {
 	Metadata    map[string]any `yaml:"metadata,omitempty"`
 }
 
-// UnmarshalYAML mirrors ScalarFunction.UnmarshalYAML: it preserves
-// explicit `deterministic: false` on each impl while defaulting an
-// omitted key to true per the substrait spec.
+// UnmarshalYAML decodes a WindowFunction and applies the Substrait default
+// for omitted deterministic values.
 func (s *WindowFunction) UnmarshalYAML(fn func(interface{}) error) error {
 	type rawImpl struct {
 		WindowFunctionImpl `yaml:",inline"`

--- a/extensions/simple_extension.go
+++ b/extensions/simple_extension.go
@@ -261,6 +261,42 @@ type ScalarFunction struct {
 	Metadata    map[string]any       `yaml:"metadata,omitempty"`
 }
 
+// UnmarshalYAML decodes a ScalarFunction and applies the substrait
+// spec default of `deterministic = true` to each impl, but only for
+// impls where the YAML omits the key. Doing this via a custom decode
+// (rather than a `default:"true"` struct tag) avoids clobbering an
+// explicit `deterministic: false`, which would otherwise be overwritten
+// because false is the zero value that creasty/defaults targets.
+func (s *ScalarFunction) UnmarshalYAML(fn func(interface{}) error) error {
+	type rawImpl struct {
+		ScalarFunctionImpl `yaml:",inline"`
+		Deterministic      *bool `yaml:"deterministic,omitempty"`
+	}
+	type rawFn struct {
+		Name        string         `yaml:",omitempty"`
+		Description string         `yaml:",omitempty,flow"`
+		Impls       []rawImpl      `yaml:",omitempty"`
+		Metadata    map[string]any `yaml:"metadata,omitempty"`
+	}
+	var aux rawFn
+	if err := fn(&aux); err != nil {
+		return err
+	}
+	s.Name = aux.Name
+	s.Description = aux.Description
+	s.Metadata = aux.Metadata
+	s.Impls = make([]ScalarFunctionImpl, len(aux.Impls))
+	for i, ri := range aux.Impls {
+		s.Impls[i] = ri.ScalarFunctionImpl
+		if ri.Deterministic != nil {
+			s.Impls[i].Deterministic = *ri.Deterministic
+		} else {
+			s.Impls[i].Deterministic = true
+		}
+	}
+	return nil
+}
+
 func (s *ScalarFunction) GetVariants(urn string) []*ScalarFunctionVariant {
 	out := make([]*ScalarFunctionVariant, len(s.Impls))
 	for i, impl := range s.Impls {
@@ -312,6 +348,39 @@ type AggregateFunction struct {
 	Metadata    map[string]any `yaml:"metadata,omitempty"`
 }
 
+// UnmarshalYAML mirrors ScalarFunction.UnmarshalYAML: it preserves
+// explicit `deterministic: false` on each impl while defaulting an
+// omitted key to true per the substrait spec.
+func (s *AggregateFunction) UnmarshalYAML(fn func(interface{}) error) error {
+	type rawImpl struct {
+		AggregateFunctionImpl `yaml:",inline"`
+		Deterministic         *bool `yaml:"deterministic,omitempty"`
+	}
+	type rawFn struct {
+		Name        string         `yaml:",omitempty"`
+		Description string         `yaml:",omitempty,flow"`
+		Impls       []rawImpl      `yaml:",omitempty"`
+		Metadata    map[string]any `yaml:"metadata,omitempty"`
+	}
+	var aux rawFn
+	if err := fn(&aux); err != nil {
+		return err
+	}
+	s.Name = aux.Name
+	s.Description = aux.Description
+	s.Metadata = aux.Metadata
+	s.Impls = make([]AggregateFunctionImpl, len(aux.Impls))
+	for i, ri := range aux.Impls {
+		s.Impls[i] = ri.AggregateFunctionImpl
+		if ri.Deterministic != nil {
+			s.Impls[i].Deterministic = *ri.Deterministic
+		} else {
+			s.Impls[i].Deterministic = true
+		}
+	}
+	return nil
+}
+
 func (s *AggregateFunction) GetVariants(urn string) []*AggregateFunctionVariant {
 	out := make([]*AggregateFunctionVariant, len(s.Impls))
 	for i, impl := range s.Impls {
@@ -360,6 +429,39 @@ type WindowFunction struct {
 	Description string
 	Impls       []WindowFunctionImpl
 	Metadata    map[string]any `yaml:"metadata,omitempty"`
+}
+
+// UnmarshalYAML mirrors ScalarFunction.UnmarshalYAML: it preserves
+// explicit `deterministic: false` on each impl while defaulting an
+// omitted key to true per the substrait spec.
+func (s *WindowFunction) UnmarshalYAML(fn func(interface{}) error) error {
+	type rawImpl struct {
+		WindowFunctionImpl `yaml:",inline"`
+		Deterministic      *bool `yaml:"deterministic,omitempty"`
+	}
+	type rawFn struct {
+		Name        string         `yaml:",omitempty"`
+		Description string         `yaml:",omitempty,flow"`
+		Impls       []rawImpl      `yaml:",omitempty"`
+		Metadata    map[string]any `yaml:"metadata,omitempty"`
+	}
+	var aux rawFn
+	if err := fn(&aux); err != nil {
+		return err
+	}
+	s.Name = aux.Name
+	s.Description = aux.Description
+	s.Metadata = aux.Metadata
+	s.Impls = make([]WindowFunctionImpl, len(aux.Impls))
+	for i, ri := range aux.Impls {
+		s.Impls[i] = ri.WindowFunctionImpl
+		if ri.Deterministic != nil {
+			s.Impls[i].Deterministic = *ri.Deterministic
+		} else {
+			s.Impls[i].Deterministic = true
+		}
+	}
+	return nil
 }
 
 func (s *WindowFunction) GetVariants(urn string) []*WindowFunctionVariant {


### PR DESCRIPTION
Fixes #239.

The [substrait spec](https://substrait.io/extensions/#scalar-function-properties) defines `deterministic` as defaulting to `true` when omitted, but the `Deterministic` field lacked a `default:` tag (compare to `Nullability` two lines down with `default:"MIRROR"`). On unmarshal an absent yaml field hits Go's bool zero value, so every standard scalar/aggregate/window function loaded from the default collection reported `Deterministic() == false`.

Repro:
```go
v, _ := extensions.GetDefaultCollectionWithNoError().GetScalarFunc(extensions.ID{
    URN:  "extension:io.substrait:functions_arithmetic",
    Name: "multiply:i64_i64",
})
fmt.Println(v.Deterministic()) // false on main, true with this patch
```

Test added asserts `Deterministic()` returns true alongside the existing `MirrorNullability` assertion in `TestCollection_GetAllScalarFunctions`.