### PR TITLE
ci: disable scheduled releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,10 @@ name: Release
 
 on:
   pull_request:    
-  schedule:
-    # 2 AM on Sunday
-    - cron: "0 2 * * 0"
+  # Uncomment to enable scheduled releases.
+  # schedule:
+  #   # 2 AM on Sunday
+  #   - cron: "0 2 * * 0"
   workflow_dispatch:
 
 # we do not want more than one release workflow executing at the same time, ever


### PR DESCRIPTION
Stops the release workflow from running on the weekly schedule while keeping the configuration commented out so it can be restored easily later. Manual and PR-triggered runs remain available.

This is so we can batch lots of changes for the next release. 