### PR TITLE
feat(extensions)!: drop loader URI tracking

### DIFF
--- a/expr/builder_test.go
+++ b/expr/builder_test.go
@@ -155,7 +155,7 @@ window_functions:
 
 	customReader := strings.NewReader(custom)
 	collection := extensions.Collection{}
-	err := collection.Load("custom", customReader)
+	err := collection.Load(customReader)
 	require.NoError(t, err)
 
 	planBuilder := plan.NewBuilder(&collection)

--- a/expr/expressions_test.go
+++ b/expr/expressions_test.go
@@ -45,7 +45,7 @@ scalar_functions:
 var collection ext.Collection
 
 func init() {
-	err := collection.Load("https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml", strings.NewReader(sampleYAML))
+	err := collection.Load(strings.NewReader(sampleYAML))
 	if err != nil {
 		panic(err)
 	}

--- a/expr/user_defined_literal_test.go
+++ b/expr/user_defined_literal_test.go
@@ -30,7 +30,7 @@ types:
 // can be round-tripped
 func TestUserDefinedLiteralRoundTrip(t *testing.T) {
 	collection := &extensions.Collection{}
-	err := collection.Load("test/uri", strings.NewReader(testExtensionYAML))
+	err := collection.Load(strings.NewReader(testExtensionYAML))
 	pointID := extensions.ID{
 		URN:  "extension:test:point_type",
 		Name: "point",
@@ -62,7 +62,7 @@ func TestUserDefinedLiteralRoundTrip(t *testing.T) {
 // TestNewUserDefinedLiteralHelper demonstrates the simplified API for creating user-defined literals
 func TestNewUserDefinedLiteralHelper(t *testing.T) {
 	collection := &extensions.Collection{}
-	err := collection.Load("test/uri", strings.NewReader(testExtensionYAML))
+	err := collection.Load(strings.NewReader(testExtensionYAML))
 	require.NoError(t, err)
 
 	registry := expr.NewEmptyExtensionRegistry(collection)
@@ -116,7 +116,7 @@ types:
 // simple string to demonstrate this.
 func TestUserDefinedLiteralWithAnyRepresentation(t *testing.T) {
 	collection := &extensions.Collection{}
-	err := collection.Load("test/uri", strings.NewReader(nestedTypesYAML))
+	err := collection.Load(strings.NewReader(nestedTypesYAML))
 	require.NoError(t, err)
 
 	registry := expr.NewEmptyExtensionRegistry(collection)
@@ -146,7 +146,7 @@ func TestUserDefinedLiteralWithAnyRepresentation(t *testing.T) {
 // user-defined type using Struct representation.
 func TestUserDefinedLiteralWithStructRepresentation(t *testing.T) {
 	collection := &extensions.Collection{}
-	err := collection.Load("test/uri", strings.NewReader(nestedTypesYAML))
+	err := collection.Load(strings.NewReader(nestedTypesYAML))
 	require.NoError(t, err)
 
 	registry := expr.NewEmptyExtensionRegistry(collection)
@@ -177,7 +177,7 @@ func TestUserDefinedLiteralWithStructRepresentation(t *testing.T) {
 // uses Any representation, and would typically encode its nested point UDTs within that Any value.
 func TestNestedUserDefinedLiteralWithAnyRepresentation(t *testing.T) {
 	collection := &extensions.Collection{}
-	err := collection.Load("test/uri", strings.NewReader(nestedTypesYAML))
+	err := collection.Load(strings.NewReader(nestedTypesYAML))
 	require.NoError(t, err)
 
 	registry := expr.NewEmptyExtensionRegistry(collection)
@@ -208,7 +208,7 @@ func TestNestedUserDefinedLiteralWithAnyRepresentation(t *testing.T) {
 // use Struct representation.
 func TestNestedUserDefinedLiteralWithStructRepresentation(t *testing.T) {
 	collection := &extensions.Collection{}
-	err := collection.Load("test/uri", strings.NewReader(nestedTypesYAML))
+	err := collection.Load(strings.NewReader(nestedTypesYAML))
 	require.NoError(t, err)
 
 	registry := expr.NewEmptyExtensionRegistry(collection)
@@ -269,7 +269,7 @@ func TestNestedUserDefinedLiteralWithStructRepresentation(t *testing.T) {
 // while the nested point UDTs use Any representation.
 func TestMixedRepresentationNestedUserDefinedLiteral(t *testing.T) {
 	collection := &extensions.Collection{}
-	err := collection.Load("test/uri", strings.NewReader(nestedTypesYAML))
+	err := collection.Load(strings.NewReader(nestedTypesYAML))
 	require.NoError(t, err)
 
 	registry := expr.NewEmptyExtensionRegistry(collection)
@@ -314,7 +314,7 @@ func TestMixedRepresentationNestedUserDefinedLiteral(t *testing.T) {
 // are correctly preserved during serialization and deserialization.
 func TestParameterizedVectorUDTRoundtrip(t *testing.T) {
 	collection := &extensions.Collection{}
-	err := collection.Load("test/uri", strings.NewReader(nestedTypesYAML))
+	err := collection.Load(strings.NewReader(nestedTypesYAML))
 	require.NoError(t, err)
 
 	registry := expr.NewEmptyExtensionRegistry(collection)

--- a/extensions/extension_mgr.go
+++ b/extensions/extension_mgr.go
@@ -21,7 +21,6 @@ import (
 
 type AdvancedExtension = extensions.AdvancedExtension
 
-const SubstraitDefaultURIPrefix = "https://github.com/substrait-io/substrait/blob/main/extensions/"
 const SubstraitDefaultURNPrefix = "extension:io.substrait:"
 
 var (
@@ -84,44 +83,12 @@ func loadExtensionFile(collection *Collection, substraitFS embed.FS, ent fs.DirE
 	}
 	fileName := path.Base(fileStat.Name())
 	if _, ok := unsupportedExtensions[fileName]; !ok {
-		err = collection.Load(SubstraitDefaultURIPrefix+ent.Name(), f)
+		err = collection.Load(f)
 		if err != nil {
 			return err
 		}
 	}
 	return nil
-}
-
-// This is just an implementation detail during the uri -> urn migration
-// This entire struct will be dropped once the migration is complete.
-type uriUrnBiMap struct {
-	uriToUrn map[string]string
-	urnToUri map[string]string
-}
-
-func newuriUrnBiMap() *uriUrnBiMap {
-	return &uriUrnBiMap{
-		uriToUrn: make(map[string]string),
-		urnToUri: make(map[string]string),
-	}
-}
-
-// Here we are assuming that we are never overwriting.
-// This is okay because we actually check for the existence right before
-// calling this function
-func (bm *uriUrnBiMap) add(uri, urn string) {
-	bm.uriToUrn[uri] = urn
-	bm.urnToUri[urn] = uri
-}
-
-func (bm *uriUrnBiMap) getUri(urn string) (string, bool) {
-	uri, found := bm.urnToUri[urn]
-	return uri, found
-}
-
-func (bm *uriUrnBiMap) getUrn(uri string) (string, bool) {
-	urn, found := bm.uriToUrn[uri]
-	return urn, found
 }
 
 // ID is the unique identifier for a substrait object
@@ -133,8 +100,7 @@ type ID struct {
 }
 
 type Collection struct {
-	urnSet      map[string]struct{}
-	urnUriBiMap *uriUrnBiMap
+	urnSet map[string]struct{}
 
 	simpleNameMap map[ID]string
 
@@ -221,7 +187,6 @@ func (c *Collection) GetWindowFunc(id ID) (*WindowFunctionVariant, bool) {
 func (c *Collection) init() {
 	if c.urnSet == nil {
 		c.urnSet = make(map[string]struct{})
-		c.urnUriBiMap = newuriUrnBiMap()
 		c.simpleNameMap = make(map[ID]string)
 		c.scalarMap = make(map[ID]*ScalarFunctionVariant)
 		c.aggregateMap = make(map[ID]*AggregateFunctionVariant)
@@ -232,13 +197,8 @@ func (c *Collection) init() {
 	}
 }
 
-func (c *Collection) Load(uri string, r io.Reader) error {
+func (c *Collection) Load(r io.Reader) error {
 	c.init()
-
-	if c.URILoaded(uri) {
-		return fmt.Errorf("%w: uri '%s' already loaded",
-			substraitgo.ErrKeyExists, uri)
-	}
 
 	var file SimpleExtensionFile
 	dec := yaml.NewDecoder(r)
@@ -258,7 +218,6 @@ func (c *Collection) Load(uri string, r io.Reader) error {
 	}
 
 	c.urnSet[urn] = void
-	c.urnUriBiMap.add(uri, urn)
 
 	if file.Metadata != nil {
 		c.fileMetadataMap[urn] = file.Metadata
@@ -336,11 +295,6 @@ func (c *Collection) Load(uri string, r io.Reader) error {
 func (c *Collection) URNLoaded(urn string) bool {
 	_, ok := c.urnSet[urn]
 	return ok
-}
-
-func (c *Collection) URILoaded(uri string) bool {
-	_, found := c.urnUriBiMap.getUrn(uri)
-	return found
 }
 
 func (c *Collection) GetAllScalarFunctions() []*ScalarFunctionVariant {
@@ -647,7 +601,7 @@ func GetExtensionSet(plan TopLevel, c *Collection) (Set, error) {
 			return "", fmt.Errorf("unable to resolve extension reference: URN reference %d could not be resolved", urnRef)
 		}
 		// Validate that the URN exists in the Collection
-		if _, found := c.urnUriBiMap.getUri(urn); !found {
+		if !c.URNLoaded(urn) {
 			return "", fmt.Errorf("%w: URN '%s' not found in extension collection", substraitgo.ErrNotFound, urn)
 		}
 		return urn, nil

--- a/extensions/extension_mgr_test.go
+++ b/extensions/extension_mgr_test.go
@@ -88,11 +88,10 @@ aggregate_functions:
 `
 
 func TestLoadExtensionCollection(t *testing.T) {
-	const uri = "http://localhost/sample.yaml"
 	const urn = "extension:test:sample"
 
 	var c extensions.Collection
-	require.NoError(t, c.Load(uri, strings.NewReader(sampleYAML)))
+	require.NoError(t, c.Load(strings.NewReader(sampleYAML)))
 
 	t.Run("check types", func(t *testing.T) {
 		id := extensions.ID{URN: urn}
@@ -161,7 +160,6 @@ func TestLoadExtensionCollection(t *testing.T) {
 }
 
 func TestExtensionSet(t *testing.T) {
-	const uri = "http://localhost/sample.yaml"
 	const urn = "extension:test:sample"
 
 	s := extensions.NewSet()
@@ -195,7 +193,7 @@ func TestExtensionSet(t *testing.T) {
 	})
 
 	var c extensions.Collection
-	require.NoError(t, c.Load(uri, strings.NewReader(sampleYAML)))
+	require.NoError(t, c.Load(strings.NewReader(sampleYAML)))
 
 	t.Run("lookup from collection", func(t *testing.T) {
 		fn, ok := s.LookupScalarFunction(1, &c)
@@ -354,7 +352,6 @@ func TestCollection_GetAllScalarFunctions(t *testing.T) {
 }
 
 func TestScalarFunctionImpl_DeterministicYAML(t *testing.T) {
-	const uri = "http://localhost/det.yaml"
 	tests := []struct {
 		name     string
 		yaml     string
@@ -408,7 +405,7 @@ scalar_functions:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var c extensions.Collection
-			require.NoError(t, c.Load(uri+tt.name, strings.NewReader(tt.yaml)))
+			require.NoError(t, c.Load(strings.NewReader(tt.yaml)))
 
 			var urn string
 			for _, line := range strings.Split(tt.yaml, "\n") {
@@ -426,11 +423,10 @@ scalar_functions:
 }
 
 func TestAggregateToWindow(t *testing.T) {
-	const uri = "http://localhost/sample.yaml"
 	const urn = "extension:test:sample"
 
 	var c extensions.Collection
-	require.NoError(t, c.Load(uri, strings.NewReader(sampleYAML)))
+	require.NoError(t, c.Load(strings.NewReader(sampleYAML)))
 
 	t.Run("aggregate functions available as window functions", func(t *testing.T) {
 		// Test that the count function (with args) is available as both aggregate and window function
@@ -576,7 +572,7 @@ scalar_functions:
 `
 
 	var c extensions.Collection
-	err := c.Load("http://localhost/test.yaml", strings.NewReader(extensionWithoutURN))
+	err := c.Load(strings.NewReader(extensionWithoutURN))
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "missing urn")
@@ -589,30 +585,10 @@ scalar_functions:
 `
 
 	var c extensions.Collection
-	err := c.Load("http://localhost/test.yaml", strings.NewReader(extensionWithInvalidURN))
+	err := c.Load(strings.NewReader(extensionWithInvalidURN))
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid urn")
-}
-
-func TestCannotLoadDuplicateURI(t *testing.T) {
-	const ext1 = `---
-urn: extension:urn:ext1
-scalar_functions:
-`
-	const ext2 = `---
-urn: extension:urn:ext2
-scalar_functions:
-`
-
-	var c extensions.Collection
-	err := c.Load("http://localhost/test.yaml", strings.NewReader(ext1))
-	assert.NoError(t, err)
-
-	err = c.Load("http://localhost/test.yaml", strings.NewReader(ext2))
-
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "already loaded")
 }
 
 func TestCannotLoadDuplicateURN(t *testing.T) {
@@ -622,10 +598,10 @@ scalar_functions:
 `
 
 	var c extensions.Collection
-	err := c.Load("http://localhost/test.yaml", strings.NewReader(extension))
+	err := c.Load(strings.NewReader(extension))
 	assert.NoError(t, err)
 
-	err = c.Load("http://localhost/test2.yaml", strings.NewReader(extension))
+	err = c.Load(strings.NewReader(extension))
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "already loaded")
@@ -633,7 +609,7 @@ scalar_functions:
 
 func TestToProtoPopulatesURN(t *testing.T) {
 	c := &extensions.Collection{}
-	require.NoError(t, c.Load("some/uri", strings.NewReader(sampleYAML)))
+	require.NoError(t, c.Load(strings.NewReader(sampleYAML)))
 
 	plan := &proto.Plan{
 		ExtensionUrns: []*extensionspb.SimpleExtensionURN{
@@ -666,7 +642,7 @@ func TestToProtoPopulatesURN(t *testing.T) {
 
 func TestResolveRefToURNAllConditions(t *testing.T) {
 	c := &extensions.Collection{}
-	err := c.Load("some/uri", strings.NewReader(sampleYAML))
+	err := c.Load(strings.NewReader(sampleYAML))
 	require.NoError(t, err)
 
 	t.Run("non-zero URN reference found and valid", func(t *testing.T) {
@@ -779,7 +755,7 @@ scalar_functions:
         return: struct<any1>
 `
 	var c extensions.Collection
-	require.NoError(t, c.Load("http://test", strings.NewReader(yaml)))
+	require.NoError(t, c.Load(strings.NewReader(yaml)))
 
 	fn, _ := c.GetScalarFunc(extensions.ID{URN: "extension:x:test", Name: "f:any"})
 	i64 := &types.Int64Type{Nullability: types.NullabilityRequired}
@@ -806,7 +782,7 @@ scalar_functions:
         return: map<any1, any2>
 `
 	var c extensions.Collection
-	require.NoError(t, c.Load("http://test", strings.NewReader(yaml)))
+	require.NoError(t, c.Load(strings.NewReader(yaml)))
 
 	fn, _ := c.GetScalarFunc(extensions.ID{URN: "extension:x:test", Name: "f:any_any"})
 	str := &types.StringType{Nullability: types.NullabilityRequired}
@@ -836,7 +812,7 @@ scalar_functions:
         return: u!Wrapper<any1>
 `
 	var c extensions.Collection
-	require.NoError(t, c.Load("http://test", strings.NewReader(yaml)))
+	require.NoError(t, c.Load(strings.NewReader(yaml)))
 
 	fn, _ := c.GetScalarFunc(extensions.ID{URN: "extension:x:test", Name: "f:any"})
 	i64 := &types.Int64Type{Nullability: types.NullabilityRequired}
@@ -896,7 +872,7 @@ window_functions:
 `
 
 	var c extensions.Collection
-	require.NoError(t, c.Load("http://test-metadata", strings.NewReader(yamlWithMetadata)))
+	require.NoError(t, c.Load(strings.NewReader(yamlWithMetadata)))
 
 	urn := "extension:test:metadata_test"
 

--- a/functions/dialect_test.go
+++ b/functions/dialect_test.go
@@ -601,7 +601,7 @@ scalar_functions:
 `
 	// get substrait function registry
 	var c extensions.Collection
-	require.NoError(t, c.Load(urn, strings.NewReader(defYaml)))
+	require.NoError(t, c.Load(strings.NewReader(defYaml)))
 	funcRegistry := NewFunctionRegistry(&c)
 	localRegistry := getLocalFunctionRegistry(t, dialectYaml, funcRegistry)
 
@@ -665,7 +665,7 @@ scalar_functions:
 `
 	// get substrait function registry
 	var c extensions.Collection
-	require.NoError(t, c.Load(urn, strings.NewReader(defYaml)))
+	require.NoError(t, c.Load(strings.NewReader(defYaml)))
 	funcRegistry := NewFunctionRegistry(&c)
 	localRegistry := getLocalFunctionRegistry(t, dialectYaml, funcRegistry)
 
@@ -738,7 +738,7 @@ scalar_functions:
 `
 	// get substrait function registry
 	var c extensions.Collection
-	require.NoError(t, c.Load(urn, strings.NewReader(defYaml)))
+	require.NoError(t, c.Load(strings.NewReader(defYaml)))
 	funcRegistry := NewFunctionRegistry(&c)
 	localRegistry := getLocalFunctionRegistry(t, dialectYaml, funcRegistry)
 
@@ -821,7 +821,7 @@ scalar_functions:
 `
 	// get substrait function registry
 	var c extensions.Collection
-	require.NoError(t, c.Load(urn, strings.NewReader(defYaml)))
+	require.NoError(t, c.Load(strings.NewReader(defYaml)))
 	funcRegistry := NewFunctionRegistry(&c)
 	localRegistry := getLocalFunctionRegistry(t, dialectYaml, funcRegistry)
 
@@ -895,7 +895,7 @@ scalar_functions:
 `
 	// get substrait function registry
 	var c extensions.Collection
-	require.NoError(t, c.Load(urn, strings.NewReader(defYaml)))
+	require.NoError(t, c.Load(strings.NewReader(defYaml)))
 	funcRegistry := NewFunctionRegistry(&c)
 	localRegistry := getLocalFunctionRegistry(t, dialectYaml, funcRegistry)
 
@@ -950,7 +950,7 @@ scalar_functions:
 `
 	// get substrait function registry
 	var c extensions.Collection
-	require.NoError(t, c.Load(urn, strings.NewReader(defYaml)))
+	require.NoError(t, c.Load(strings.NewReader(defYaml)))
 	funcRegistry := NewFunctionRegistry(&c)
 	localRegistry := getLocalFunctionRegistry(t, dialectYaml, funcRegistry)
 
@@ -1033,7 +1033,7 @@ scalar_functions:
 `
 	// get substrait function registry
 	var c extensions.Collection
-	require.NoError(t, c.Load(urn, strings.NewReader(defYaml)))
+	require.NoError(t, c.Load(strings.NewReader(defYaml)))
 	funcRegistry := NewFunctionRegistry(&c)
 	localRegistry := getLocalFunctionRegistry(t, dialectYaml, funcRegistry)
 
@@ -1100,7 +1100,7 @@ scalar_functions:
 `
 	// get substrait function registry
 	var c extensions.Collection
-	require.NoError(t, c.Load(urn, strings.NewReader(defYaml)))
+	require.NoError(t, c.Load(strings.NewReader(defYaml)))
 	funcRegistry := NewFunctionRegistry(&c)
 	localRegistry := getLocalFunctionRegistry(t, dialectYaml, funcRegistry)
 
@@ -1159,7 +1159,7 @@ scalar_functions:
 `
 	// get substrait function registry
 	var c extensions.Collection
-	require.NoError(t, c.Load(urn, strings.NewReader(defYaml)))
+	require.NoError(t, c.Load(strings.NewReader(defYaml)))
 	funcRegistry := NewFunctionRegistry(&c)
 	localRegistry := getLocalFunctionRegistry(t, dialectYaml, funcRegistry)
 
@@ -1220,7 +1220,7 @@ scalar_functions:
 `
 	// get substrait function registry
 	var c extensions.Collection
-	require.NoError(t, c.Load(urn, strings.NewReader(defYaml)))
+	require.NoError(t, c.Load(strings.NewReader(defYaml)))
 	funcRegistry := NewFunctionRegistry(&c)
 	localRegistry := getLocalFunctionRegistry(t, dialectYaml, funcRegistry)
 
@@ -1288,7 +1288,7 @@ aggregate_functions:
 `
 	// get substrait function registry
 	var c extensions.Collection
-	require.NoError(t, c.Load(urn, strings.NewReader(defYaml)))
+	require.NoError(t, c.Load(strings.NewReader(defYaml)))
 	funcRegistry := NewFunctionRegistry(&c)
 	localRegistry := getLocalFunctionRegistry(t, dialectYaml, funcRegistry)
 
@@ -1354,7 +1354,7 @@ window_functions:
 `
 	// get substrait function registry
 	var c extensions.Collection
-	require.NoError(t, c.Load(urn, strings.NewReader(defYaml)))
+	require.NoError(t, c.Load(strings.NewReader(defYaml)))
 	funcRegistry := NewFunctionRegistry(&c)
 	localRegistry := getLocalFunctionRegistry(t, dialectYaml, funcRegistry)
 
@@ -1643,8 +1643,8 @@ scalar_functions:
 `
 	// get substrait function registry
 	var c extensions.Collection
-	require.NoError(t, c.Load(arithmeticUrn, strings.NewReader(arithmeticYaml)))
-	require.NoError(t, c.Load(decimalUrn, strings.NewReader(decimalYaml)))
+	require.NoError(t, c.Load(strings.NewReader(arithmeticYaml)))
+	require.NoError(t, c.Load(strings.NewReader(decimalYaml)))
 	funcRegistry := NewFunctionRegistry(&c)
 	localRegistry := getLocalFunctionRegistry(t, dialectYaml, funcRegistry)
 	allFunctions := funcRegistry.GetAllFunctions()
@@ -1782,8 +1782,8 @@ aggregate_functions:
 `
 	// get substrait function registry
 	var c extensions.Collection
-	require.NoError(t, c.Load(arithmeticUrn, strings.NewReader(arithmeticYaml)))
-	require.NoError(t, c.Load(decimalUrn, strings.NewReader(decimalYaml)))
+	require.NoError(t, c.Load(strings.NewReader(arithmeticYaml)))
+	require.NoError(t, c.Load(strings.NewReader(decimalYaml)))
 	funcRegistry := NewFunctionRegistry(&c)
 	localRegistry := getLocalFunctionRegistry(t, dialectYaml, funcRegistry)
 	allFunctions := funcRegistry.GetAllFunctions()

--- a/functions/dialect_test.go
+++ b/functions/dialect_test.go
@@ -569,7 +569,6 @@ func checkCompoundNames(t *testing.T, compoundNames []string, expectedNames []st
 
 // test match functionality fails if it has sync param
 func TestScalarFunctionsSyncParamsError(t *testing.T) {
-	const urn = "extension:test:def"
 	const defYaml = `---
 urn: extension:test:def
 scalar_functions:
@@ -633,7 +632,6 @@ scalar_functions:
 
 // test match functionality with MIRROR nullability
 func TestScalarFunctionsMirrorNullabilityMatch(t *testing.T) {
-	const urn = "extension:test:def"
 	const defYaml = `---
 urn: extension:test:def
 scalar_functions:
@@ -705,7 +703,6 @@ scalar_functions:
 
 // test match functionality DeclaredOutput nullability
 func TestScalarFunctionsDeclaredOutputNullabilityMatch(t *testing.T) {
-	const urn = "extension:test:def"
 	const defYaml = `---
 urn: extension:test:def
 scalar_functions:
@@ -774,7 +771,6 @@ scalar_functions:
 
 // test match functionality with DISCRETE nullability
 func TestScalarFunctionsDiscreteNullabilityMatch(t *testing.T) {
-	const urn = "extension:test:def"
 	const defYaml = `---
 urn: extension:test:def
 scalar_functions:
@@ -860,7 +856,6 @@ scalar_functions:
 
 // test match functionality returns true for function with variadic argument
 func TestScalarFunctionsVariadicMatch(t *testing.T) {
-	const urn = "extension:test:def"
 	const defYaml = `---
 urn: extension:test:def
 scalar_functions:
@@ -918,7 +913,6 @@ scalar_functions:
 }
 
 func TestScalarFunctionsVariadicMin0(t *testing.T) {
-	const urn = "extension:test:def"
 	const defYaml = `---
 urn: extension:test:def
 scalar_functions:
@@ -995,7 +989,6 @@ scalar_functions:
 // this tests that match functionality returns true for function with variadic argument
 // when argument count is greater than variadic min count
 func TestScalarFuncVariadicArgMatch(t *testing.T) {
-	const urn = "extension:test:def"
 	const defYaml = `---
 urn: extension:test:def
 scalar_functions:
@@ -1062,7 +1055,6 @@ scalar_functions:
 // this tests that match functionality returns true for function with variadic argument
 // when argument count is greater than variadic min count
 func TestScalarFuncVariadicArgMisMatch(t *testing.T) {
-	const urn = "extension:test:def"
 	const defYaml = `---
 urn: extension:test:def
 scalar_functions:
@@ -1125,7 +1117,6 @@ scalar_functions:
 // test match functionality returns true for function with variadic argument
 // if argument count is lesser than variadic min count
 func TestScalarFuncVariadicMismatch(t *testing.T) {
-	const urn = "extension:test:def"
 	const defYaml = `---
 urn: extension:test:def
 scalar_functions:
@@ -1184,7 +1175,6 @@ scalar_functions:
 // test match functionality returns false if consistency check for argument fails
 // when function implementation has "CONSISTENCY" property for parameter consistency
 func TestScalarFuncVariadicConsistencyCheckMisMatch(t *testing.T) {
-	const urn = "extension:test:def"
 	const defYaml = `---
 urn: extension:test:def
 scalar_functions:
@@ -1240,7 +1230,6 @@ scalar_functions:
 }
 
 func TestAggregateFuncMinMax(t *testing.T) {
-	const urn = "extension:test:def"
 	const defYaml = `---
 urn: extension:test:def
 aggregate_functions:
@@ -1306,7 +1295,6 @@ aggregate_functions:
 }
 
 func TestWindowFuncMinMax(t *testing.T) {
-	const urn = "extension:test:def"
 	const defYaml = `---
 urn: extension:test:def
 window_functions:

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -86,7 +86,7 @@ scalar_functions:
 
 func TestPlanRoundTripWithExtensions(t *testing.T) {
 	c := &extensions.Collection{}
-	err := c.Load("some/uri", strings.NewReader(sampleYAML))
+	err := c.Load(strings.NewReader(sampleYAML))
 	require.NoError(t, err)
 
 	original := &proto.Plan{


### PR DESCRIPTION
Follow-up to #212. The protobuf API no longer has simple extension URI fields, but `Collection.Load` still accepted a source URI and the collection still kept a URI-to-URN map internally.

This removes that leftover loader URI state and makes loaded-extension identity fully URN-based. `Collection.Load` now reads the extension URN from the YAML file and duplicate detection happens only on that URN.

This is a breaking API cleanup because `Collection.Load` no longer takes a URI argument.

---
Note: This PR was developed with AI assistance. All changes have been reviewed, and I take full responsibility for this contribution.