### PR TITLE
refactor(extensions): introduce argument matcher

### DIFF
--- a/extensions/variants.go
+++ b/extensions/variants.go
@@ -175,12 +175,12 @@ func matchArguments(nullability NullabilityHandling, paramTypeList FuncParameter
 	if err != nil {
 		return false, nil
 	}
-	// loop over actualTypes and not params since actualTypes can be more than params
-	// considering variadic type
-	for argPos := range actualTypes {
-		match, err1 := matchArgumentAtCommon(actualTypes[argPos], argPos, nullability, funcDefArgList, variadicBehavior)
-		if err1 != nil {
-			return false, err1
+
+	matcher := newArgumentMatcher(nullability, funcDefArgList, variadicBehavior)
+	for argPos, actualType := range actualTypes {
+		match, err := matcher.matchArgument(actualType, argPos)
+		if err != nil {
+			return false, err
 		}
 		if !match {
 			return false, nil
@@ -190,7 +190,7 @@ func matchArguments(nullability NullabilityHandling, paramTypeList FuncParameter
 		return types.AreSyncTypeParametersMatching(funcDefArgList, actualTypes), nil
 	}
 
-	if err := ValidateConstrainedAnyTypeConsistency(funcDefArgList, actualTypes, variadicBehavior); err != nil {
+	if err := matcher.validateConstrainedAnyTypeConsistency(actualTypes); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -204,34 +204,55 @@ func matchArgumentAt(actualType types.Type, argPos int, nullability NullabilityH
 	if err != nil {
 		return false, nil
 	}
-	return matchArgumentAtCommon(actualType, argPos, nullability, funcDefArgList, variadicBehavior)
+	return newArgumentMatcher(nullability, funcDefArgList, variadicBehavior).matchArgument(actualType, argPos)
 }
 
-func matchArgumentAtCommon(actualType types.Type, argPos int, nullability NullabilityHandling, funcDefArgList []types.FuncDefArgType, variadicBehavior *VariadicBehavior) (bool, error) {
-	// check if argument out of range
-	if variadicBehavior == nil && argPos >= len(funcDefArgList) {
-		return false, nil
-	} else if variadicBehavior != nil && !variadicBehavior.IsValidArgumentPosition(argPos) {
-		// this argument position can't be more than the max allowed by the variadic behavior
+type argumentMatcher struct {
+	nullability      NullabilityHandling
+	funcDefArgList   []types.FuncDefArgType
+	variadicBehavior *VariadicBehavior
+}
+
+func newArgumentMatcher(nullability NullabilityHandling, funcDefArgList []types.FuncDefArgType, variadicBehavior *VariadicBehavior) *argumentMatcher {
+	return &argumentMatcher{
+		nullability:      nullability,
+		funcDefArgList:   funcDefArgList,
+		variadicBehavior: variadicBehavior,
+	}
+}
+
+func (m *argumentMatcher) matchArgument(actualType types.Type, argPos int) (bool, error) {
+	funcDefArg, ok := m.parameterAt(argPos)
+	if !ok {
 		return false, nil
 	}
 
-	// if argPos is >= len(funcDefArgList) than last funcDefArg type should be considered for type match
-	// already checked for parameter in range above (considering variadic) so no need to check again for variadic
-	var funcDefArg types.FuncDefArgType
-	if argPos < len(funcDefArgList) {
-		funcDefArg = funcDefArgList[argPos]
-	} else {
-		funcDefArg = funcDefArgList[len(funcDefArgList)-1]
-	}
-	switch nullability {
+	switch m.nullability {
 	case DiscreteNullability:
 		return funcDefArg.MatchWithNullability(actualType), nil
 	case MirrorNullability, DeclaredOutputNullability:
 		return funcDefArg.MatchWithoutNullability(actualType), nil
 	}
-	// unreachable case
-	return false, fmt.Errorf("invalid nullability type: %s", nullability)
+	return false, fmt.Errorf("invalid nullability type: %s", m.nullability)
+}
+
+func (m *argumentMatcher) parameterAt(argPos int) (types.FuncDefArgType, bool) {
+	if argPos < 0 {
+		return nil, false
+	}
+	if m.variadicBehavior == nil {
+		if argPos >= len(m.funcDefArgList) {
+			return nil, false
+		}
+		return m.funcDefArgList[argPos], true
+	}
+	if !m.variadicBehavior.IsValidArgumentPosition(argPos) {
+		return nil, false
+	}
+	if argPos < len(m.funcDefArgList) {
+		return m.funcDefArgList[argPos], true
+	}
+	return m.funcDefArgList[len(m.funcDefArgList)-1], true
 }
 
 // validateVariadicBehaviorForMatch validates variadic argument counts and enforces
@@ -756,28 +777,37 @@ func validateAnyTypeBinding(paramType types.FuncDefArgType, argType types.Type, 
 // ValidateConstrainedAnyTypeConsistency validates that all uses of the same AnyN parameter
 // (e.g., any1, any2, etc.) resolve to the same concrete type across all arguments
 func ValidateConstrainedAnyTypeConsistency(funcParameters []types.FuncDefArgType, argumentTypes []types.Type, variadicBehavior *VariadicBehavior) error {
-	// For variadic functions, expand the parameter list to match actual arguments
-	expandedFuncParameters := funcParameters
-	if variadicBehavior != nil && len(argumentTypes) > len(funcParameters) {
-		numVariadicArgs := len(argumentTypes) - len(funcParameters) + 1
-		nonVariadicParams := funcParameters[:len(funcParameters)-1]
-		variadicParam := funcParameters[len(funcParameters)-1]
+	return newArgumentMatcher(MirrorNullability, funcParameters, variadicBehavior).validateConstrainedAnyTypeConsistency(argumentTypes)
+}
 
-		expandedFuncParameters = make([]types.FuncDefArgType, len(nonVariadicParams)+numVariadicArgs)
-		copy(expandedFuncParameters, nonVariadicParams)
-		for i := range numVariadicArgs {
-			expandedFuncParameters[len(nonVariadicParams)+i] = variadicParam
-		}
-	}
-
+func (m *argumentMatcher) validateConstrainedAnyTypeConsistency(argumentTypes []types.Type) error {
 	bindings := make(map[string]types.Type)
 
-	// Validate each argument against its parameter type
-	for i := 0; i < len(expandedFuncParameters) && i < len(argumentTypes); i++ {
-		if err := validateAnyTypeBinding(expandedFuncParameters[i], argumentTypes[i], bindings); err != nil {
+	for i, funcParameter := range m.expandedParameters(argumentTypes) {
+		if i >= len(argumentTypes) {
+			break
+		}
+		if err := validateAnyTypeBinding(funcParameter, argumentTypes[i], bindings); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func (m *argumentMatcher) expandedParameters(argumentTypes []types.Type) []types.FuncDefArgType {
+	if m.variadicBehavior == nil || len(argumentTypes) <= len(m.funcDefArgList) {
+		return m.funcDefArgList
+	}
+
+	numVariadicArgs := len(argumentTypes) - len(m.funcDefArgList) + 1
+	nonVariadicParams := m.funcDefArgList[:len(m.funcDefArgList)-1]
+	variadicParam := m.funcDefArgList[len(m.funcDefArgList)-1]
+
+	expandedFuncParameters := make([]types.FuncDefArgType, len(nonVariadicParams)+numVariadicArgs)
+	copy(expandedFuncParameters, nonVariadicParams)
+	for i := range numVariadicArgs {
+		expandedFuncParameters[len(nonVariadicParams)+i] = variadicParam
+	}
+	return expandedFuncParameters
 }

--- a/extensions/variants.go
+++ b/extensions/variants.go
@@ -207,12 +207,14 @@ func matchArgumentAt(actualType types.Type, argPos int, nullability NullabilityH
 	return newArgumentMatcher(nullability, funcDefArgList, variadicBehavior).matchArgument(actualType, argPos)
 }
 
+// argumentMatcher holds the state needed to compare invocation argument types against a function variant signature.
 type argumentMatcher struct {
 	nullability      NullabilityHandling
 	funcDefArgList   []types.FuncDefArgType
 	variadicBehavior *VariadicBehavior
 }
 
+// newArgumentMatcher creates a matcher for one function variant signature.
 func newArgumentMatcher(nullability NullabilityHandling, funcDefArgList []types.FuncDefArgType, variadicBehavior *VariadicBehavior) *argumentMatcher {
 	return &argumentMatcher{
 		nullability:      nullability,
@@ -221,6 +223,7 @@ func newArgumentMatcher(nullability NullabilityHandling, funcDefArgList []types.
 	}
 }
 
+// matchArgument checks whether an argument type matches the signature parameter at the same position.
 func (m *argumentMatcher) matchArgument(actualType types.Type, argPos int) (bool, error) {
 	funcDefArg, ok := m.parameterAt(argPos)
 	if !ok {
@@ -236,6 +239,7 @@ func (m *argumentMatcher) matchArgument(actualType types.Type, argPos int) (bool
 	return false, fmt.Errorf("invalid nullability type: %s", m.nullability)
 }
 
+// parameterAt returns the signature parameter for an argument position, accounting for variadic signatures.
 func (m *argumentMatcher) parameterAt(argPos int) (types.FuncDefArgType, bool) {
 	if argPos < 0 {
 		return nil, false
@@ -780,6 +784,7 @@ func ValidateConstrainedAnyTypeConsistency(funcParameters []types.FuncDefArgType
 	return newArgumentMatcher(MirrorNullability, funcParameters, variadicBehavior).validateConstrainedAnyTypeConsistency(argumentTypes)
 }
 
+// validateConstrainedAnyTypeConsistency checks that repeated anyN parameters bind to the same concrete type.
 func (m *argumentMatcher) validateConstrainedAnyTypeConsistency(argumentTypes []types.Type) error {
 	bindings := make(map[string]types.Type)
 
@@ -795,6 +800,7 @@ func (m *argumentMatcher) validateConstrainedAnyTypeConsistency(argumentTypes []
 	return nil
 }
 
+// expandedParameters repeats the variadic parameter so parameter and argument slices can be compared positionally.
 func (m *argumentMatcher) expandedParameters(argumentTypes []types.Type) []types.FuncDefArgType {
 	if m.variadicBehavior == nil || len(argumentTypes) <= len(m.funcDefArgList) {
 		return m.funcDefArgList

--- a/extensions/variants_test.go
+++ b/extensions/variants_test.go
@@ -532,6 +532,61 @@ func TestResolveTypeErrorHandling(t *testing.T) {
 	assert.Contains(t, err.Error(), "mismatch in number of arguments")
 }
 
+func TestFunctionVariantMatchAt(t *testing.T) {
+	const matchAtYAML = `---
+urn: extension:test:match-at
+scalar_functions:
+  - name: example
+    impls:
+      - args:
+          - name: x
+            value: i32
+        nullability: MIRROR
+        return: i32
+`
+
+	var c extensions.Collection
+	require.NoError(t, c.Load("test://match-at.yaml", strings.NewReader(matchAtYAML)))
+	variant, ok := c.GetScalarFunc(extensions.ID{URN: "extension:test:match-at", Name: "example:i32"})
+	require.True(t, ok)
+
+	matches, err := variant.MatchAt(&types.Int32Type{Nullability: types.NullabilityRequired}, 0)
+	require.NoError(t, err)
+	require.True(t, matches)
+
+	matches, err = variant.MatchAt(&types.Int32Type{Nullability: types.NullabilityRequired}, 1)
+	require.NoError(t, err)
+	require.False(t, matches)
+}
+
+func TestVariadicFunctionVariantMatchAtRejectsInvalidPosition(t *testing.T) {
+	variant := extensions.NewScalarFuncVariantWithProps(
+		extensions.ID{URN: "extension:test", Name: "example:i32"},
+		&extensions.VariadicBehavior{Min: 1, Max: 2},
+		false,
+		true)
+
+	matches, err := variant.MatchAt(&types.Int32Type{Nullability: types.NullabilityRequired}, 3)
+	require.NoError(t, err)
+	require.False(t, matches)
+}
+
+func TestEvaluateTypeExpressionInvalidNullabilityHandling(t *testing.T) {
+	argType, err := parser.ParseType("i32")
+	require.NoError(t, err)
+
+	_, err = extensions.EvaluateTypeExpression(
+		"extension:test",
+		extensions.NullabilityHandling("INVALID"),
+		argType,
+		extensions.FuncParameterList{valArg(argType)},
+		nil,
+		[]types.Type{&types.Int32Type{Nullability: types.NullabilityRequired}},
+		extensions.NewSet())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid nullability type")
+}
+
 func TestValidateConstrainedAnyTypeConsistency(t *testing.T) {
 	t.Run("non-variadic with matching types succeeds", func(t *testing.T) {
 		// func(any1, any1) with (i32, i32)


### PR DESCRIPTION
Function variant matching currently spreads argument position resolution, nullability handling, variadic expansion, and constrained `any` validation across several helpers. This refactors those responsibilities behind an internal matcher so the matching flow has one place to evolve without changing the exported matching APIs.

This is intended to be behavior-preserving groundwork for improving constrained `any` matching semantics in a follow-up PR.

---
Note: This PR was developed with AI assistance. All changes have been reviewed, and I take full responsibility for this contribution.