### PR TITLE
fix(types): preserve nested nullability in any binding

### DIFF
--- a/extensions/variants.go
+++ b/extensions/variants.go
@@ -681,33 +681,46 @@ func getLeafParameterizedParams(abstractTypes interface{}) []string {
 	panic("invalid non-leaf, non-parameterized type param")
 }
 
+func bindAnyType(anyType *types.AnyType, argType types.Type, bindings map[string]types.Type, ignoreNullability bool) error {
+	// Plain "any" is unconstrained - each occurrence can be a different type.
+	if anyType.Name == "any" {
+		return nil
+	}
+
+	boundType := argType
+	if boundType.GetNullability() == types.NullabilityUnspecified {
+		boundType = boundType.WithNullability(types.NullabilityRequired)
+	}
+	if ignoreNullability {
+		boundType = boundType.WithNullability(types.NullabilityRequired)
+	}
+
+	if existingType, exists := bindings[anyType.Name]; exists {
+		if !existingType.Equals(boundType) {
+			return fmt.Errorf("%w: type parameter %s cannot be both %s and %s",
+				substraitgo.ErrInvalidType, anyType.Name,
+				existingType.ShortString(), boundType.ShortString())
+		}
+	} else {
+		bindings[anyType.Name] = boundType
+	}
+	return nil
+}
+
+func validateTopLevelAnyTypeBinding(nullHandling NullabilityHandling, paramType types.FuncDefArgType, argType types.Type, bindings map[string]types.Type) error {
+	if anyType, ok := paramType.(*types.AnyType); ok {
+		return bindAnyType(anyType, argType, bindings,
+			nullHandling != DiscreteNullability || anyType.Nullability != types.NullabilityRequired)
+	}
+	return validateAnyTypeBinding(nullHandling, paramType, argType, bindings)
+}
+
 // validateAnyTypeBinding validates and records the binding of an AnyType parameter to a concrete type.
