### PR TITLE
fix(extensions): bind constrained any during matching

### DIFF
--- a/extensions/variants.go
+++ b/extensions/variants.go
@@ -240,46 +240,37 @@ func (m *argumentMatcher) matchArgument(actualType types.Type, argPos int) (bool
 func (m *argumentMatcher) matchTopLevel(paramType types.FuncDefArgType, argType types.Type) (bool, error) {
 	switch m.nullability {
 	case DiscreteNullability:
-		if anyType, ok := paramType.(*types.AnyType); ok {
-			return m.matchTopLevelAnyType(anyType, argType, true)
-		}
-		return m.matchType(paramType, argType, true)
+		return m.matchNested(paramType, argType)
 	case MirrorNullability, DeclaredOutputNullability:
-		if anyType, ok := paramType.(*types.AnyType); ok {
-			return m.matchTopLevelAnyType(anyType, argType, false)
-		}
-		return m.matchType(paramType, argType, false)
+		return m.matchTopLevelWithoutNullability(paramType, argType)
 	}
 	return false, fmt.Errorf("invalid nullability type: %s", m.nullability)
 }
 
-func (m *argumentMatcher) matchTopLevelAnyType(anyType *types.AnyType, argType types.Type, checkOuterNullability bool) (bool, error) {
-	if anyType.Nullability == types.NullabilityNullable && argType.GetNullability() != types.NullabilityNullable {
-		return false, nil
+func (m *argumentMatcher) matchTopLevelWithoutNullability(paramType types.FuncDefArgType, argType types.Type) (bool, error) {
+	if anyType, ok := paramType.(*types.AnyType); ok {
+		if anyType.Nullability == types.NullabilityNullable && argType.GetNullability() != types.NullabilityNullable {
+			return false, nil
+		}
+		return m.bindAnyType(anyType, argType, true)
 	}
-	if checkOuterNullability && anyType.Nullability != argType.GetNullability() {
-		return false, nil
-	}
-	return m.bindAnyType(anyType, argType, !checkOuterNullability || anyType.Nullability != types.NullabilityRequired)
+	return m.matchType(paramType, argType, false)
 }
 
 func (m *argumentMatcher) matchNested(paramType types.FuncDefArgType, argType types.Type) (bool, error) {
+	if anyType, ok := paramType.(*types.AnyType); ok {
+		if anyType.Nullability == types.NullabilityNullable && argType.GetNullability() != types.NullabilityNullable {
+			return false, nil
+		}
+		return m.bindAnyType(anyType, argType, anyType.Nullability != types.NullabilityRequired)
+	}
+	if paramType.GetNullability() != argType.GetNullability() {
+		return false, nil
+	}
 	return m.matchType(paramType, argType, true)
 }
 
-func (m *argumentMatcher) matchType(paramType types.FuncDefArgType, argType types.Type, checkOuterNullability bool) (bool, error) {
-	switch p := paramType.(type) {
-	case *types.AnyType:
-		if p.Nullability == types.NullabilityNullable && argType.GetNullability() != types.NullabilityNullable {
-			return false, nil
-		}
-		return m.bindAnyType(p, argType, p.Nullability != types.NullabilityRequired)
-	}
-
-	if checkOuterNullability && paramType.GetNullability() != argType.GetNullability() {
-		return false, nil
-	}
-
+func (m *argumentMatcher) matchType(paramType types.FuncDefArgType, argType types.Type, hasMatchedOuterNullability bool) (bool, error) {
 	switch p := paramType.(type) {
 	case *types.ParameterizedListType:
 		listType, ok := argType.(*types.ListType)
@@ -320,7 +311,7 @@ func (m *argumentMatcher) matchType(paramType types.FuncDefArgType, argType type
 		return m.matchNested(p.Return, funcType.ReturnType)
 	}
 
-	if checkOuterNullability {
+	if hasMatchedOuterNullability {
 		return paramType.MatchWithNullability(argType), nil
 	}
 	return paramType.MatchWithoutNullability(argType), nil

--- a/extensions/variants.go
+++ b/extensions/variants.go
@@ -240,27 +240,40 @@ func (m *argumentMatcher) matchArgument(actualType types.Type, argPos int) (bool
 func (m *argumentMatcher) matchTopLevel(paramType types.FuncDefArgType, argType types.Type) (bool, error) {
 	switch m.nullability {
 	case DiscreteNullability:
-		return m.matchType(paramType, argType, true, true)
+		if anyType, ok := paramType.(*types.AnyType); ok {
+			return m.matchTopLevelAnyType(anyType, argType, true)
+		}
+		return m.matchType(paramType, argType, true)
 	case MirrorNullability, DeclaredOutputNullability:
-		return m.matchType(paramType, argType, false, true)
+		if anyType, ok := paramType.(*types.AnyType); ok {
+			return m.matchTopLevelAnyType(anyType, argType, false)
+		}
+		return m.matchType(paramType, argType, false)
 	}
 	return false, fmt.Errorf("invalid nullability type: %s", m.nullability)
 }
 
-func (m *argumentMatcher) matchNested(paramType types.FuncDefArgType, argType types.Type) (bool, error) {
-	return m.matchType(paramType, argType, true, false)
+func (m *argumentMatcher) matchTopLevelAnyType(anyType *types.AnyType, argType types.Type, checkOuterNullability bool) (bool, error) {
+	if anyType.Nullability == types.NullabilityNullable && argType.GetNullability() != types.NullabilityNullable {
+		return false, nil
+	}
+	if checkOuterNullability && anyType.Nullability != argType.GetNullability() {
+		return false, nil
+	}
+	return m.bindAnyType(anyType, argType, !checkOuterNullability || anyType.Nullability != types.NullabilityRequired)
 }
 
-func (m *argumentMatcher) matchType(paramType types.FuncDefArgType, argType types.Type, checkOuterNullability, isTopLevel bool) (bool, error) {
+func (m *argumentMatcher) matchNested(paramType types.FuncDefArgType, argType types.Type) (bool, error) {
+	return m.matchType(paramType, argType, true)
+}
+
+func (m *argumentMatcher) matchType(paramType types.FuncDefArgType, argType types.Type, checkOuterNullability bool) (bool, error) {
 	switch p := paramType.(type) {
 	case *types.AnyType:
 		if p.Nullability == types.NullabilityNullable && argType.GetNullability() != types.NullabilityNullable {
 			return false, nil
 		}
-		if isTopLevel && checkOuterNullability && p.Nullability != argType.GetNullability() {
-			return false, nil
-		}
-		return m.bindAnyType(p, argType, !checkOuterNullability || p.Nullability != types.NullabilityRequired)
+		return m.bindAnyType(p, argType, p.Nullability != types.NullabilityRequired)
 	}
 
 	if checkOuterNullability && paramType.GetNullability() != argType.GetNullability() {

--- a/extensions/variants.go
+++ b/extensions/variants.go
@@ -159,6 +159,12 @@ func EvaluateTypeExpression(urn string, nullHandling NullabilityHandling, return
 		return outType.WithNullability(types.NullabilityNullable), nil
 	}
 
+	if nullHandling == DeclaredOutputNullability {
+		if anyReturn, ok := returnTypeExpr.(*types.AnyType); ok && anyReturn.Nullability == types.NullabilityRequired {
+			return outType.WithNullability(types.NullabilityRequired), nil
+		}
+	}
+
 	return outType, nil
 }
 
@@ -189,10 +195,6 @@ func matchArguments(nullability NullabilityHandling, paramTypeList FuncParameter
 	if HasSyncParams(funcDefArgList) {
 		return types.AreSyncTypeParametersMatching(funcDefArgList, actualTypes), nil
 	}
-
-	if err := matcher.validateConstrainedAnyTypeConsistency(actualTypes); err != nil {
-		return false, err
-	}
 	return true, nil
 }
 
@@ -212,6 +214,7 @@ type argumentMatcher struct {
 	nullability      NullabilityHandling
 	funcDefArgList   []types.FuncDefArgType
 	variadicBehavior *VariadicBehavior
+	bindings         map[string]types.Type
 }
 
 // newArgumentMatcher creates a matcher for one function variant signature.
@@ -220,6 +223,7 @@ func newArgumentMatcher(nullability NullabilityHandling, funcDefArgList []types.
 		nullability:      nullability,
 		funcDefArgList:   funcDefArgList,
 		variadicBehavior: variadicBehavior,
+		bindings:         make(map[string]types.Type),
 	}
 }
 
@@ -230,13 +234,105 @@ func (m *argumentMatcher) matchArgument(actualType types.Type, argPos int) (bool
 		return false, nil
 	}
 
+	return m.matchTopLevel(funcDefArg, actualType)
+}
+
+func (m *argumentMatcher) matchTopLevel(paramType types.FuncDefArgType, argType types.Type) (bool, error) {
 	switch m.nullability {
 	case DiscreteNullability:
-		return funcDefArg.MatchWithNullability(actualType), nil
+		return m.matchType(paramType, argType, true, true)
 	case MirrorNullability, DeclaredOutputNullability:
-		return funcDefArg.MatchWithoutNullability(actualType), nil
+		return m.matchType(paramType, argType, false, true)
 	}
 	return false, fmt.Errorf("invalid nullability type: %s", m.nullability)
+}
+
+func (m *argumentMatcher) matchNested(paramType types.FuncDefArgType, argType types.Type) (bool, error) {
+	return m.matchType(paramType, argType, true, false)
+}
+
+func (m *argumentMatcher) matchType(paramType types.FuncDefArgType, argType types.Type, checkOuterNullability, isTopLevel bool) (bool, error) {
+	switch p := paramType.(type) {
+	case *types.AnyType:
+		if p.Nullability == types.NullabilityNullable && argType.GetNullability() != types.NullabilityNullable {
+			return false, nil
+		}
+		if isTopLevel && checkOuterNullability && p.Nullability != argType.GetNullability() {
+			return false, nil
+		}
+		return m.bindAnyType(p, argType, !checkOuterNullability || p.Nullability != types.NullabilityRequired)
+	}
+
+	if checkOuterNullability && paramType.GetNullability() != argType.GetNullability() {
+		return false, nil
+	}
+
+	switch p := paramType.(type) {
+	case *types.ParameterizedListType:
+		listType, ok := argType.(*types.ListType)
+		if !ok {
+			return false, nil
+		}
+		return m.matchNested(p.Type, listType.Type)
+	case *types.ParameterizedMapType:
+		mapType, ok := argType.(*types.MapType)
+		if !ok {
+			return false, nil
+		}
+		if match, err := m.matchNested(p.Key, mapType.Key); !match || err != nil {
+			return match, err
+		}
+		return m.matchNested(p.Value, mapType.Value)
+	case *types.ParameterizedStructType:
+		structType, ok := argType.(*types.StructType)
+		if !ok || len(p.Types) != len(structType.Types) {
+			return false, nil
+		}
+		for i, fieldType := range p.Types {
+			if match, err := m.matchNested(fieldType, structType.Types[i]); !match || err != nil {
+				return match, err
+			}
+		}
+		return true, nil
+	case *types.ParameterizedFuncType:
+		funcType, ok := argType.(*types.FuncType)
+		if !ok || len(p.Parameters) != len(funcType.ParameterTypes) {
+			return false, nil
+		}
+		for i, parameterType := range p.Parameters {
+			if match, err := m.matchNested(parameterType, funcType.ParameterTypes[i]); !match || err != nil {
+				return match, err
+			}
+		}
+		return m.matchNested(p.Return, funcType.ReturnType)
+	}
+
+	if checkOuterNullability {
+		return paramType.MatchWithNullability(argType), nil
+	}
+	return paramType.MatchWithoutNullability(argType), nil
+}
+
+func (m *argumentMatcher) bindAnyType(anyType *types.AnyType, argType types.Type, ignoreNullability bool) (bool, error) {
+	if anyType.Name == "any" {
+		return true, nil
+	}
+
+	boundType := argType
+	if boundType.GetNullability() == types.NullabilityUnspecified || ignoreNullability {
+		boundType = boundType.WithNullability(types.NullabilityRequired)
+	}
+
+	if existingType, exists := m.bindings[anyType.Name]; exists {
+		if !existingType.Equals(boundType) {
+			return false, fmt.Errorf("%w: type parameter %s cannot be both %s and %s",
+				substraitgo.ErrInvalidType, anyType.Name,
+				existingType.ShortString(), boundType.ShortString())
+		}
+	} else {
+		m.bindings[anyType.Name] = boundType
+	}
+	return true, nil
 }
 
 // parameterAt returns the signature parameter for an argument position, accounting for variadic signatures.
@@ -700,103 +796,19 @@ func getLeafParameterizedParams(abstractTypes interface{}) []string {
 	panic("invalid non-leaf, non-parameterized type param")
 }
 
-// validateAnyTypeBinding validates and records the binding of an AnyType parameter to a concrete type.
-// It recursively handles nested types (lists, maps, structs).
-func validateAnyTypeBinding(paramType types.FuncDefArgType, argType types.Type, bindings map[string]types.Type) error {
-	switch p := paramType.(type) {
-	case *types.AnyType:
-		// Plain "any" is unconstrained - each occurrence can be a different type
-		if p.Name == "any" {
-			return nil
-		}
-		if existingType, exists := bindings[p.Name]; exists {
-			// Compare base types ignoring nullability. Nullability is enforced separately
-			// at the individual argument level by MatchWithNullability/MatchWithoutNullability
-			// (see matchArgumentAtCommon in variants.go). Here we only validate that all uses
-			// of the same type parameter (e.g., any1) resolve to the same base type.
-			existingBase := existingType.WithNullability(types.NullabilityRequired)
-			argBase := argType.WithNullability(types.NullabilityRequired)
-			if !existingBase.Equals(argBase) {
-				return fmt.Errorf("%w: type parameter %s cannot be both %s and %s",
-					substraitgo.ErrInvalidType, p.Name,
-					existingType.ShortString(), argType.ShortString())
-			}
-		} else {
-			bindings[p.Name] = argType
-		}
-	case *types.ParameterizedListType:
-		if listType, ok := argType.(*types.ListType); ok {
-			params := listType.GetParameters()
-			if len(params) > 0 && params[0] != nil {
-				elementType, ok := params[0].(types.Type)
-				if !ok {
-					return fmt.Errorf("%w: invalid list element type", substraitgo.ErrInvalidType)
-				}
-				if err := validateAnyTypeBinding(p.Type, elementType, bindings); err != nil {
-					return err
-				}
-			}
-		}
-	case *types.ParameterizedMapType:
-		if mapType, ok := argType.(*types.MapType); ok {
-			params := mapType.GetParameters()
-			if len(params) >= 2 && params[0] != nil && params[1] != nil {
-				keyType, ok := params[0].(types.Type)
-				if !ok {
-					return fmt.Errorf("%w: invalid map key type", substraitgo.ErrInvalidType)
-				}
-				valueType, ok := params[1].(types.Type)
-				if !ok {
-					return fmt.Errorf("%w: invalid map value type", substraitgo.ErrInvalidType)
-				}
-				if err := validateAnyTypeBinding(p.Key, keyType, bindings); err != nil {
-					return err
-				}
-				if err := validateAnyTypeBinding(p.Value, valueType, bindings); err != nil {
-					return err
-				}
-			}
-		}
-	case *types.ParameterizedStructType:
-		if structType, ok := argType.(*types.StructType); ok {
-			params := structType.GetParameters()
-			if len(params) == len(p.Types) {
-				for i, fieldType := range p.Types {
-					if params[i] != nil {
-						elementType, ok := params[i].(types.Type)
-						if !ok {
-							return fmt.Errorf("%w: invalid struct field type at position %d", substraitgo.ErrInvalidType, i)
-						}
-						if err := validateAnyTypeBinding(fieldType, elementType, bindings); err != nil {
-							return err
-						}
-					}
-				}
-			}
-		}
-	}
-	return nil
-}
-
 // ValidateConstrainedAnyTypeConsistency validates that all uses of the same AnyN parameter
 // (e.g., any1, any2, etc.) resolve to the same concrete type across all arguments
 func ValidateConstrainedAnyTypeConsistency(funcParameters []types.FuncDefArgType, argumentTypes []types.Type, variadicBehavior *VariadicBehavior) error {
-	return newArgumentMatcher(MirrorNullability, funcParameters, variadicBehavior).validateConstrainedAnyTypeConsistency(argumentTypes)
-}
-
-// validateConstrainedAnyTypeConsistency checks that repeated anyN parameters bind to the same concrete type.
-func (m *argumentMatcher) validateConstrainedAnyTypeConsistency(argumentTypes []types.Type) error {
-	bindings := make(map[string]types.Type)
-
-	for i, funcParameter := range m.expandedParameters(argumentTypes) {
-		if i >= len(argumentTypes) {
-			break
-		}
-		if err := validateAnyTypeBinding(funcParameter, argumentTypes[i], bindings); err != nil {
+	matcher := newArgumentMatcher(MirrorNullability, funcParameters, variadicBehavior)
+	for argPos, argumentType := range argumentTypes {
+		match, err := matcher.matchArgument(argumentType, argPos)
+		if err != nil {
 			return err
 		}
+		if !match {
+			return fmt.Errorf("%w: argument types did not match", substraitgo.ErrInvalidType)
+		}
 	}
-
 	return nil
 }
 

--- a/extensions/variants_test.go
+++ b/extensions/variants_test.go
@@ -442,6 +442,92 @@ func valArg(typ types.FuncDefArgType) extensions.ValueArg {
 	return extensions.ValueArg{Value: &parser.TypeExpression{ValueType: typ}}
 }
 
+func mustParseFuncDefArg(t *testing.T, typeExpression string) types.FuncDefArgType {
+	t.Helper()
+
+	typ, err := parser.ParseType(typeExpression)
+	require.NoError(t, err)
+	return typ
+}
+
+func mustParseConcreteType(t *testing.T, typeExpression string) types.Type {
+	t.Helper()
+
+	typ, err := mustParseFuncDefArg(t, typeExpression).ReturnType(nil, nil)
+	require.NoError(t, err)
+	return typ
+}
+
+func TestNullabilityAndAnyTypeBindingDocExamples(t *testing.T) {
+	tests := []struct {
+		definition          string
+		nullabilityHandling extensions.NullabilityHandling
+		argTypes            []string
+		returnType          string
+		matches             bool
+		expectedReturnType  string
+	}{
+		{"f(any1, any1) -> any1", extensions.MirrorNullability, []string{"i32", "i32"}, "any1", true, "i32"},
+		{"f(any1, any1) -> any1", extensions.MirrorNullability, []string{"i32?", "i32"}, "any1", true, "i32?"},
+		{"f(any1, any1) -> any1", extensions.MirrorNullability, []string{"i32", "i32?"}, "any1", true, "i32?"},
+		{"f(any1, any1) -> any1", extensions.MirrorNullability, []string{"i32?", "i32?"}, "any1", true, "i32?"},
+		{"h(list<any1>, list<any1>) -> list<any1>", extensions.MirrorNullability, []string{"list<i32>", "list<i32>"}, "list<any1>", true, "list<i32>"},
+		{"h(list<any1>, list<any1>) -> list<any1>", extensions.MirrorNullability, []string{"list?<i32>", "list<i32>"}, "list<any1>", true, "list?<i32>"},
+		{"h(list<any1>, list<any1>) -> list<any1>", extensions.MirrorNullability, []string{"list<i32?>", "list<i32?>"}, "list<any1>", true, "list<i32?>"},
+		{"h(list<any1>, list<any1>) -> list<any1>", extensions.MirrorNullability, []string{"list<i32>", "list<i32?>"}, "list<any1>", false, ""},
+		{"k(func<any1 -> any1>) -> any1", extensions.MirrorNullability, []string{"func<i32 -> i32>"}, "any1", true, "i32"},
+		{"k(func<any1 -> any1>) -> any1", extensions.MirrorNullability, []string{"func<i32 -> fp64>"}, "any1", false, ""},
+		{"j(any1, list<any1?>) -> any1", extensions.MirrorNullability, []string{"i32", "list<i32?>"}, "any1", true, "i32"},
+		{"j(any1, list<any1?>) -> any1", extensions.MirrorNullability, []string{"i32", "list<i32>"}, "any1", false, ""},
+		{"j(any1, list<any1?>) -> any1", extensions.MirrorNullability, []string{"i32", "list<fp64?>"}, "any1", false, ""},
+		{"d(any1, any1) -> any1?", extensions.DeclaredOutputNullability, []string{"i32", "i32"}, "any1?", true, "i32?"},
+		{"d(any1, any1) -> any1?", extensions.DeclaredOutputNullability, []string{"i32?", "i32"}, "any1?", true, "i32?"},
+		{"d(any1, any1) -> any1?", extensions.DeclaredOutputNullability, []string{"i32?", "i32?"}, "any1?", true, "i32?"},
+		{"d(any1, any1) -> any1", extensions.DeclaredOutputNullability, []string{"i32", "i32"}, "any1", true, "i32"},
+		{"d(any1, any1) -> any1", extensions.DeclaredOutputNullability, []string{"i32?", "i32"}, "any1", true, "i32"},
+		{"d(any1, any1) -> any1", extensions.DeclaredOutputNullability, []string{"i32?", "i32?"}, "any1", true, "i32"},
+		{"g(any1, any1) -> any1", extensions.DiscreteNullability, []string{"i32", "i32"}, "any1", true, "i32"},
+		{"g(any1, any1) -> any1", extensions.DiscreteNullability, []string{"i32?", "i32?"}, "any1", false, ""},
+		{"g(any1, any1) -> any1", extensions.DiscreteNullability, []string{"i32", "i32?"}, "any1", false, ""},
+		{"g2(any1, any1?) -> any1?", extensions.DiscreteNullability, []string{"i32", "i32?"}, "any1?", true, "i32?"},
+		{"g2(any1, any1?) -> any1?", extensions.DiscreteNullability, []string{"i32", "i32"}, "any1?", false, ""},
+		{"g2(any1, any1?) -> any1?", extensions.DiscreteNullability, []string{"i32?", "i32?"}, "any1?", false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.definition+" with "+strings.Join(tt.argTypes, ", "), func(t *testing.T) {
+			funcParams := strings.TrimSuffix(strings.TrimPrefix(tt.definition[strings.Index(tt.definition, "("):strings.Index(tt.definition, ")")], "("), ")")
+			paramExpressions := strings.Split(funcParams, ", ")
+			parameters := make(extensions.FuncParameterList, len(paramExpressions))
+			for i, paramExpression := range paramExpressions {
+				parameters[i] = valArg(mustParseFuncDefArg(t, paramExpression))
+			}
+
+			arguments := make([]types.Type, len(tt.argTypes))
+			for i, argType := range tt.argTypes {
+				arguments[i] = mustParseConcreteType(t, argType)
+			}
+
+			actual, err := extensions.EvaluateTypeExpression(
+				"extension:test:def",
+				tt.nullabilityHandling,
+				mustParseFuncDefArg(t, tt.returnType),
+				parameters,
+				nil,
+				arguments,
+				extensions.NewSet())
+
+			if !tt.matches {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.True(t, mustParseConcreteType(t, tt.expectedReturnType).Equals(actual))
+		})
+	}
+}
+
 func TestResolveType(t *testing.T) {
 	// Test TypeReference setting logic for user-defined types
 	tests := []struct {
@@ -825,6 +911,45 @@ func TestValidateConstrainedAnyTypeConsistency(t *testing.T) {
 		err := extensions.ValidateConstrainedAnyTypeConsistency(params, args, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "type parameter any1 cannot be both i32 and i64")
+	})
+
+	t.Run("nested function types with matching parameter and return types", func(t *testing.T) {
+		// func(func<any1 -> any1>) with (func<i32 -> i32>)
+		params := []types.FuncDefArgType{
+			&types.ParameterizedFuncType{
+				Parameters: []types.FuncDefArgType{&types.AnyType{Name: "any1"}},
+				Return:     &types.AnyType{Name: "any1"},
+			},
+		}
+		args := []types.Type{
+			&types.FuncType{
+				ParameterTypes: []types.Type{&types.Int32Type{}},
+				ReturnType:     &types.Int32Type{},
+			},
+		}
+
+		err := extensions.ValidateConstrainedAnyTypeConsistency(params, args, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("nested function types with mismatched return type fail", func(t *testing.T) {
+		// func(func<any1 -> any1>) with (func<i32 -> fp64>)
+		params := []types.FuncDefArgType{
+			&types.ParameterizedFuncType{
+				Parameters: []types.FuncDefArgType{&types.AnyType{Name: "any1"}},
+				Return:     &types.AnyType{Name: "any1"},
+			},
+		}
+		args := []types.Type{
+			&types.FuncType{
+				ParameterTypes: []types.Type{&types.Int32Type{}},
+				ReturnType:     &types.Float64Type{},
+			},
+		}
+
+		err := extensions.ValidateConstrainedAnyTypeConsistency(params, args, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "type parameter any1 cannot be both i32 and fp64")
 	})
 
 	t.Run("single any1 parameter is always valid", func(t *testing.T) {


### PR DESCRIPTION
Constrained `any` matching needs to distinguish top-level argument nullability from nested component nullability. The previous separate consistency pass compared base types after structural matching, which made it difficult to correctly handle nested nullable components and function-typed parameters.

This changes the internal argument matcher to bind constrained `anyN` parameters as it walks the argument type. That lets matching preserve nested nullability where the signature requires it, ignore top-level nullability for mirror and declared-output functions, and enforce consistency inside list, map, struct, and function types.

Closes substrait-io/substrait#943

---
Note: This PR was developed with AI assistance. All changes have been reviewed, and I take full responsibility for this contribution.