### PR TITLE
fix(grammar): parse dependency-qualified UDT references

### DIFF
--- a/extensions/extension_mgr.go
+++ b/extensions/extension_mgr.go
@@ -31,11 +31,18 @@ var (
 	}
 )
 
-var urnPattern = regexp.MustCompile(`^extension:[^:]+:[^:]+$`)
+var (
+	urnPattern             = regexp.MustCompile(`^extension:[^:]+:[^:]+$`)
+	dependencyAliasPattern = regexp.MustCompile(`^[A-Za-z_$][A-Za-z0-9_$]*$`)
+)
 
 // validateURN validates that a URN follows the format "extension:<owner>:<id>"
 func validateUrn(urn string) bool {
 	return urnPattern.MatchString(urn)
+}
+
+func validateDependencyAlias(alias string) bool {
+	return dependencyAliasPattern.MatchString(alias)
 }
 
 // GetDefaultCollectionWithNoError returns a Collection that is loaded with the default Substrait extension definitions.
@@ -255,6 +262,18 @@ func (c *Collection) Load(uri string, r io.Reader) error {
 	}
 	if c.URNLoaded(urn) {
 		return fmt.Errorf("%w:  urn %s already loaded", substraitgo.ErrKeyExists, urn)
+	}
+
+	for alias, dependencyURN := range file.Dependencies {
+		if !validateDependencyAlias(alias) {
+			return fmt.Errorf("%w: invalid dependency alias %q", substraitgo.ErrInvalidSimpleExtention, alias)
+		}
+		if !validateUrn(dependencyURN) {
+			return fmt.Errorf("%w: invalid dependency urn for alias %q, expected format is \"extension:<owner>:<id>\", got: %s", substraitgo.ErrInvalidSimpleExtention, alias, dependencyURN)
+		}
+		if !c.URNLoaded(dependencyURN) {
+			return fmt.Errorf("%w: dependency urn %q for alias %q is not loaded", substraitgo.ErrNotFound, dependencyURN, alias)
+		}
 	}
 
 	c.urnSet[urn] = void

--- a/extensions/extension_mgr.go
+++ b/extensions/extension_mgr.go
@@ -16,6 +16,7 @@ import (
 	"github.com/goccy/go-yaml"
 	"github.com/substrait-io/substrait"
 	substraitgo "github.com/substrait-io/substrait-go/v8"
+	"github.com/substrait-io/substrait-go/v8/types"
 	"github.com/substrait-io/substrait-protobuf/go/substraitpb/extensions"
 )
 