-// It recursively handles nested types (lists, maps, structs).
-func validateAnyTypeBinding(nullHandling NullabilityHandling, paramType types.FuncDefArgType, argType types.Type, bindings map[string]types.Type, isTopLevel bool) error {
+// It recursively handles nested types (lists, maps, structs, and functions).
+func validateAnyTypeBinding(nullHandling NullabilityHandling, paramType types.FuncDefArgType, argType types.Type, bindings map[string]types.Type) error {
 	switch p := paramType.(type) {
 	case *types.AnyType:
-		// Plain "any" is unconstrained - each occurrence can be a different type
-		if p.Name == "any" {
-			return nil
-		}
-
-		boundType := argType
-		if boundType.GetNullability() == types.NullabilityUnspecified {
-			boundType = boundType.WithNullability(types.NullabilityRequired)
-		}
-		if p.Nullability != types.NullabilityRequired || (isTopLevel && nullHandling != DiscreteNullability) {
-			boundType = boundType.WithNullability(types.NullabilityRequired)
-		}
-
-		if existingType, exists := bindings[p.Name]; exists {
-			if !existingType.Equals(boundType) {
-				return fmt.Errorf("%w: type parameter %s cannot be both %s and %s",
-					substraitgo.ErrInvalidType, p.Name,
-					existingType.ShortString(), boundType.ShortString())
-			}
-		} else {
-			bindings[p.Name] = boundType
-		}
+		return bindAnyType(p, argType, bindings, p.Nullability != types.NullabilityRequired)
 	case *types.ParameterizedListType:
 		if listType, ok := argType.(*types.ListType); ok {
 			params := listType.GetParameters()
@@ -716,7 +729,7 @@ func validateAnyTypeBinding(nullHandling NullabilityHandling, paramType types.Fu
 				if !ok {
 					return fmt.Errorf("%w: invalid list element type", substraitgo.ErrInvalidType)
 				}
-				if err := validateAnyTypeBinding(nullHandling, p.Type, elementType, bindings, false); err != nil {
+				if err := validateAnyTypeBinding(nullHandling, p.Type, elementType, bindings); err != nil {
 					return err
 				}
 			}
@@ -733,10 +746,10 @@ func validateAnyTypeBinding(nullHandling NullabilityHandling, paramType types.Fu
 				if !ok {
 					return fmt.Errorf("%w: invalid map value type", substraitgo.ErrInvalidType)
 				}
-				if err := validateAnyTypeBinding(nullHandling, p.Key, keyType, bindings, false); err != nil {
+				if err := validateAnyTypeBinding(nullHandling, p.Key, keyType, bindings); err != nil {
 					return err
 				}
-				if err := validateAnyTypeBinding(nullHandling, p.Value, valueType, bindings, false); err != nil {
+				if err := validateAnyTypeBinding(nullHandling, p.Value, valueType, bindings); err != nil {
 					return err
 				}
 			}
@@ -751,7 +764,7 @@ func validateAnyTypeBinding(nullHandling NullabilityHandling, paramType types.Fu
 						if !ok {
 							return fmt.Errorf("%w: invalid struct field type at position %d", substraitgo.ErrInvalidType, i)
 						}
-						if err := validateAnyTypeBinding(nullHandling, fieldType, elementType, bindings, false); err != nil {
+						if err := validateAnyTypeBinding(nullHandling, fieldType, elementType, bindings); err != nil {
 							return err
 						}
 					}
@@ -761,11 +774,11 @@ func validateAnyTypeBinding(nullHandling NullabilityHandling, paramType types.Fu
 	case *types.ParameterizedFuncType:
 		if funcType, ok := argType.(*types.FuncType); ok && len(funcType.ParameterTypes) == len(p.Parameters) {
 			for i, parameterType := range p.Parameters {
-				if err := validateAnyTypeBinding(nullHandling, parameterType, funcType.ParameterTypes[i], bindings, false); err != nil {
+				if err := validateAnyTypeBinding(nullHandling, parameterType, funcType.ParameterTypes[i], bindings); err != nil {
 					return err
 				}
 			}
-			if err := validateAnyTypeBinding(nullHandling, p.Return, funcType.ReturnType, bindings, false); err != nil {
+			if err := validateAnyTypeBinding(nullHandling, p.Return, funcType.ReturnType, bindings); err != nil {
 				return err
 			}
 		}
@@ -798,7 +811,7 @@ func validateConstrainedAnyTypeConsistency(nullHandling NullabilityHandling, fun
 
 	// Validate each argument against its parameter type
 	for i := 0; i < len(expandedFuncParameters) && i < len(argumentTypes); i++ {
-		if err := validateAnyTypeBinding(nullHandling, expandedFuncParameters[i], argumentTypes[i], bindings, true); err != nil {
+		if err := validateTopLevelAnyTypeBinding(nullHandling, expandedFuncParameters[i], argumentTypes[i], bindings); err != nil {
 			return err
 		}
 	}

--- a/extensions/variants.go
+++ b/extensions/variants.go
@@ -159,6 +159,12 @@ func EvaluateTypeExpression(urn string, nullHandling NullabilityHandling, return
 		return outType.WithNullability(types.NullabilityNullable), nil
 	}
 
+	if nullHandling == DeclaredOutputNullability {
+		if anyReturn, ok := returnTypeExpr.(*types.AnyType); ok && anyReturn.Nullability == types.NullabilityRequired {
+			return outType.WithNullability(types.NullabilityRequired), nil
+		}
+	}
+
 	return outType, nil
 }
 
@@ -750,6 +756,17 @@ func validateAnyTypeBinding(nullHandling NullabilityHandling, paramType types.Fu
 						}
 					}
 				}
+			}
+		}
+	case *types.ParameterizedFuncType:
+		if funcType, ok := argType.(*types.FuncType); ok && len(funcType.ParameterTypes) == len(p.Parameters) {
+			for i, parameterType := range p.Parameters {
+				if err := validateAnyTypeBinding(nullHandling, parameterType, funcType.ParameterTypes[i], bindings, false); err != nil {
+					return err
+				}
+			}
+			if err := validateAnyTypeBinding(nullHandling, p.Return, funcType.ReturnType, bindings, false); err != nil {
+				return err
 			}
 		}
 	}

--- a/extensions/variants.go
+++ b/extensions/variants.go
@@ -681,6 +681,8 @@ func getLeafParameterizedParams(abstractTypes interface{}) []string {
 	panic("invalid non-leaf, non-parameterized type param")
 }
 
+// bindAnyType binds a constrained AnyType name to a concrete argument type.
+// When ignoreNullability is true, the binding uses the required version of the argument type.
 func bindAnyType(anyType *types.AnyType, argType types.Type, bindings map[string]types.Type, ignoreNullability bool) error {
 	// Plain "any" is unconstrained - each occurrence can be a different type.
 	if anyType.Name == "any" {
@@ -707,6 +709,7 @@ func bindAnyType(anyType *types.AnyType, argType types.Type, bindings map[string
 	return nil
 }
 
+// validateTopLevelAnyTypeBinding handles top-level argument bindings, where MIRROR and DECLARED_OUTPUT ignore outer argument nullability.
 func validateTopLevelAnyTypeBinding(nullHandling NullabilityHandling, paramType types.FuncDefArgType, argType types.Type, bindings map[string]types.Type) error {
 	if anyType, ok := paramType.(*types.AnyType); ok {
 		return bindAnyType(anyType, argType, bindings,
@@ -715,7 +718,7 @@ func validateTopLevelAnyTypeBinding(nullHandling NullabilityHandling, paramType 
 	return validateAnyTypeBinding(nullHandling, paramType, argType, bindings)
 }
 
-// validateAnyTypeBinding validates and records the binding of an AnyType parameter to a concrete type.
+// validateAnyTypeBinding validates nested AnyType bindings, preserving nullability unless the nested AnyType is declared nullable.
 // It recursively handles nested types (lists, maps, structs, and functions).
 func validateAnyTypeBinding(nullHandling NullabilityHandling, paramType types.FuncDefArgType, argType types.Type, bindings map[string]types.Type) error {
 	switch p := paramType.(type) {

--- a/extensions/variants.go
+++ b/extensions/variants.go
@@ -190,7 +190,7 @@ func matchArguments(nullability NullabilityHandling, paramTypeList FuncParameter
 		return types.AreSyncTypeParametersMatching(funcDefArgList, actualTypes), nil
 	}
 
-	if err := ValidateConstrainedAnyTypeConsistency(funcDefArgList, actualTypes, variadicBehavior); err != nil {
+	if err := validateConstrainedAnyTypeConsistency(nullability, funcDefArgList, actualTypes, variadicBehavior); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -677,27 +677,30 @@ func getLeafParameterizedParams(abstractTypes interface{}) []string {
 
 // validateAnyTypeBinding validates and records the binding of an AnyType parameter to a concrete type.
 // It recursively handles nested types (lists, maps, structs).
-func validateAnyTypeBinding(paramType types.FuncDefArgType, argType types.Type, bindings map[string]types.Type) error {
+func validateAnyTypeBinding(nullHandling NullabilityHandling, paramType types.FuncDefArgType, argType types.Type, bindings map[string]types.Type, isTopLevel bool) error {
 	switch p := paramType.(type) {
 	case *types.AnyType:
 		// Plain "any" is unconstrained - each occurrence can be a different type
 		if p.Name == "any" {
 			return nil
 		}
+
+		boundType := argType
+		if boundType.GetNullability() == types.NullabilityUnspecified {
+			boundType = boundType.WithNullability(types.NullabilityRequired)
+		}
+		if p.Nullability != types.NullabilityRequired || (isTopLevel && nullHandling != DiscreteNullability) {
+			boundType = boundType.WithNullability(types.NullabilityRequired)
+		}
+
 		if existingType, exists := bindings[p.Name]; exists {
-			// Compare base types ignoring nullability. Nullability is enforced separately
-			// at the individual argument level by MatchWithNullability/MatchWithoutNullability
-			// (see matchArgumentAtCommon in variants.go). Here we only validate that all uses
-			// of the same type parameter (e.g., any1) resolve to the same base type.
-			existingBase := existingType.WithNullability(types.NullabilityRequired)
-			argBase := argType.WithNullability(types.NullabilityRequired)
-			if !existingBase.Equals(argBase) {
+			if !existingType.Equals(boundType) {
 				return fmt.Errorf("%w: type parameter %s cannot be both %s and %s",
 					substraitgo.ErrInvalidType, p.Name,
-					existingType.ShortString(), argType.ShortString())
+					existingType.ShortString(), boundType.ShortString())
 			}
 		} else {
-			bindings[p.Name] = argType
+			bindings[p.Name] = boundType
 		}
 	case *types.ParameterizedListType:
 		if listType, ok := argType.(*types.ListType); ok {
@@ -707,7 +710,7 @@ func validateAnyTypeBinding(paramType types.FuncDefArgType, argType types.Type, 
 				if !ok {
 					return fmt.Errorf("%w: invalid list element type", substraitgo.ErrInvalidType)
 				}
-				if err := validateAnyTypeBinding(p.Type, elementType, bindings); err != nil {
+				if err := validateAnyTypeBinding(nullHandling, p.Type, elementType, bindings, false); err != nil {
 					return err
 				}
 			}
@@ -724,10 +727,10 @@ func validateAnyTypeBinding(paramType types.FuncDefArgType, argType types.Type, 
 				if !ok {
 					return fmt.Errorf("%w: invalid map value type", substraitgo.ErrInvalidType)
 				}
-				if err := validateAnyTypeBinding(p.Key, keyType, bindings); err != nil {
+				if err := validateAnyTypeBinding(nullHandling, p.Key, keyType, bindings, false); err != nil {
 					return err
 				}
-				if err := validateAnyTypeBinding(p.Value, valueType, bindings); err != nil {
+				if err := validateAnyTypeBinding(nullHandling, p.Value, valueType, bindings, false); err != nil {
 					return err
 				}
 			}
@@ -742,7 +745,7 @@ func validateAnyTypeBinding(paramType types.FuncDefArgType, argType types.Type, 
 						if !ok {
 							return fmt.Errorf("%w: invalid struct field type at position %d", substraitgo.ErrInvalidType, i)
 						}
-						if err := validateAnyTypeBinding(fieldType, elementType, bindings); err != nil {
+						if err := validateAnyTypeBinding(nullHandling, fieldType, elementType, bindings, false); err != nil {
 							return err
 						}
 					}
@@ -754,8 +757,12 @@ func validateAnyTypeBinding(paramType types.FuncDefArgType, argType types.Type, 
 }
 
 // ValidateConstrainedAnyTypeConsistency validates that all uses of the same AnyN parameter
-// (e.g., any1, any2, etc.) resolve to the same concrete type across all arguments
+// (e.g., any1, any2, etc.) resolve to the same concrete type across all arguments.
 func ValidateConstrainedAnyTypeConsistency(funcParameters []types.FuncDefArgType, argumentTypes []types.Type, variadicBehavior *VariadicBehavior) error {
+	return validateConstrainedAnyTypeConsistency(MirrorNullability, funcParameters, argumentTypes, variadicBehavior)
+}
+
+func validateConstrainedAnyTypeConsistency(nullHandling NullabilityHandling, funcParameters []types.FuncDefArgType, argumentTypes []types.Type, variadicBehavior *VariadicBehavior) error {
 	// For variadic functions, expand the parameter list to match actual arguments
 	expandedFuncParameters := funcParameters
 	if variadicBehavior != nil && len(argumentTypes) > len(funcParameters) {
@@ -774,7 +781,7 @@ func ValidateConstrainedAnyTypeConsistency(funcParameters []types.FuncDefArgType
 
 	// Validate each argument against its parameter type
 	for i := 0; i < len(expandedFuncParameters) && i < len(argumentTypes); i++ {
-		if err := validateAnyTypeBinding(expandedFuncParameters[i], argumentTypes[i], bindings); err != nil {
+		if err := validateAnyTypeBinding(nullHandling, expandedFuncParameters[i], argumentTypes[i], bindings, true); err != nil {
 			return err
 		}
 	}

--- a/extensions/variants_test.go
+++ b/extensions/variants_test.go
@@ -475,12 +475,17 @@ func TestNullabilityAndAnyTypeBindingDocExamples(t *testing.T) {
 		{"h(list<any1>, list<any1>) -> list<any1>", extensions.MirrorNullability, []string{"list?<i32>", "list<i32>"}, "list<any1>", true, "list?<i32>"},
 		{"h(list<any1>, list<any1>) -> list<any1>", extensions.MirrorNullability, []string{"list<i32?>", "list<i32?>"}, "list<any1>", true, "list<i32?>"},
 		{"h(list<any1>, list<any1>) -> list<any1>", extensions.MirrorNullability, []string{"list<i32>", "list<i32?>"}, "list<any1>", false, ""},
+		{"k(func<any1 -> any1>) -> any1", extensions.MirrorNullability, []string{"func<i32 -> i32>"}, "any1", true, "i32"},
+		{"k(func<any1 -> any1>) -> any1", extensions.MirrorNullability, []string{"func<i32 -> fp64>"}, "any1", false, ""},
 		{"j(any1, list<any1?>) -> any1", extensions.MirrorNullability, []string{"i32", "list<i32?>"}, "any1", true, "i32"},
 		{"j(any1, list<any1?>) -> any1", extensions.MirrorNullability, []string{"i32", "list<i32>"}, "any1", false, ""},
 		{"j(any1, list<any1?>) -> any1", extensions.MirrorNullability, []string{"i32", "list<fp64?>"}, "any1", false, ""},
 		{"d(any1, any1) -> any1?", extensions.DeclaredOutputNullability, []string{"i32", "i32"}, "any1?", true, "i32?"},
 		{"d(any1, any1) -> any1?", extensions.DeclaredOutputNullability, []string{"i32?", "i32"}, "any1?", true, "i32?"},
 		{"d(any1, any1) -> any1?", extensions.DeclaredOutputNullability, []string{"i32?", "i32?"}, "any1?", true, "i32?"},
+		{"d(any1, any1) -> any1", extensions.DeclaredOutputNullability, []string{"i32", "i32"}, "any1", true, "i32"},
+		{"d(any1, any1) -> any1", extensions.DeclaredOutputNullability, []string{"i32?", "i32"}, "any1", true, "i32"},
+		{"d(any1, any1) -> any1", extensions.DeclaredOutputNullability, []string{"i32?", "i32?"}, "any1", true, "i32"},
 		{"g(any1, any1) -> any1", extensions.DiscreteNullability, []string{"i32", "i32"}, "any1", true, "i32"},
 		{"g(any1, any1) -> any1", extensions.DiscreteNullability, []string{"i32?", "i32?"}, "any1", false, ""},
 		{"g(any1, any1) -> any1", extensions.DiscreteNullability, []string{"i32", "i32?"}, "any1", false, ""},
@@ -906,6 +911,45 @@ func TestValidateConstrainedAnyTypeConsistency(t *testing.T) {
 		err := extensions.ValidateConstrainedAnyTypeConsistency(params, args, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "type parameter any1 cannot be both i32 and i64")
+	})
+
+	t.Run("nested function types with matching parameter and return types", func(t *testing.T) {
+		// func(func<any1 -> any1>) with (func<i32 -> i32>)
+		params := []types.FuncDefArgType{
+			&types.ParameterizedFuncType{
+				Parameters: []types.FuncDefArgType{&types.AnyType{Name: "any1"}},
+				Return:     &types.AnyType{Name: "any1"},
+			},
+		}
+		args := []types.Type{
+			&types.FuncType{
+				ParameterTypes: []types.Type{&types.Int32Type{}},
+				ReturnType:     &types.Int32Type{},
+			},
+		}
+
+		err := extensions.ValidateConstrainedAnyTypeConsistency(params, args, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("nested function types with mismatched return type fail", func(t *testing.T) {
+		// func(func<any1 -> any1>) with (func<i32 -> fp64>)
+		params := []types.FuncDefArgType{
+			&types.ParameterizedFuncType{
+				Parameters: []types.FuncDefArgType{&types.AnyType{Name: "any1"}},
+				Return:     &types.AnyType{Name: "any1"},
+			},
+		}
+		args := []types.Type{
+			&types.FuncType{
+				ParameterTypes: []types.Type{&types.Int32Type{}},
+				ReturnType:     &types.Float64Type{},
+			},
+		}
+
+		err := extensions.ValidateConstrainedAnyTypeConsistency(params, args, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "type parameter any1 cannot be both i32 and fp64")
 	})
 
 	t.Run("single any1 parameter is always valid", func(t *testing.T) {

--- a/extensions/variants_test.go
+++ b/extensions/variants_test.go
@@ -442,6 +442,87 @@ func valArg(typ types.FuncDefArgType) extensions.ValueArg {
 	return extensions.ValueArg{Value: &parser.TypeExpression{ValueType: typ}}
 }
 
+func mustParseFuncDefArg(t *testing.T, typeExpression string) types.FuncDefArgType {
+	t.Helper()
+
+	typ, err := parser.ParseType(typeExpression)
+	require.NoError(t, err)
+	return typ
+}
+
+func mustParseConcreteType(t *testing.T, typeExpression string) types.Type {
+	t.Helper()
+
+	typ, err := mustParseFuncDefArg(t, typeExpression).ReturnType(nil, nil)
+	require.NoError(t, err)
+	return typ
+}
+
+func TestNullabilityAndAnyTypeBindingDocExamples(t *testing.T) {
+	tests := []struct {
+		definition          string
+		nullabilityHandling extensions.NullabilityHandling
+		argTypes            []string
+		returnType          string
+		matches             bool
+		expectedReturnType  string
+	}{
+		{"f(any1, any1) -> any1", extensions.MirrorNullability, []string{"i32", "i32"}, "any1", true, "i32"},
+		{"f(any1, any1) -> any1", extensions.MirrorNullability, []string{"i32?", "i32"}, "any1", true, "i32?"},
+		{"f(any1, any1) -> any1", extensions.MirrorNullability, []string{"i32", "i32?"}, "any1", true, "i32?"},
+		{"f(any1, any1) -> any1", extensions.MirrorNullability, []string{"i32?", "i32?"}, "any1", true, "i32?"},
+		{"h(list<any1>, list<any1>) -> list<any1>", extensions.MirrorNullability, []string{"list<i32>", "list<i32>"}, "list<any1>", true, "list<i32>"},
+		{"h(list<any1>, list<any1>) -> list<any1>", extensions.MirrorNullability, []string{"list?<i32>", "list<i32>"}, "list<any1>", true, "list?<i32>"},
+		{"h(list<any1>, list<any1>) -> list<any1>", extensions.MirrorNullability, []string{"list<i32?>", "list<i32?>"}, "list<any1>", true, "list<i32?>"},
+		{"h(list<any1>, list<any1>) -> list<any1>", extensions.MirrorNullability, []string{"list<i32>", "list<i32?>"}, "list<any1>", false, ""},
+		{"j(any1, list<any1?>) -> any1", extensions.MirrorNullability, []string{"i32", "list<i32?>"}, "any1", true, "i32"},
+		{"j(any1, list<any1?>) -> any1", extensions.MirrorNullability, []string{"i32", "list<i32>"}, "any1", false, ""},
+		{"j(any1, list<any1?>) -> any1", extensions.MirrorNullability, []string{"i32", "list<fp64?>"}, "any1", false, ""},
+		{"d(any1, any1) -> any1?", extensions.DeclaredOutputNullability, []string{"i32", "i32"}, "any1?", true, "i32?"},
+		{"d(any1, any1) -> any1?", extensions.DeclaredOutputNullability, []string{"i32?", "i32"}, "any1?", true, "i32?"},
+		{"d(any1, any1) -> any1?", extensions.DeclaredOutputNullability, []string{"i32?", "i32?"}, "any1?", true, "i32?"},
+		{"g(any1, any1) -> any1", extensions.DiscreteNullability, []string{"i32", "i32"}, "any1", true, "i32"},
+		{"g(any1, any1) -> any1", extensions.DiscreteNullability, []string{"i32?", "i32?"}, "any1", false, ""},
+		{"g(any1, any1) -> any1", extensions.DiscreteNullability, []string{"i32", "i32?"}, "any1", false, ""},
+		{"g2(any1, any1?) -> any1?", extensions.DiscreteNullability, []string{"i32", "i32?"}, "any1?", true, "i32?"},
+		{"g2(any1, any1?) -> any1?", extensions.DiscreteNullability, []string{"i32", "i32"}, "any1?", false, ""},
+		{"g2(any1, any1?) -> any1?", extensions.DiscreteNullability, []string{"i32?", "i32?"}, "any1?", false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.definition+" with "+strings.Join(tt.argTypes, ", "), func(t *testing.T) {
+			funcParams := strings.TrimSuffix(strings.TrimPrefix(tt.definition[strings.Index(tt.definition, "("):strings.Index(tt.definition, ")")], "("), ")")
+			paramExpressions := strings.Split(funcParams, ", ")
+			parameters := make(extensions.FuncParameterList, len(paramExpressions))
+			for i, paramExpression := range paramExpressions {
+				parameters[i] = valArg(mustParseFuncDefArg(t, paramExpression))
+			}
+
+			arguments := make([]types.Type, len(tt.argTypes))
+			for i, argType := range tt.argTypes {
+				arguments[i] = mustParseConcreteType(t, argType)
+			}
+
+			actual, err := extensions.EvaluateTypeExpression(
+				"extension:test:def",
+				tt.nullabilityHandling,
+				mustParseFuncDefArg(t, tt.returnType),
+				parameters,
+				nil,
+				arguments,
+				extensions.NewSet())
+
+			if !tt.matches {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.True(t, mustParseConcreteType(t, tt.expectedReturnType).Equals(actual))
+		})
+	}
+}
+
 func TestResolveType(t *testing.T) {
 	// Test TypeReference setting logic for user-defined types
 	tests := []struct {

--- a/testcases/parser/parse_test.go
+++ b/testcases/parser/parse_test.go
@@ -175,20 +175,20 @@ func TestParseTestWithVariousTypes(t *testing.T) {
 		{testCaseStr: "f10('P10Y5M'::iyear, 5::i64) = 'P15Y5M'::iyear", expTestStr: "f10('P10Y5M'::interval_year, 5::i64) = 'P15Y5M'::interval_year"},
 		{testCaseStr: "f11('P10DT5H6M7S'::interval_day, 5::i64) = 'P10DT10H6M7S'::interval_day", expTestStr: "f11('P10DT5H6M7S'::interval_day<0>, 5::i64) = 'P10DT10H6M7S'::interval_day<0>"},
 		{testCaseStr: "f11('P10DT6M7S'::interval_day, 5::i64) = 'P10DT11M7S'::interval_day", expTestStr: "f11('P10DT6M7S'::interval_day<0>, 5::i64) = 'P10DT11M7S'::interval_day<0>"},
-		{testCaseStr: "or(false::bool, null::bool) = null::bool", expTestStr: "or(false::boolean, null::boolean?) = null::boolean?"},
+		{testCaseStr: "or(false::bool, null::bool?) = null::bool?", expTestStr: "or(false::boolean, null::boolean?) = null::boolean?"},
 		{testCaseStr: "f12('a'::vchar<9>, 'b'::varchar<4>) = 'c'::varchar<3>", expTestStr: "f12('a'::varchar<9>, 'b'::varchar<4>) = 'c'::varchar<3>"},
 		{testCaseStr: "f8('1991-01-01T01:02:03.456'::pts<3>, '1991-01-01T00:00:00.000000'::pts<6>) = '1991-01-01T22:33:44'::pts<0>", expTestStr: "f8('1991-01-01T01:02:03.456'::precision_timestamp<3>, '1991-01-01T00:00:00'::precision_timestamp<6>) = '1991-01-01T22:33:44'::precision_timestamp<0>"},
 		{testCaseStr: "f8('1991-01-01T01:02:03.456+05:30'::ptstz<3>, '1991-01-01T00:00:00+15:30'::ptstz<0>) = '1991-01-01T22:33:44+15:30'::ptstz<0>", expTestStr: "f8('1990-12-31T19:32:03.456+00:00'::precision_timestamp_tz<3>, '1990-12-31T08:30:00.000+00:00'::precision_timestamp_tz<0>) = '1991-01-01T07:03:44.000+00:00'::precision_timestamp_tz<0>"},
 		//{"f12('P10DT6M7.2000S'::iday<4>, 5::i64) = 'P10DT11M7.2000S'::iday<4>"},  // TODO enable after fixing the grammar
 		{testCaseStr: "f12('P10DT6M7S'::interval_day, 5::i64) = 'P10DT11M7S'::interval_day", expTestStr: "f12('P10DT6M7S'::interval_day<0>, 5::i64) = 'P10DT11M7S'::interval_day<0>"},
-		{testCaseStr: "concat('abcd'::varchar<9>, Null::str) [null_handling:ACCEPT_NULLS] = Null::str", expTestStr: "concat('abcd'::varchar<9>, null::string?) [null_handling:ACCEPT_NULLS] = null::string?"},
-		{testCaseStr: "concat('abcd'::varchar<9>, null::string) [null_handling:ACCEPT_NULLS] = null::string", expTestStr: "concat('abcd'::varchar<9>, null::string?) [null_handling:ACCEPT_NULLS] = null::string?"},
+		{testCaseStr: "concat('abcd'::varchar<9>, Null::str?) [null_handling:ACCEPT_NULLS] = Null::str?", expTestStr: "concat('abcd'::varchar<9>, null::string?) [null_handling:ACCEPT_NULLS] = null::string?"},
+		{testCaseStr: "concat('abcd'::varchar<9>, null::string?) [null_handling:ACCEPT_NULLS] = null::string?", expTestStr: "concat('abcd'::varchar<9>, null::string?) [null_handling:ACCEPT_NULLS] = null::string?"},
 		{testCaseStr: "concat('abcd'::varchar<9>, null::varchar?<9>) [null_handling:ACCEPT_NULLS] = null::varchar?<9>"},
 		{testCaseStr: "concat('abcd'::vchar<9>, 'ef'::varchar<9>) = 'abcdef'::vchar<9>", expTestStr: "concat('abcd'::varchar<9>, 'ef'::varchar<9>) = 'abcdef'::varchar<9>"},
 		{testCaseStr: "concat('abcd'::fchar<9>, 'ef'::fixedchar<9>) = 'abcdef'::fchar<9>", expTestStr: "concat('abcd'::fixedchar<9>, 'ef'::fixedchar<9>) = 'abcdef'::fixedchar<9>"},
-		{testCaseStr: "concat('abcd'::vchar<9>, Null::varchar<9>) = Null::vchar<9>", expTestStr: "concat('abcd'::varchar<9>, null::varchar?<9>) = null::varchar?<9>"},
-		{testCaseStr: "concat('abcd'::vchar<9>, Null::fixedchar<9>) = Null::fchar<9>", expTestStr: "concat('abcd'::varchar<9>, null::fixedchar?<9>) = null::fixedchar?<9>"},
-		{testCaseStr: "concat('abcd'::fbin<9>, Null::fixedbinary<9>) = Null::fbin<9>", expTestStr: "concat('0x61626364'::fixedbinary<9>, null::fixedbinary?<9>) = null::fixedbinary?<9>"},
+		{testCaseStr: "concat('abcd'::vchar<9>, Null::varchar?<9>) = Null::vchar?<9>", expTestStr: "concat('abcd'::varchar<9>, null::varchar?<9>) = null::varchar?<9>"},
+		{testCaseStr: "concat('abcd'::vchar<9>, Null::fixedchar?<9>) = Null::fchar?<9>", expTestStr: "concat('abcd'::varchar<9>, null::fixedchar?<9>) = null::fixedchar?<9>"},
+		{testCaseStr: "concat('abcd'::fbin<9>, Null::fixedbinary?<9>) = Null::fbin?<9>", expTestStr: "concat('0x61626364'::fixedbinary<9>, null::fixedbinary?<9>) = null::fixedbinary?<9>"},
 		{testCaseStr: "extract(YEAR::enum, '2016-12-31T13:30:15'::ts) = 2016::i64", expTestStr: "extract(YEAR::enum, '2016-12-31T13:30:15'::timestamp) = 2016::i64"},
 		{testCaseStr: "f35('1991-01-01T01:02:03.456'::pts<3>) = '1991-01-01T01:02:30.123123'::precision_timestamp<3>", expTestStr: "f35('1991-01-01T01:02:03.456'::precision_timestamp<3>) = '1991-01-01T01:02:30.123'::precision_timestamp<3>"},
 		{testCaseStr: "f36('1991-01-01T01:02:03.456'::pts<3>, '1991-01-01T01:02:30.123123'::precision_timestamp<3>) = 123456::i64", expTestStr: "f36('1991-01-01T01:02:03.456'::precision_timestamp<3>, '1991-01-01T01:02:30.123'::precision_timestamp<3>) = 123456::i64"},
@@ -799,6 +799,7 @@ func TestParseTestWithBadScalarTests(t *testing.T) {
 		{"add(123::fp32, 3.E.5::fp32) = 123::fp32", 17, "no viable alternative at input '3.E'"},
 		{"f1((1, 2, 3, 4)::i64) = 10::fp64", 0, "expected scalar testcase based on test file header, but got aggregate function testcase"},
 		{"add(4.53::dec<1, 0>, 0.25::dec<2, 2>) = 0.78::dec<5, 2>", 0, "Visit error at line 5: invalid argument number 4.53"},
+		{"f1(null::str) = null::str?", 0, "null literal must use a nullable type, got string"},
 	}
 	for _, test := range tests {
 		t.Run(test.testCaseStr, func(t *testing.T) {
@@ -869,7 +870,7 @@ func TestParseAggregateTestWithVariousTypes(t *testing.T) {
 		{testCaseStr: "f8(('1991-01-01T01:02:03.456', '1991-01-01T00:00:00')::timestamp) = '1991-01-01T22:33:44'::ts", expTestStr: "f8(('1991-01-01T01:02:03.456', '1991-01-01T00:00:00')::timestamp) = '1991-01-01T22:33:44'::timestamp"},
 		{testCaseStr: "f8(('1991-01-01T01:02:03.456+05:30', '1991-01-01T00:00:00+15:30')::tstz) = 23::i32", expTestStr: "f8(('1990-12-31T19:32:03.456', '1990-12-31T08:30:00')::timestamp_tz) = 23::i32"},
 		{testCaseStr: "f10(('P10Y5M', 'P11Y5M')::interval_year) = 'P21Y10M'::interval_year"},
-		{testCaseStr: "f10(('P10Y5M', null)::interval_year) = null::interval_year", expTestStr: "f10(('P10Y5M', null)::interval_year?) = null::interval_year?"},
+		{testCaseStr: "f10(('P10Y5M', null)::interval_year?) = null::interval_year?"},
 		{testCaseStr: "f10(('P10Y2M', 'P10Y7M')::iyear) = 'P20Y9M'::iyear", expTestStr: "f10(('P10Y2M', 'P10Y7M')::interval_year) = 'P20Y9M'::interval_year"},
 		{testCaseStr: "f11(('P10DT5H6M7S', 'P10DT6M7S')::interval_day) = 'P20DT11H6M7S'::interval_day", expTestStr: "f11(('P10DT5H6M7S', 'P10DT6M7S')::interval_day<0>) = 'P20DT11H6M7S'::interval_day<0>"},
 		{testCaseStr: "f11(('P10DT5H6M7S', 'P10DT6M7S')::iday?) = 'P20DT11H6M7S'::iday", expTestStr: "f11(('P10DT5H6M7S', 'P10DT6M7S')::interval_day?<0>) = 'P20DT11H6M7S'::interval_day<0>"},
@@ -878,19 +879,19 @@ func TestParseAggregateTestWithVariousTypes(t *testing.T) {
 		{testCaseStr: "((20), (3), (1), (10), (5)) count_star() = 1::fp64", expTestStr: "(('20'), ('3'), ('1'), ('10'), ('5')) count_star() = 1::fp64"},                                               // no type specified for columns in the test case
 		{testCaseStr: `DEFINE t1(fp32, fp32) = ((20, 20), (-3, -3), (1, 1), (10,10), (5,5))
 count_star() = 1::fp64`, expTestStr: "((20, 20), (-3, -3), (1, 1), (10, 10), (5, 5)) count_star() = 1::fp64"},
-		{testCaseStr: `DEFINE t1(varchar<5>) = (('cat'), ('bat'), ('rat'), (null))
+		{testCaseStr: `DEFINE t1(varchar?<5>) = (('cat'), ('bat'), ('rat'), (null))
 count_star() = 1::fp64`, expTestStr: "(('cat'), ('bat'), ('rat'), (null)) count_star() = 1::fp64"}, // no arguments, so no type info in the output format
-		{testCaseStr: `DEFINE t1(varchar<5>) = (('cat'), ('bat'), ('rat'), (null))
+		{testCaseStr: `DEFINE t1(varchar?<5>) = (('cat'), ('bat'), ('rat'), (null))
 count(t1.col0) = 4::fp64`, expTestStr: "(('cat'), ('bat'), ('rat'), (null)) count(col0::varchar?<5>) = 4::fp64"},
-		{testCaseStr: "f20(('abcd', 'ef')::fchar?<9>) = Null::fchar<9>", expTestStr: "f20(('abcd', 'ef')::fixedchar?<9>) = null::fixedchar?<9>"},
-		{testCaseStr: "f20(('abcd', 'ef')::fixedchar<9>) = Null::fchar<9>", expTestStr: "f20(('abcd', 'ef')::fixedchar<9>) = null::fixedchar?<9>"},
-		{testCaseStr: "f20(('abcd', null)::fixedchar<9>) = Null::fchar<9>", expTestStr: "f20(('abcd', null)::fixedchar?<9>) = null::fixedchar?<9>"},
-		{testCaseStr: "f20(('abcd', 'ef', null)::vchar?<9>) = Null::vchar<9>", expTestStr: "f20(('abcd', 'ef', null)::varchar?<9>) = null::varchar?<9>"},
-		{testCaseStr: "f20(('abcd', 'ef')::varchar<9>) = Null::vchar<9>", expTestStr: "f20(('abcd', 'ef')::varchar<9>) = null::varchar?<9>"},
-		{testCaseStr: "f20(('abcd', 'ef')::fbin<9>) = Null::fbin<9>", expTestStr: "f20(('abcd', 'ef')::fixedbinary<9>) = null::fixedbinary?<9>"},
+		{testCaseStr: "f20(('abcd', 'ef')::fchar?<9>) = Null::fchar?<9>", expTestStr: "f20(('abcd', 'ef')::fixedchar?<9>) = null::fixedchar?<9>"},
+		{testCaseStr: "f20(('abcd', 'ef')::fixedchar<9>) = Null::fchar?<9>", expTestStr: "f20(('abcd', 'ef')::fixedchar<9>) = null::fixedchar?<9>"},
+		{testCaseStr: "f20(('abcd', null)::fixedchar?<9>) = Null::fchar?<9>", expTestStr: "f20(('abcd', null)::fixedchar?<9>) = null::fixedchar?<9>"},
+		{testCaseStr: "f20(('abcd', 'ef', null)::vchar?<9>) = Null::vchar?<9>", expTestStr: "f20(('abcd', 'ef', null)::varchar?<9>) = null::varchar?<9>"},
+		{testCaseStr: "f20(('abcd', 'ef')::varchar<9>) = Null::vchar?<9>", expTestStr: "f20(('abcd', 'ef')::varchar<9>) = null::varchar?<9>"},
+		{testCaseStr: "f20(('abcd', 'ef')::fbin<9>) = Null::fbin?<9>", expTestStr: "f20(('abcd', 'ef')::fixedbinary<9>) = null::fixedbinary?<9>"},
 		{testCaseStr: "f20(('abcd', 'ef')::varchar?<9>) = 'abcdef'::varchar<9>", expTestStr: "f20(('abcd', 'ef')::varchar?<9>) = 'abcdef'::varchar<9>"},
-		{testCaseStr: "f20(('abcd', null)::fixedchar?<9>) = Null::fixedchar<9>", expTestStr: "f20(('abcd', null)::fixedchar?<9>) = null::fixedchar?<9>"},
-		{testCaseStr: "f20(('abcd', 'ef')::fixedbinary?<9>) = Null::fixedbinary<9>", expTestStr: "f20(('abcd', 'ef')::fixedbinary?<9>) = null::fixedbinary?<9>"},
+		{testCaseStr: "f20(('abcd', null)::fixedchar?<9>) = Null::fixedchar?<9>", expTestStr: "f20(('abcd', null)::fixedchar?<9>) = null::fixedchar?<9>"},
+		{testCaseStr: "f20(('abcd', 'ef')::fixedbinary?<9>) = Null::fixedbinary?<9>", expTestStr: "f20(('abcd', 'ef')::fixedbinary?<9>) = null::fixedbinary?<9>"},
 		{testCaseStr: "f35(('1991-01-01T01:02:03.456')::pts?<3>) = '1991-01-01T01:02:30.123123'::precision_timestamp<3>",
 			expTestStr: "f35(('1991-01-01T01:02:03.456')::precision_timestamp?<3>) = '1991-01-01T01:02:30.123'::precision_timestamp<3>"},
 		{testCaseStr: "f36(('1991-01-01T01:02:03.456', '1991-01-01T01:02:30.123123')::precision_timestamp<3>) = 123456::i64"},

--- a/testcases/parser/visitor.go
+++ b/testcases/parser/visitor.go
@@ -43,6 +43,12 @@ func (v *TestCaseVisitor) clearLiteralTypeInContext() {
 	v.literalTypeInContext = nil
 }
 
+func (v *TestCaseVisitor) validateNullLiteralType(ctx antlr.ParserRuleContext, nullType types.Type) {
+	if nullType.GetNullability() != types.NullabilityNullable {
+		v.ErrorListener.ReportVisitError(ctx, fmt.Errorf("null literal must use a nullable type, got %s", nullType))
+	}
+}
+
 var _ baseparser.FuncTestCaseParserVisitor = &TestCaseVisitor{}
 
 func (v *TestCaseVisitor) Visit(tree antlr.ParseTree) interface{} {
@@ -436,7 +442,8 @@ func (v *TestCaseVisitor) VisitArgument(ctx *baseparser.ArgumentContext) interfa
 
 func (v *TestCaseVisitor) VisitNullArg(ctx *baseparser.NullArgContext) interface{} {
 	dataType := v.Visit(ctx.DataType()).(types.Type)
-	return &CaseLiteral{Value: expr.NewNullLiteral(dataType), ValueText: ctx.NullLiteral().GetText(), Type: dataType.WithNullability(types.NullabilityNullable)}
+	v.validateNullLiteralType(ctx, dataType)
+	return &CaseLiteral{Value: expr.NewNullLiteral(dataType), ValueText: ctx.NullLiteral().GetText(), Type: dataType}
 }
 
 func (v *TestCaseVisitor) VisitBooleanArg(ctx *baseparser.BooleanArgContext) interface{} {

--- a/types/any_type.go
+++ b/types/any_type.go
@@ -128,13 +128,9 @@ func (m *AnyType) ReturnType(funcParameters []FuncDefArgType, argumentTypes []Ty
 			return nil, err
 		}
 		if typ != nil {
-			// Apply the declared nullability from the return type definition.
+			// Apply nullable output from the return type definition.
 			// For example, nullif declares `return: any1?` — the `?` means
 			// the result is always nullable regardless of argument nullability.
-			//
-			// TODO: It is unclear if a declared non-nullable return type (e.g. `any1`)
-			// should override a nullable argument type to produce a non-nullable result.
-			// This is being resolved in https://github.com/substrait-io/substrait/issues/943
 			if m.Nullability == NullabilityNullable {
 				typ = typ.WithNullability(NullabilityNullable)
 			}

--- a/types/parameterized_func_type.go
+++ b/types/parameterized_func_type.go
@@ -72,12 +72,16 @@ func (f *ParameterizedFuncType) MatchWithNullability(ot Type) bool {
 	if f.Nullability != ot.GetNullability() {
 		return false
 	}
-	return f.MatchWithoutNullability(ot)
+	return f.matchComponents(ot)
 }
 
 // MatchWithoutNullability checks if this parameterized type matches the given concrete type
-// ignoring nullability
+// ignoring only this function type's outer nullability.
 func (f *ParameterizedFuncType) MatchWithoutNullability(ot Type) bool {
+	return f.matchComponents(ot)
+}
+
+func (f *ParameterizedFuncType) matchComponents(ot Type) bool {
 	oft, ok := ot.(*FuncType)
 	if !ok {
 		return false
@@ -86,11 +90,11 @@ func (f *ParameterizedFuncType) MatchWithoutNullability(ot Type) bool {
 		return false
 	}
 	for i, pt := range f.Parameters {
-		if !pt.MatchWithoutNullability(oft.ParameterTypes[i]) {
+		if !matchTypeComponentWithNullability(pt, oft.ParameterTypes[i]) {
 			return false
 		}
 	}
-	return f.Return.MatchWithoutNullability(oft.ReturnType)
+	return matchTypeComponentWithNullability(f.Return, oft.ReturnType)
 }
 
 // GetNullability returns the nullability of this type

--- a/types/parameterized_list_type.go
+++ b/types/parameterized_list_type.go
@@ -43,15 +43,14 @@ func (m *ParameterizedListType) MatchWithNullability(ot Type) bool {
 		return false
 	}
 	if olt, ok := ot.(*ListType); ok {
-		result := m.Type.MatchWithNullability(olt.Type)
-		return result
+		return matchTypeComponentWithNullability(m.Type, olt.Type)
 	}
 	return false
 }
 
 func (m *ParameterizedListType) MatchWithoutNullability(ot Type) bool {
 	if olt, ok := ot.(*ListType); ok {
-		return m.Type.MatchWithoutNullability(olt.Type)
+		return matchTypeComponentWithNullability(m.Type, olt.Type)
 	}
 	return false
 }

--- a/types/parameterized_map_type.go
+++ b/types/parameterized_map_type.go
@@ -49,14 +49,16 @@ func (m *ParameterizedMapType) MatchWithNullability(ot Type) bool {
 		return false
 	}
 	if omt, ok := ot.(*MapType); ok {
-		return m.Key.MatchWithNullability(omt.Key) && m.Value.MatchWithNullability(omt.Value)
+		return matchTypeComponentWithNullability(m.Key, omt.Key) &&
+			matchTypeComponentWithNullability(m.Value, omt.Value)
 	}
 	return false
 }
 
 func (m *ParameterizedMapType) MatchWithoutNullability(ot Type) bool {
 	if omt, ok := ot.(*MapType); ok {
-		return m.Key.MatchWithoutNullability(omt.Key) && m.Value.MatchWithoutNullability(omt.Value)
+		return matchTypeComponentWithNullability(m.Key, omt.Key) &&
+			matchTypeComponentWithNullability(m.Value, omt.Value)
 	}
 	return false
 }

--- a/types/parameterized_struct_type.go
+++ b/types/parameterized_struct_type.go
@@ -64,7 +64,7 @@ func (m *ParameterizedStructType) MatchWithNullability(ot Type) bool {
 			return false
 		}
 		for i, typ := range m.Types {
-			if !typ.MatchWithNullability(omt.Types[i]) {
+			if !matchTypeComponentWithNullability(typ, omt.Types[i]) {
 				return false
 			}
 		}
@@ -79,7 +79,7 @@ func (m *ParameterizedStructType) MatchWithoutNullability(ot Type) bool {
 			return false
 		}
 		for i, typ := range m.Types {
-			if !typ.MatchWithoutNullability(omt.Types[i]) {
+			if !matchTypeComponentWithNullability(typ, omt.Types[i]) {
 				return false
 			}
 		}

--- a/types/types.go
+++ b/types/types.go
@@ -537,6 +537,17 @@ type (
 	}
 )
 
+// matchTypeComponentWithNullability matches a nested type component where
+// nullability is part of the structural match. AnyType is special because
+// `any1` binds to the argument type it sees, while `any1?` constrains that
+// binding to nullable arguments without changing the bound type's base shape.
+func matchTypeComponentWithNullability(param FuncDefArgType, actual Type) bool {
+	if anyType, ok := param.(*AnyType); ok {
+		return anyType.Nullability != NullabilityNullable || actual.GetNullability() == NullabilityNullable
+	}
+	return param.MatchWithNullability(actual)
+}
+
 var CommonEnumType = &EnumType{}
 
 // EnumType represents an enumeration function parameter.

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -701,6 +701,60 @@ func TestStructTypeDepthFirstNameCount(t *testing.T) {
 	}
 }
 
+func TestParameterizedTypeComponentNullabilityMatching(t *testing.T) {
+	tests := []struct {
+		name   string
+		param  FuncDefArgType
+		actual Type
+		match  bool
+	}{
+		{
+			name:   "non-any requires matching nullability",
+			param:  &Int32Type{Nullability: NullabilityRequired},
+			actual: &Int32Type{Nullability: NullabilityRequired},
+			match:  true,
+		},
+		{
+			name:   "non-any rejects different nullability",
+			param:  &Int32Type{Nullability: NullabilityRequired},
+			actual: &Int32Type{Nullability: NullabilityNullable},
+			match:  false,
+		},
+		{
+			name:   "any1 accepts required component",
+			param:  &AnyType{Name: "any1", Nullability: NullabilityRequired},
+			actual: &Int32Type{Nullability: NullabilityRequired},
+			match:  true,
+		},
+		{
+			name:   "any1 accepts nullable component",
+			param:  &AnyType{Name: "any1", Nullability: NullabilityRequired},
+			actual: &Int32Type{Nullability: NullabilityNullable},
+			match:  true,
+		},
+		{
+			name:   "any1 nullable accepts nullable component",
+			param:  &AnyType{Name: "any1", Nullability: NullabilityNullable},
+			actual: &Int32Type{Nullability: NullabilityNullable},
+			match:  true,
+		},
+		{
+			name:   "any1 nullable rejects required component",
+			param:  &AnyType{Name: "any1", Nullability: NullabilityNullable},
+			actual: &Int32Type{Nullability: NullabilityRequired},
+			match:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			param := &ParameterizedListType{Nullability: NullabilityRequired, Type: tt.param}
+			actual := &ListType{Nullability: NullabilityRequired, Type: tt.actual}
+			assert.Equal(t, tt.match, param.MatchWithNullability(actual))
+		})
+	}
+}
+
 func TestEnumTypeShortString(t *testing.T) {
 	assert.Equal(t, "req", CommonEnumType.ShortString())
 }

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -701,6 +701,49 @@ func TestStructTypeDepthFirstNameCount(t *testing.T) {
 	}
 }
 
+func TestParameterizedFuncTypeComponentNullabilityMatching(t *testing.T) {
+	param := &ParameterizedFuncType{
+		Nullability: NullabilityRequired,
+		Parameters:  []FuncDefArgType{&AnyType{Name: "any1", Nullability: NullabilityRequired}},
+		Return:      &AnyType{Name: "any1", Nullability: NullabilityNullable},
+	}
+
+	t.Run("match without nullability ignores only outer function nullability", func(t *testing.T) {
+		actual := &FuncType{
+			Nullability:    NullabilityNullable,
+			ParameterTypes: []Type{&Int32Type{Nullability: NullabilityRequired}},
+			ReturnType:     &Int32Type{Nullability: NullabilityNullable},
+		}
+
+		assert.True(t, param.MatchWithoutNullability(actual))
+		assert.False(t, param.MatchWithNullability(actual))
+	})
+
+	t.Run("nested component nullability still matters", func(t *testing.T) {
+		actual := &FuncType{
+			Nullability:    NullabilityRequired,
+			ParameterTypes: []Type{&Int32Type{Nullability: NullabilityRequired}},
+			ReturnType:     &Int32Type{Nullability: NullabilityRequired},
+		}
+
+		assert.False(t, param.MatchWithoutNullability(actual))
+	})
+
+	t.Run("non-function actual does not match", func(t *testing.T) {
+		assert.False(t, param.MatchWithoutNullability(&Int32Type{Nullability: NullabilityRequired}))
+	})
+
+	t.Run("parameter count must match", func(t *testing.T) {
+		actual := &FuncType{
+			Nullability:    NullabilityRequired,
+			ParameterTypes: []Type{},
+			ReturnType:     &Int32Type{Nullability: NullabilityNullable},
+		}
+
+		assert.False(t, param.MatchWithoutNullability(actual))
+	})
+}
+
 func TestParameterizedTypeComponentNullabilityMatching(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
Function matching for constrained `any` parameters was ignoring nullability too broadly. Under the clarified Substrait semantics, MIRROR and DECLARED_OUTPUT strip only the outermost argument nullability before binding; nested nullability inside compound types still participates in structural matching.

This keeps cases like `list<i32>` and `list<i32?>` from binding to the same `list<any1>` parameter while still allowing outer nullable wrappers to match as intended. The added tests mirror the examples from substrait-io/substrait#943.

---
Note: This PR was developed with AI assistance. All changes have been reviewed, and I take full responsibility for this contribution.