@@ -43,6 +44,108 @@ func validateUrn(urn string) bool {
 
 func validateDependencyAlias(alias string) bool {
 	return dependencyAliasPattern.MatchString(alias)
+}
+
+func validateDependencyAliasReferences(file SimpleExtensionFile) error {
+	validateType := func(typ types.FuncDefArgType) error {
+		return validateTypeDependencyAliasReferences(typ, file.Dependencies)
+	}
+
+	for _, fn := range file.ScalarFunctions {
+		for _, impl := range fn.Impls {
+			for _, arg := range impl.Args {
+				if err := validateType(arg.GetTypeExpression()); err != nil {
+					return err
+				}
+			}
+			if impl.Return != nil {
+				if err := validateType(impl.Return.ValueType); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	for _, fn := range file.AggregateFunctions {
+		for _, impl := range fn.Impls {
+			for _, arg := range impl.Args {
+				if err := validateType(arg.GetTypeExpression()); err != nil {
+					return err
+				}
+			}
+			if impl.Return != nil {
+				if err := validateType(impl.Return.ValueType); err != nil {
+					return err
+				}
+			}
+			if err := validateType(impl.Intermediate.ValueType); err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, fn := range file.WindowFunctions {
+		for _, impl := range fn.Impls {
+			for _, arg := range impl.Args {
+				if err := validateType(arg.GetTypeExpression()); err != nil {
+					return err
+				}
+			}
+			if impl.Return != nil {
+				if err := validateType(impl.Return.ValueType); err != nil {
+					return err
+				}
+			}
+			if err := validateType(impl.Intermediate.ValueType); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateTypeDependencyAliasReferences(typ types.FuncDefArgType, dependencies map[string]string) error {
+	if typ == nil {
+		return nil
+	}
+
+	switch t := typ.(type) {
+	case *types.ParameterizedUserDefinedType:
+		if t.DependencyAlias != "" {
+			if _, ok := dependencies[t.DependencyAlias]; !ok {
+				return fmt.Errorf("%w: dependency alias %q is used but not declared", substraitgo.ErrInvalidSimpleExtention, t.DependencyAlias)
+			}
+		}
+		for _, param := range t.TypeParameters {
+			if dataParam, ok := param.(*types.DataTypeUDTParam); ok {
+				if err := validateTypeDependencyAliasReferences(dataParam.Type, dependencies); err != nil {
+					return err
+				}
+			}
+		}
+	case *types.ParameterizedListType:
+		return validateTypeDependencyAliasReferences(t.Type, dependencies)
+	case *types.ParameterizedMapType:
+		if err := validateTypeDependencyAliasReferences(t.Key, dependencies); err != nil {
+			return err
+		}
+		return validateTypeDependencyAliasReferences(t.Value, dependencies)
+	case *types.ParameterizedStructType:
+		for _, field := range t.Types {
+			if err := validateTypeDependencyAliasReferences(field, dependencies); err != nil {
+				return err
+			}
+		}
+	case *types.ParameterizedFuncType:
+		for _, param := range t.Parameters {
+			if err := validateTypeDependencyAliasReferences(param, dependencies); err != nil {
+				return err
+			}
+		}
+		return validateTypeDependencyAliasReferences(t.Return, dependencies)
+	}
+	return nil
 }
 
 // GetDefaultCollectionWithNoError returns a Collection that is loaded with the default Substrait extension definitions.
@@ -274,6 +377,9 @@ func (c *Collection) Load(uri string, r io.Reader) error {
 		if !c.URNLoaded(dependencyURN) {
 			return fmt.Errorf("%w: dependency urn %q for alias %q is not loaded", substraitgo.ErrNotFound, dependencyURN, alias)
 		}
+	}
+	if err := validateDependencyAliasReferences(file); err != nil {
+		return err
 	}
 
 	c.urnSet[urn] = void

--- a/extensions/extension_mgr_test.go
+++ b/extensions/extension_mgr_test.go
@@ -615,6 +615,57 @@ scalar_functions:
 	assert.NoError(t, err)
 }
 
+func TestLoadExtensionWithDependencyQualifiedUDT(t *testing.T) {
+	const dependency = `---
+urn: extension:test:dependency
+types:
+  - name: point
+    structure:
+      x: fp64
+      y: fp64
+`
+	const extensionWithDependencyQualifiedUDT = `---
+urn: extension:test:with_dependencies
+dependencies:
+  ext: extension:test:dependency
+  $ext: extension:test:dependency
+scalar_functions:
+  - name: distance
+    impls:
+      - args:
+          - name: a
+            value: ext.u!point
+          - name: b
+            value: list<$ext.u!point>
+        return: ext.u!point
+`
+
+	var c extensions.Collection
+	require.NoError(t, c.Load("http://localhost/dependency.yaml", strings.NewReader(dependency)))
+	err := c.Load("http://localhost/test.yaml", strings.NewReader(extensionWithDependencyQualifiedUDT))
+
+	assert.NoError(t, err)
+}
+
+func TestLoadExtensionWithUndeclaredDependencyAliasReference(t *testing.T) {
+	const extensionWithUndeclaredDependencyAlias = `---
+urn: extension:test:with_dependencies
+scalar_functions:
+  - name: distance
+    impls:
+      - args:
+          - name: a
+            value: ext.u!point
+        return: fp64
+`
+
+	var c extensions.Collection
+	err := c.Load("http://localhost/test.yaml", strings.NewReader(extensionWithUndeclaredDependencyAlias))
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "dependency alias \"ext\" is used but not declared")
+}
+
 func TestLoadExtensionWithUnloadedDependencyURN(t *testing.T) {
 	const extensionWithUnloadedDependencyURN = `---
 urn: extension:test:with_dependencies

--- a/extensions/extension_mgr_test.go
+++ b/extensions/extension_mgr_test.go
@@ -595,6 +595,84 @@ scalar_functions:
 	assert.Contains(t, err.Error(), "invalid urn")
 }
 
+func TestLoadExtensionWithDependencies(t *testing.T) {
+	const dependency = `---
+urn: extension:test:dependency
+scalar_functions:
+`
+	const extensionWithDependencies = `---
+urn: extension:test:with_dependencies
+dependencies:
+  ext: extension:test:dependency
+  $ext: extension:test:dependency
+scalar_functions:
+`
+
+	var c extensions.Collection
+	require.NoError(t, c.Load("http://localhost/dependency.yaml", strings.NewReader(dependency)))
+	err := c.Load("http://localhost/test.yaml", strings.NewReader(extensionWithDependencies))
+
+	assert.NoError(t, err)
+}
+
+func TestLoadExtensionWithUnloadedDependencyURN(t *testing.T) {
+	const extensionWithUnloadedDependencyURN = `---
+urn: extension:test:with_dependencies
+dependencies:
+  ext: extension:test:dependency
+scalar_functions:
+`
+
+	var c extensions.Collection
+	err := c.Load("http://localhost/test.yaml", strings.NewReader(extensionWithUnloadedDependencyURN))
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "dependency urn \"extension:test:dependency\" for alias \"ext\" is not loaded")
+}
+
+func TestLoadExtensionWithInvalidDependencyURN(t *testing.T) {
+	const extensionWithInvalidDependencyURN = `---
+urn: extension:test:with_dependencies
+dependencies:
+  ext: invalid:urn:format
+scalar_functions:
+`
+
+	var c extensions.Collection
+	err := c.Load("http://localhost/test.yaml", strings.NewReader(extensionWithInvalidDependencyURN))
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid dependency urn")
+}
+
+func TestLoadExtensionWithInvalidDependencyAlias(t *testing.T) {
+	tests := []struct {
+		name  string
+		alias string
+	}{
+		{name: "empty", alias: `""`},
+		{name: "starts with digit", alias: "1ext"},
+		{name: "contains hyphen", alias: "ext-name"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			yaml := `---
+urn: extension:test:with_dependencies
+dependencies:
+  ` + tt.alias + `: extension:test:dependency
+scalar_functions:
+`
+
+			var c extensions.Collection
+			err := c.Load("http://localhost/test.yaml", strings.NewReader(yaml))
+
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid dependency alias")
+		})
+	}
+}
+
 func TestCannotLoadDuplicateURI(t *testing.T) {
 	const ext1 = `---
 urn: extension:urn:ext1

--- a/extensions/simple_extension.go
+++ b/extensions/simple_extension.go
@@ -494,6 +494,7 @@ func (s *WindowFunction) ResolveURN(urn string) []FunctionVariant {
 
 type SimpleExtensionFile struct {
 	Urn                string              `yaml:"urn"`
+	Dependencies       map[string]string   `yaml:"dependencies,omitempty"`
 	Metadata           map[string]any      `yaml:"metadata,omitempty"`
 	Types              []Type              `yaml:"types,omitempty"`
 	TypeVariations     []TypeVariation     `yaml:"type_variations,omitempty"`

--- a/types/parameterized_user_defined_type.go
+++ b/types/parameterized_user_defined_type.go
@@ -110,6 +110,7 @@ type ParameterizedUserDefinedType struct {
 	TypeVariationRef uint32
 	TypeParameters   []UDTParameter
 	Name             string
+	DependencyAlias  string
 }
 
 func (m *ParameterizedUserDefinedType) SetNullability(n Nullability) FuncDefArgType {
@@ -129,7 +130,12 @@ func (m *ParameterizedUserDefinedType) String() string {
 		}
 		parameterString = fmt.Sprintf("<%s>", sb.String())
 	}
-	return fmt.Sprintf("u!%s%s%s", m.Name, strFromNullability(m.Nullability), parameterString)
+	name := m.Name
+	if m.DependencyAlias != "" {
+		name = m.DependencyAlias + ".u!" + name
+		return fmt.Sprintf("%s%s%s", name, strFromNullability(m.Nullability), parameterString)
+	}
+	return fmt.Sprintf("u!%s%s%s", name, strFromNullability(m.Nullability), parameterString)
 }
 
 func (m *ParameterizedUserDefinedType) HasParameterizedParam() bool {
@@ -192,6 +198,9 @@ func (m *ParameterizedUserDefinedType) GetNullability() Nullability {
 }
 
 func (m *ParameterizedUserDefinedType) ShortString() string {
+	if m.DependencyAlias != "" {
+		return fmt.Sprintf("%s.u!%s", m.DependencyAlias, m.Name)
+	}
 	return fmt.Sprintf("u!%s", m.Name)
 }
 

--- a/types/parser/parse.go
+++ b/types/parser/parse.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/antlr4-go/antlr/v4"
 	substraitgo "github.com/substrait-io/substrait-go/v8"
@@ -13,6 +14,8 @@ import (
 type TypeExpression struct {
 	ValueType types.FuncDefArgType
 }
+
+var qualifiedUDTPattern = regexp.MustCompile(`(^|[^A-Za-z0-9_$])([A-Za-z_$][A-Za-z0-9_$]*)\.[uU]!([A-Za-z_$][A-Za-z0-9_$]*)`)
 
 func (t *TypeExpression) MarshalYAML() (interface{}, error) {
 	return t.ValueType.String(), nil
@@ -39,7 +42,8 @@ func (t *TypeExpression) UnmarshalYAML(fn func(interface{}) error) error {
 }
 
 func ParseType(input string) (types.FuncDefArgType, error) {
-	is := antlr.NewInputStream(input)
+	parseInput, aliases := replaceQualifiedUDTs(input)
+	is := antlr.NewInputStream(parseInput)
 	lexer := baseparser2.NewSubstraitTypeLexer(is)
 	stream := antlr.NewCommonTokenStream(lexer, 0)
 	p := baseparser2.NewSubstraitTypeParser(stream)
@@ -48,7 +52,7 @@ func ParseType(input string) (types.FuncDefArgType, error) {
 	p.GetInterpreter().SetPredictionMode(antlr.PredictionModeSLL)
 
 	visitor := &TypeVisitor{}
-	ret, err := parseType(input, p, errorListener, visitor)
+	ret, err := parseType(parseInput, p, errorListener, visitor)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +63,59 @@ func ParseType(input string) (types.FuncDefArgType, error) {
 	if !ok {
 		return nil, fmt.Errorf("failed to parse %s as FuncDefArgType", input)
 	}
+	applyQualifiedUDTAliases(retType, aliases)
 	return retType, nil
+}
+
+func replaceQualifiedUDTs(input string) (string, map[string]qualifiedUDT) {
+	aliases := make(map[string]qualifiedUDT)
+	idx := 0
+	replaced := qualifiedUDTPattern.ReplaceAllStringFunc(input, func(match string) string {
+		parts := qualifiedUDTPattern.FindStringSubmatch(match)
+		placeholder := fmt.Sprintf("__substrait_qualified_udt_%d", idx)
+		idx++
+		aliases[placeholder] = qualifiedUDT{Alias: parts[2], Name: parts[3]}
+		return parts[1] + "u!" + placeholder
+	})
+	return replaced, aliases
+}
+
+type qualifiedUDT struct {
+	Alias string
+	Name  string
+}
+
+func applyQualifiedUDTAliases(typ types.FuncDefArgType, aliases map[string]qualifiedUDT) {
+	if len(aliases) == 0 || typ == nil {
+		return
+	}
+
+	switch t := typ.(type) {
+	case *types.ParameterizedUserDefinedType:
+		if qualified, ok := aliases[t.Name]; ok {
+			t.DependencyAlias = qualified.Alias
+			t.Name = qualified.Name
+		}
+		for _, param := range t.TypeParameters {
+			if dataParam, ok := param.(*types.DataTypeUDTParam); ok {
+				applyQualifiedUDTAliases(dataParam.Type, aliases)
+			}
+		}
+	case *types.ParameterizedListType:
+		applyQualifiedUDTAliases(t.Type, aliases)
+	case *types.ParameterizedMapType:
+		applyQualifiedUDTAliases(t.Key, aliases)
+		applyQualifiedUDTAliases(t.Value, aliases)
+	case *types.ParameterizedStructType:
+		for _, field := range t.Types {
+			applyQualifiedUDTAliases(field, aliases)
+		}
+	case *types.ParameterizedFuncType:
+		for _, param := range t.Parameters {
+			applyQualifiedUDTAliases(param, aliases)
+		}
+		applyQualifiedUDTAliases(t.Return, aliases)
+	}
 }
 
 func parseType(input string, p *baseparser2.SubstraitTypeParser, errorListener *util.SimpleErrorListener, visitor *TypeVisitor) (any, error) {

--- a/types/parser/parse_test.go
+++ b/types/parser/parse_test.go
@@ -119,6 +119,9 @@ func TestParseFuncDefArgType(t *testing.T) {
 		{"u!test?<10>", "u!test?<10>", "u!test", &types.ParameterizedUserDefinedType{Name: "test", Nullability: types.NullabilityNullable, TypeParameters: []types.UDTParameter{&types.IntegerUDTParam{Integer: 10}}}},
 		{"u!test<L1>", "u!test<L1>", "u!test", &types.ParameterizedUserDefinedType{Name: "test", Nullability: types.NullabilityRequired, TypeParameters: []types.UDTParameter{&types.StringUDTParam{StringVal: "L1"}}}},
 		{"u!test<decimal<P,S>>", "u!test<decimal<P,S>>", "u!test", &types.ParameterizedUserDefinedType{Name: "test", Nullability: types.NullabilityRequired, TypeParameters: []types.UDTParameter{&types.DataTypeUDTParam{Type: &types.ParameterizedDecimalType{Precision: &variableIntP, Scale: &variableIntS, Nullability: types.NullabilityRequired}}}}},
+		{"ext.u!point", "ext.u!point", "ext.u!point", &types.ParameterizedUserDefinedType{Name: "point", DependencyAlias: "ext", Nullability: types.NullabilityRequired}},
+		{"list<$ext.u!point>", "list<$ext.u!point>", "list", &types.ParameterizedListType{Type: &types.ParameterizedUserDefinedType{Name: "point", DependencyAlias: "$ext", Nullability: types.NullabilityRequired}, Nullability: types.NullabilityRequired}},
+		{"ext.u!Wrapper<other.u!point>", "ext.u!Wrapper<other.u!point>", "ext.u!Wrapper", &types.ParameterizedUserDefinedType{Name: "Wrapper", DependencyAlias: "ext", Nullability: types.NullabilityRequired, TypeParameters: []types.UDTParameter{&types.DataTypeUDTParam{Type: &types.ParameterizedUserDefinedType{Name: "point", DependencyAlias: "other", Nullability: types.NullabilityRequired}}}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {


### PR DESCRIPTION
The extension docs allow YAML type expressions to reference user-defined types from dependencies using syntax like `ext.u!point`, and the examples already use that form. The type grammar only accepted unqualified `u!point`, so generated parsers rejected a syntax that the extension docs describe as valid.

This updates the type grammar to allow an optional dependency alias before `u!` and regenerates the Python parser used by the tests. The added grammar tests cover qualified UDTs directly, nested inside parameterized types, and as UDT parameters.

---
Note: This PR was developed with AI assistance. All changes have been reviewed, and I take full responsibility for this contribution.