### PR TITLE
feat(extensions): resolve UDT URNs while parsing

### DIFF
--- a/expr/expressions_test.go
+++ b/expr/expressions_test.go
@@ -380,7 +380,7 @@ func TestRoundTripUsingTestData(t *testing.T) {
 			assert.True(t, e.Equals(e))
 
 			if typTest, ok := test["type"].(string); ok {
-				exp, err := parser.ParseType(typTest)
+				exp, err := parser.ParseType(typTest, nil)
 				require.NoError(t, err)
 
 				assert.Equal(t, exp.String(), e.GetType().String())

--- a/extensions/simple_extension.go
+++ b/extensions/simple_extension.go
@@ -3,10 +3,11 @@
 package extensions
 
 import (
+	"context"
 	"fmt"
-	"reflect"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	substraitgo "github.com/substrait-io/substrait-go/v8"
 	"github.com/substrait-io/substrait-go/v8/types"
 	"github.com/substrait-io/substrait-go/v8/types/parser"
@@ -114,7 +115,7 @@ func (v TypeArg) GetTypeExpression() types.FuncDefArgType {
 
 type FuncParameterList []FuncParameter
 
-func (a *FuncParameterList) UnmarshalYAML(fn func(interface{}) error) error {
+func (a *FuncParameterList) UnmarshalYAML(ctx context.Context, fn func(interface{}) error) error {
 	var args []map[string]any
 	if err := fn(&args); err != nil {
 		return err
@@ -149,45 +150,29 @@ func (a *FuncParameterList) UnmarshalYAML(fn func(interface{}) error) error {
 				constant = c.(bool)
 			}
 
-			arg := ValueArg{
+			valueType, err := parseTypeExpressionFromYAMLValue(ctx, val)
+			if err != nil {
+				return fmt.Errorf("failure reading YAML %v", err)
+			}
+
+			(*a)[i] = ValueArg{
 				Name:        name,
 				Description: desc,
-				Value:       new(parser.TypeExpression),
+				Value:       &valueType,
 				Constant:    constant,
 			}
-			err := arg.Value.UnmarshalYAML(func(v any) error {
-				rv := reflect.ValueOf(v)
-				if rv.Type().Kind() != reflect.Ptr {
-					return substraitgo.ErrInvalidType
-				}
-				rv.Elem().Set(reflect.ValueOf(val))
-				return nil
-			})
-			if err != nil {
-				return fmt.Errorf("failure reading YAML %v", err)
-			}
-
-			(*a)[i] = arg
 
 		} else if typ, ok := arg["type"]; ok {
-			arg := TypeArg{
-				Name:        name,
-				Description: desc,
-				Type:        new(parser.TypeExpression),
-			}
-			err := arg.Type.UnmarshalYAML(func(v any) error {
-				rv := reflect.ValueOf(v)
-				if rv.Type().Kind() != reflect.Ptr {
-					return substraitgo.ErrInvalidType
-				}
-				rv.Elem().Set(reflect.ValueOf(typ))
-				return nil
-			})
+			typeExpr, err := parseTypeExpressionFromYAMLValue(ctx, typ)
 			if err != nil {
 				return fmt.Errorf("failure reading YAML %v", err)
 			}
 
-			(*a)[i] = arg
+			(*a)[i] = TypeArg{
+				Name:        name,
+				Description: desc,
+				Type:        &typeExpr,
+			}
 		}
 	}
 
@@ -502,252 +487,46 @@ type SimpleExtensionFile struct {
 	WindowFunctions    []WindowFunction    `yaml:"window_functions,omitempty"`
 }
 
-type rawSimpleExtensionFile struct {
-	Urn                string                 `yaml:"urn"`
-	Metadata           map[string]any         `yaml:"metadata,omitempty"`
-	Types              []Type                 `yaml:"types,omitempty"`
-	TypeVariations     []TypeVariation        `yaml:"type_variations,omitempty"`
-	ScalarFunctions    []rawScalarFunction    `yaml:"scalar_functions,omitempty"`
-	AggregateFunctions []rawAggregateFunction `yaml:"aggregate_functions,omitempty"`
-	WindowFunctions    []rawWindowFunction    `yaml:"window_functions,omitempty"`
-}
-
-type rawScalarFunction struct {
-	Name        string                  `yaml:",omitempty"`
-	Description string                  `yaml:",omitempty,flow"`
-	Impls       []rawScalarFunctionImpl `yaml:",omitempty"`
-	Metadata    map[string]any          `yaml:"metadata,omitempty"`
-}
-
-type rawScalarFunctionImpl struct {
-	Args             []rawFuncParameter  `yaml:",omitempty"`
-	Options          map[string]Option   `yaml:",omitempty"`
-	Variadic         *VariadicBehavior   `yaml:",omitempty"`
-	SessionDependent bool                `yaml:"sessionDependent,omitempty"`
-	Deterministic    *bool               `yaml:"deterministic,omitempty"`
-	Nullability      NullabilityHandling `yaml:",omitempty" default:"MIRROR"`
-	Return           any                 `yaml:",omitempty"`
-	Implementation   map[string]string   `yaml:",omitempty"`
-}
-
-type rawAggregateFunction struct {
-	Name        string                     `yaml:",omitempty"`
-	Description string                     `yaml:",omitempty,flow"`
-	Impls       []rawAggregateFunctionImpl `yaml:",omitempty"`
-	Metadata    map[string]any             `yaml:"metadata,omitempty"`
-}
-
-type rawAggregateFunctionImpl struct {
-	ScalarFunctionImpl rawScalarFunctionImpl `yaml:",inline"`
-	Intermediate       any
-	Ordered            bool
-	MaxSet             int
-	Decomposable       DecomposeType
-}
-
-type rawWindowFunction struct {
-	Name        string                  `yaml:",omitempty"`
-	Description string                  `yaml:",omitempty,flow"`
-	Impls       []rawWindowFunctionImpl `yaml:",omitempty"`
-	Metadata    map[string]any          `yaml:"metadata,omitempty"`
-}
-
-type rawWindowFunctionImpl struct {
-	AggregateFunctionImpl rawAggregateFunctionImpl `yaml:",inline"`
-	WindowType            WindowType               `yaml:"window_type"`
-}
-
-type rawFuncParameter struct {
-	Name        string   `yaml:",omitempty"`
-	Description string   `yaml:",omitempty"`
-	Options     []string `yaml:",omitempty"`
-	Value       any
-	Constant    bool `yaml:",omitempty"`
-	Type        any
-}
-
-func (s *SimpleExtensionFile) UnmarshalYAML(fn func(interface{}) error) error {
-	var raw rawSimpleExtensionFile
-	if err := fn(&raw); err != nil {
+func (s *SimpleExtensionFile) UnmarshalYAML(ctx context.Context, data []byte) error {
+	type typeDeclarations struct {
+		Urn   string `yaml:"urn"`
+		Types []Type `yaml:"types,omitempty"`
+	}
+	var declarations typeDeclarations
+	if err := yaml.UnmarshalContext(ctx, data, &declarations); err != nil {
 		return err
 	}
 
-	declaredTypes := make(map[string]struct{}, len(raw.Types))
-	for _, typ := range raw.Types {
+	declaredTypes := make(map[string]struct{}, len(declarations.Types))
+	for _, typ := range declarations.Types {
 		declaredTypes[typ.Name] = struct{}{}
 	}
 
-	resolveUserDefinedType := parser.WithUserDefinedTypeResolver(func(name string) (string, error) {
+	resolveUserDefinedType := func(name string) (string, error) {
 		if _, ok := declaredTypes[name]; ok {
-			return raw.Urn, nil
+			return declarations.Urn, nil
 		}
 		return "", fmt.Errorf("%w: user-defined type %q is not declared", substraitgo.ErrInvalidSimpleExtention, name)
-	})
+	}
 
-	scalarFunctions, err := convertScalarFunctions(raw.ScalarFunctions, resolveUserDefinedType)
-	if err != nil {
-		return err
-	}
-	aggregateFunctions, err := convertAggregateFunctions(raw.AggregateFunctions, resolveUserDefinedType)
-	if err != nil {
-		return err
-	}
-	windowFunctions, err := convertWindowFunctions(raw.WindowFunctions, resolveUserDefinedType)
-	if err != nil {
+	type rawFile SimpleExtensionFile
+	var raw rawFile
+	ctx = parser.ContextWithUserDefinedTypeResolver(ctx, resolveUserDefinedType)
+	if err := yaml.UnmarshalContext(ctx, data, &raw); err != nil {
 		return err
 	}
 
-	*s = SimpleExtensionFile{
-		Urn:                raw.Urn,
-		Metadata:           raw.Metadata,
-		Types:              raw.Types,
-		TypeVariations:     raw.TypeVariations,
-		ScalarFunctions:    scalarFunctions,
-		AggregateFunctions: aggregateFunctions,
-		WindowFunctions:    windowFunctions,
-	}
+	*s = SimpleExtensionFile(raw)
 	return nil
 }
 
-func convertScalarFunctions(rawFunctions []rawScalarFunction, parseOptions ...parser.ParseOption) ([]ScalarFunction, error) {
-	functions := make([]ScalarFunction, len(rawFunctions))
-	for i, rawFunction := range rawFunctions {
-		impls, err := convertScalarFunctionImpls(rawFunction.Impls, parseOptions...)
-		if err != nil {
-			return nil, fmt.Errorf("scalar function %q: %w", rawFunction.Name, err)
-		}
-		functions[i] = ScalarFunction{Name: rawFunction.Name, Description: rawFunction.Description, Impls: impls, Metadata: rawFunction.Metadata}
-	}
-	return functions, nil
-}
-
-func convertAggregateFunctions(rawFunctions []rawAggregateFunction, parseOptions ...parser.ParseOption) ([]AggregateFunction, error) {
-	functions := make([]AggregateFunction, len(rawFunctions))
-	for i, rawFunction := range rawFunctions {
-		impls := make([]AggregateFunctionImpl, len(rawFunction.Impls))
-		for j, rawImpl := range rawFunction.Impls {
-			scalarImpl, err := convertScalarFunctionImpl(rawImpl.ScalarFunctionImpl, parseOptions...)
-			if err != nil {
-				return nil, fmt.Errorf("aggregate function %q impl %d: %w", rawFunction.Name, j, err)
-			}
-			intermediate, err := parseTypeExpression(rawImpl.Intermediate, parseOptions...)
-			if err != nil {
-				return nil, fmt.Errorf("aggregate function %q impl %d intermediate: %w", rawFunction.Name, j, err)
-			}
-			impls[j] = AggregateFunctionImpl{ScalarFunctionImpl: scalarImpl, Intermediate: intermediate, Ordered: rawImpl.Ordered, MaxSet: rawImpl.MaxSet, Decomposable: rawImpl.Decomposable}
-		}
-		functions[i] = AggregateFunction{Name: rawFunction.Name, Description: rawFunction.Description, Impls: impls, Metadata: rawFunction.Metadata}
-	}
-	return functions, nil
-}
-
-func convertWindowFunctions(rawFunctions []rawWindowFunction, parseOptions ...parser.ParseOption) ([]WindowFunction, error) {
-	functions := make([]WindowFunction, len(rawFunctions))
-	for i, rawFunction := range rawFunctions {
-		impls := make([]WindowFunctionImpl, len(rawFunction.Impls))
-		for j, rawImpl := range rawFunction.Impls {
-			aggImpl, err := convertAggregateFunctionImpl(rawImpl.AggregateFunctionImpl, parseOptions...)
-			if err != nil {
-				return nil, fmt.Errorf("window function %q impl %d: %w", rawFunction.Name, j, err)
-			}
-			impls[j] = WindowFunctionImpl{AggregateFunctionImpl: aggImpl, WindowType: rawImpl.WindowType}
-		}
-		functions[i] = WindowFunction{Name: rawFunction.Name, Description: rawFunction.Description, Impls: impls, Metadata: rawFunction.Metadata}
-	}
-	return functions, nil
-}
-
-func convertAggregateFunctionImpl(rawImpl rawAggregateFunctionImpl, parseOptions ...parser.ParseOption) (AggregateFunctionImpl, error) {
-	scalarImpl, err := convertScalarFunctionImpl(rawImpl.ScalarFunctionImpl, parseOptions...)
-	if err != nil {
-		return AggregateFunctionImpl{}, err
-	}
-	intermediate, err := parseTypeExpression(rawImpl.Intermediate, parseOptions...)
-	if err != nil {
-		return AggregateFunctionImpl{}, fmt.Errorf("intermediate: %w", err)
-	}
-	return AggregateFunctionImpl{ScalarFunctionImpl: scalarImpl, Intermediate: intermediate, Ordered: rawImpl.Ordered, MaxSet: rawImpl.MaxSet, Decomposable: rawImpl.Decomposable}, nil
-}
-
-func convertScalarFunctionImpls(rawImpls []rawScalarFunctionImpl, parseOptions ...parser.ParseOption) ([]ScalarFunctionImpl, error) {
-	impls := make([]ScalarFunctionImpl, len(rawImpls))
-	for i, rawImpl := range rawImpls {
-		impl, err := convertScalarFunctionImpl(rawImpl, parseOptions...)
-		if err != nil {
-			return nil, fmt.Errorf("impl %d: %w", i, err)
-		}
-		impls[i] = impl
-	}
-	return impls, nil
-}
-
-func convertScalarFunctionImpl(rawImpl rawScalarFunctionImpl, parseOptions ...parser.ParseOption) (ScalarFunctionImpl, error) {
-	args, err := convertFuncParameters(rawImpl.Args, parseOptions...)
-	if err != nil {
-		return ScalarFunctionImpl{}, err
-	}
-	returnType, err := parseTypeExpression(rawImpl.Return, parseOptions...)
-	if err != nil {
-		return ScalarFunctionImpl{}, fmt.Errorf("return: %w", err)
-	}
-	deterministic := true
-	if rawImpl.Deterministic != nil {
-		deterministic = *rawImpl.Deterministic
-	}
-	return ScalarFunctionImpl{
-		Args:             args,
-		Options:          rawImpl.Options,
-		Variadic:         rawImpl.Variadic,
-		SessionDependent: rawImpl.SessionDependent,
-		Deterministic:    deterministic,
-		Nullability:      rawImpl.Nullability,
-		Return:           &returnType,
-		Implementation:   rawImpl.Implementation,
-	}, nil
-}
-
-func convertFuncParameters(rawArgs []rawFuncParameter, parseOptions ...parser.ParseOption) (FuncParameterList, error) {
-	args := make(FuncParameterList, len(rawArgs))
-	for i, rawArg := range rawArgs {
-		arg, err := convertFuncParameter(rawArg, parseOptions...)
-		if err != nil {
-			return nil, fmt.Errorf("arg %d: %w", i, err)
-		}
-		args[i] = arg
-	}
-	return args, nil
-}
-
-func convertFuncParameter(rawArg rawFuncParameter, parseOptions ...parser.ParseOption) (FuncParameter, error) {
-	if len(rawArg.Options) > 0 {
-		return EnumArg{Name: rawArg.Name, Description: rawArg.Description, Options: rawArg.Options}, nil
-	}
-	if rawArg.Value != nil {
-		value, err := parseTypeExpression(rawArg.Value, parseOptions...)
-		if err != nil {
-			return nil, err
-		}
-		return ValueArg{Name: rawArg.Name, Description: rawArg.Description, Value: &value, Constant: rawArg.Constant}, nil
-	}
-	if rawArg.Type != nil {
-		typ, err := parseTypeExpression(rawArg.Type, parseOptions...)
-		if err != nil {
-			return nil, err
-		}
-		return TypeArg{Name: rawArg.Name, Description: rawArg.Description, Type: &typ}, nil
-	}
-	return nil, substraitgo.ErrInvalidSimpleExtention
-}
-
-func parseTypeExpression(value any, parseOptions ...parser.ParseOption) (parser.TypeExpression, error) {
-	if value == nil {
-		return parser.TypeExpression{}, nil
-	}
+func parseTypeExpressionFromYAMLValue(ctx context.Context, value any) (parser.TypeExpression, error) {
 	typeString, ok := value.(string)
 	if !ok {
 		return parser.TypeExpression{}, substraitgo.ErrInvalidType
 	}
-	typ, err := parser.ParseType(typeString, parseOptions...)
+
+	typ, err := parser.ParseType(typeString, parser.UserDefinedTypeResolverFromContext(ctx))
 	if err != nil {
 		return parser.TypeExpression{}, err
 	}

--- a/extensions/simple_extension.go
+++ b/extensions/simple_extension.go
@@ -502,11 +502,16 @@ func (s *SimpleExtensionFile) UnmarshalYAML(ctx context.Context, data []byte) er
 		declaredTypes[typ.Name] = struct{}{}
 	}
 
-	resolveUserDefinedType := func(name string) (string, error) {
-		if _, ok := declaredTypes[name]; ok {
-			return declarations.Urn, nil
+	resolveUserDefinedType := func(name string, nullability types.Nullability, parameters []types.UDTParameter) (*types.ParameterizedUserDefinedType, error) {
+		if _, ok := declaredTypes[name]; !ok {
+			return nil, fmt.Errorf("%w: user-defined type %q is not declared", substraitgo.ErrInvalidSimpleExtention, name)
 		}
-		return "", fmt.Errorf("%w: user-defined type %q is not declared", substraitgo.ErrInvalidSimpleExtention, name)
+		return &types.ParameterizedUserDefinedType{
+			Name:           name,
+			URN:            declarations.Urn,
+			Nullability:    nullability,
+			TypeParameters: parameters,
+		}, nil
 	}
 
 	type rawFile SimpleExtensionFile

--- a/extensions/simple_extension.go
+++ b/extensions/simple_extension.go
@@ -3,7 +3,6 @@
 package extensions
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -115,13 +114,17 @@ func (v TypeArg) GetTypeExpression() types.FuncDefArgType {
 
 type FuncParameterList []FuncParameter
 
-func (a *FuncParameterList) UnmarshalYAML(ctx context.Context, fn func(interface{}) error) error {
+func (a *FuncParameterList) UnmarshalYAML(data []byte) error {
+	return parseFuncParameterList(data, parser.TypeParser{}, a)
+}
+
+func parseFuncParameterList(data []byte, typeParser parser.TypeParser, out *FuncParameterList) error {
 	var args []map[string]any
-	if err := fn(&args); err != nil {
+	if err := yaml.Unmarshal(data, &args); err != nil {
 		return err
 	}
 
-	*a = make(FuncParameterList, len(args))
+	*out = make(FuncParameterList, len(args))
 	for i, arg := range args {
 		var (
 			name, desc string
@@ -139,7 +142,7 @@ func (a *FuncParameterList) UnmarshalYAML(ctx context.Context, fn func(interface
 			for j, v := range vals {
 				values[j] = v.(string)
 			}
-			(*a)[i] = EnumArg{
+			(*out)[i] = EnumArg{
 				Name:        name,
 				Description: desc,
 				Options:     values,
@@ -150,12 +153,12 @@ func (a *FuncParameterList) UnmarshalYAML(ctx context.Context, fn func(interface
 				constant = c.(bool)
 			}
 
-			valueType, err := parseTypeExpressionFromYAMLValue(ctx, val)
+			valueType, err := parseTypeExpressionFromYAMLValue(typeParser, val)
 			if err != nil {
 				return fmt.Errorf("failure reading YAML %v", err)
 			}
 
-			(*a)[i] = ValueArg{
+			(*out)[i] = ValueArg{
 				Name:        name,
 				Description: desc,
 				Value:       &valueType,
@@ -163,12 +166,12 @@ func (a *FuncParameterList) UnmarshalYAML(ctx context.Context, fn func(interface
 			}
 
 		} else if typ, ok := arg["type"]; ok {
-			typeExpr, err := parseTypeExpressionFromYAMLValue(ctx, typ)
+			typeExpr, err := parseTypeExpressionFromYAMLValue(typeParser, typ)
 			if err != nil {
 				return fmt.Errorf("failure reading YAML %v", err)
 			}
 
-			(*a)[i] = TypeArg{
+			(*out)[i] = TypeArg{
 				Name:        name,
 				Description: desc,
 				Type:        &typeExpr,
@@ -487,13 +490,13 @@ type SimpleExtensionFile struct {
 	WindowFunctions    []WindowFunction    `yaml:"window_functions,omitempty"`
 }
 
-func (s *SimpleExtensionFile) UnmarshalYAML(ctx context.Context, data []byte) error {
+func (s *SimpleExtensionFile) UnmarshalYAML(data []byte) error {
 	type typeDeclarations struct {
 		Urn   string `yaml:"urn"`
 		Types []Type `yaml:"types,omitempty"`
 	}
 	var declarations typeDeclarations
-	if err := yaml.UnmarshalContext(ctx, data, &declarations); err != nil {
+	if err := yaml.Unmarshal(data, &declarations); err != nil {
 		return err
 	}
 
@@ -502,22 +505,37 @@ func (s *SimpleExtensionFile) UnmarshalYAML(ctx context.Context, data []byte) er
 		declaredTypes[typ.Name] = struct{}{}
 	}
 
-	resolveUserDefinedType := func(name string, nullability types.Nullability, parameters []types.UDTParameter) (*types.ParameterizedUserDefinedType, error) {
-		if _, ok := declaredTypes[name]; !ok {
-			return nil, fmt.Errorf("%w: user-defined type %q is not declared", substraitgo.ErrInvalidSimpleExtention, name)
-		}
-		return &types.ParameterizedUserDefinedType{
-			Name:           name,
-			URN:            declarations.Urn,
-			Nullability:    nullability,
-			TypeParameters: parameters,
-		}, nil
+	typeParser := parser.TypeParser{
+		ResolveUserDefinedType: func(name string, nullability types.Nullability, parameters []types.UDTParameter) (*types.ParameterizedUserDefinedType, error) {
+			if _, ok := declaredTypes[name]; !ok {
+				return nil, fmt.Errorf("%w: user-defined type %q is not declared", substraitgo.ErrInvalidSimpleExtention, name)
+			}
+			return &types.ParameterizedUserDefinedType{
+				Name:           name,
+				URN:            declarations.Urn,
+				Nullability:    nullability,
+				TypeParameters: parameters,
+			}, nil
+		},
 	}
 
 	type rawFile SimpleExtensionFile
 	var raw rawFile
-	ctx = parser.ContextWithUserDefinedTypeResolver(ctx, resolveUserDefinedType)
-	if err := yaml.UnmarshalContext(ctx, data, &raw); err != nil {
+	if err := yaml.UnmarshalWithOptions(
+		data,
+		&raw,
+		yaml.CustomUnmarshaler[parser.TypeExpression](func(out *parser.TypeExpression, data []byte) error {
+			parsed, err := parseTypeExpression(data, typeParser)
+			if err != nil {
+				return err
+			}
+			*out = parsed
+			return nil
+		}),
+		yaml.CustomUnmarshaler[FuncParameterList](func(out *FuncParameterList, data []byte) error {
+			return parseFuncParameterList(data, typeParser, out)
+		}),
+	); err != nil {
 		return err
 	}
 
@@ -525,13 +543,21 @@ func (s *SimpleExtensionFile) UnmarshalYAML(ctx context.Context, data []byte) er
 	return nil
 }
 
-func parseTypeExpressionFromYAMLValue(ctx context.Context, value any) (parser.TypeExpression, error) {
+func parseTypeExpressionFromYAMLValue(typeParser parser.TypeParser, value any) (parser.TypeExpression, error) {
 	typeString, ok := value.(string)
 	if !ok {
 		return parser.TypeExpression{}, substraitgo.ErrInvalidType
 	}
+	return parseTypeExpression([]byte(typeString), typeParser)
+}
 
-	typ, err := parser.ParseType(typeString, parser.UserDefinedTypeResolverFromContext(ctx))
+func parseTypeExpression(data []byte, typeParser parser.TypeParser) (parser.TypeExpression, error) {
+	var typeString string
+	if err := yaml.Unmarshal(data, &typeString); err != nil {
+		return parser.TypeExpression{}, err
+	}
+
+	typ, err := typeParser.Parse(typeString)
 	if err != nil {
 		return parser.TypeExpression{}, err
 	}

--- a/extensions/simple_extension.go
+++ b/extensions/simple_extension.go
@@ -501,3 +501,255 @@ type SimpleExtensionFile struct {
 	AggregateFunctions []AggregateFunction `yaml:"aggregate_functions,omitempty"`
 	WindowFunctions    []WindowFunction    `yaml:"window_functions,omitempty"`
 }
+
+type rawSimpleExtensionFile struct {
+	Urn                string                 `yaml:"urn"`
+	Metadata           map[string]any         `yaml:"metadata,omitempty"`
+	Types              []Type                 `yaml:"types,omitempty"`
+	TypeVariations     []TypeVariation        `yaml:"type_variations,omitempty"`
+	ScalarFunctions    []rawScalarFunction    `yaml:"scalar_functions,omitempty"`
+	AggregateFunctions []rawAggregateFunction `yaml:"aggregate_functions,omitempty"`
+	WindowFunctions    []rawWindowFunction    `yaml:"window_functions,omitempty"`
+}
+
+type rawScalarFunction struct {
+	Name        string                  `yaml:",omitempty"`
+	Description string                  `yaml:",omitempty,flow"`
+	Impls       []rawScalarFunctionImpl `yaml:",omitempty"`
+	Metadata    map[string]any          `yaml:"metadata,omitempty"`
+}
+
+type rawScalarFunctionImpl struct {
+	Args             []rawFuncParameter  `yaml:",omitempty"`
+	Options          map[string]Option   `yaml:",omitempty"`
+	Variadic         *VariadicBehavior   `yaml:",omitempty"`
+	SessionDependent bool                `yaml:"sessionDependent,omitempty"`
+	Deterministic    *bool               `yaml:"deterministic,omitempty"`
+	Nullability      NullabilityHandling `yaml:",omitempty" default:"MIRROR"`
+	Return           any                 `yaml:",omitempty"`
+	Implementation   map[string]string   `yaml:",omitempty"`
+}
+
+type rawAggregateFunction struct {
+	Name        string                     `yaml:",omitempty"`
+	Description string                     `yaml:",omitempty,flow"`
+	Impls       []rawAggregateFunctionImpl `yaml:",omitempty"`
+	Metadata    map[string]any             `yaml:"metadata,omitempty"`
+}
+
+type rawAggregateFunctionImpl struct {
+	ScalarFunctionImpl rawScalarFunctionImpl `yaml:",inline"`
+	Intermediate       any
+	Ordered            bool
+	MaxSet             int
+	Decomposable       DecomposeType
+}
+
+type rawWindowFunction struct {
+	Name        string                  `yaml:",omitempty"`
+	Description string                  `yaml:",omitempty,flow"`
+	Impls       []rawWindowFunctionImpl `yaml:",omitempty"`
+	Metadata    map[string]any          `yaml:"metadata,omitempty"`
+}
+
+type rawWindowFunctionImpl struct {
+	AggregateFunctionImpl rawAggregateFunctionImpl `yaml:",inline"`
+	WindowType            WindowType               `yaml:"window_type"`
+}
+
+type rawFuncParameter struct {
+	Name        string   `yaml:",omitempty"`
+	Description string   `yaml:",omitempty"`
+	Options     []string `yaml:",omitempty"`
+	Value       any
+	Constant    bool `yaml:",omitempty"`
+	Type        any
+}
+
+func (s *SimpleExtensionFile) UnmarshalYAML(fn func(interface{}) error) error {
+	var raw rawSimpleExtensionFile
+	if err := fn(&raw); err != nil {
+		return err
+	}
+
+	declaredTypes := make(map[string]struct{}, len(raw.Types))
+	for _, typ := range raw.Types {
+		declaredTypes[typ.Name] = struct{}{}
+	}
+
+	resolveUserDefinedType := parser.WithUserDefinedTypeResolver(func(name string) (string, error) {
+		if _, ok := declaredTypes[name]; ok {
+			return raw.Urn, nil
+		}
+		return "", fmt.Errorf("%w: user-defined type %q is not declared", substraitgo.ErrInvalidSimpleExtention, name)
+	})
+
+	scalarFunctions, err := convertScalarFunctions(raw.ScalarFunctions, resolveUserDefinedType)
+	if err != nil {
+		return err
+	}
+	aggregateFunctions, err := convertAggregateFunctions(raw.AggregateFunctions, resolveUserDefinedType)
+	if err != nil {
+		return err
+	}
+	windowFunctions, err := convertWindowFunctions(raw.WindowFunctions, resolveUserDefinedType)
+	if err != nil {
+		return err
+	}
+
+	*s = SimpleExtensionFile{
+		Urn:                raw.Urn,
+		Metadata:           raw.Metadata,
+		Types:              raw.Types,
+		TypeVariations:     raw.TypeVariations,
+		ScalarFunctions:    scalarFunctions,
+		AggregateFunctions: aggregateFunctions,
+		WindowFunctions:    windowFunctions,
+	}
+	return nil
+}
+
+func convertScalarFunctions(rawFunctions []rawScalarFunction, parseOptions ...parser.ParseOption) ([]ScalarFunction, error) {
+	functions := make([]ScalarFunction, len(rawFunctions))
+	for i, rawFunction := range rawFunctions {
+		impls, err := convertScalarFunctionImpls(rawFunction.Impls, parseOptions...)
+		if err != nil {
+			return nil, fmt.Errorf("scalar function %q: %w", rawFunction.Name, err)
+		}
+		functions[i] = ScalarFunction{Name: rawFunction.Name, Description: rawFunction.Description, Impls: impls, Metadata: rawFunction.Metadata}
+	}
+	return functions, nil
+}
+
+func convertAggregateFunctions(rawFunctions []rawAggregateFunction, parseOptions ...parser.ParseOption) ([]AggregateFunction, error) {
+	functions := make([]AggregateFunction, len(rawFunctions))
+	for i, rawFunction := range rawFunctions {
+		impls := make([]AggregateFunctionImpl, len(rawFunction.Impls))
+		for j, rawImpl := range rawFunction.Impls {
+			scalarImpl, err := convertScalarFunctionImpl(rawImpl.ScalarFunctionImpl, parseOptions...)
+			if err != nil {
+				return nil, fmt.Errorf("aggregate function %q impl %d: %w", rawFunction.Name, j, err)
+			}
+			intermediate, err := parseTypeExpression(rawImpl.Intermediate, parseOptions...)
+			if err != nil {
+				return nil, fmt.Errorf("aggregate function %q impl %d intermediate: %w", rawFunction.Name, j, err)
+			}
+			impls[j] = AggregateFunctionImpl{ScalarFunctionImpl: scalarImpl, Intermediate: intermediate, Ordered: rawImpl.Ordered, MaxSet: rawImpl.MaxSet, Decomposable: rawImpl.Decomposable}
+		}
+		functions[i] = AggregateFunction{Name: rawFunction.Name, Description: rawFunction.Description, Impls: impls, Metadata: rawFunction.Metadata}
+	}
+	return functions, nil
+}
+
+func convertWindowFunctions(rawFunctions []rawWindowFunction, parseOptions ...parser.ParseOption) ([]WindowFunction, error) {
+	functions := make([]WindowFunction, len(rawFunctions))
+	for i, rawFunction := range rawFunctions {
+		impls := make([]WindowFunctionImpl, len(rawFunction.Impls))
+		for j, rawImpl := range rawFunction.Impls {
+			aggImpl, err := convertAggregateFunctionImpl(rawImpl.AggregateFunctionImpl, parseOptions...)
+			if err != nil {
+				return nil, fmt.Errorf("window function %q impl %d: %w", rawFunction.Name, j, err)
+			}
+			impls[j] = WindowFunctionImpl{AggregateFunctionImpl: aggImpl, WindowType: rawImpl.WindowType}
+		}
+		functions[i] = WindowFunction{Name: rawFunction.Name, Description: rawFunction.Description, Impls: impls, Metadata: rawFunction.Metadata}
+	}
+	return functions, nil
+}
+
+func convertAggregateFunctionImpl(rawImpl rawAggregateFunctionImpl, parseOptions ...parser.ParseOption) (AggregateFunctionImpl, error) {
+	scalarImpl, err := convertScalarFunctionImpl(rawImpl.ScalarFunctionImpl, parseOptions...)
+	if err != nil {
+		return AggregateFunctionImpl{}, err
+	}
+	intermediate, err := parseTypeExpression(rawImpl.Intermediate, parseOptions...)
+	if err != nil {
+		return AggregateFunctionImpl{}, fmt.Errorf("intermediate: %w", err)
+	}
+	return AggregateFunctionImpl{ScalarFunctionImpl: scalarImpl, Intermediate: intermediate, Ordered: rawImpl.Ordered, MaxSet: rawImpl.MaxSet, Decomposable: rawImpl.Decomposable}, nil
+}
+
+func convertScalarFunctionImpls(rawImpls []rawScalarFunctionImpl, parseOptions ...parser.ParseOption) ([]ScalarFunctionImpl, error) {
+	impls := make([]ScalarFunctionImpl, len(rawImpls))
+	for i, rawImpl := range rawImpls {
+		impl, err := convertScalarFunctionImpl(rawImpl, parseOptions...)
+		if err != nil {
+			return nil, fmt.Errorf("impl %d: %w", i, err)
+		}
+		impls[i] = impl
+	}
+	return impls, nil
+}
+
+func convertScalarFunctionImpl(rawImpl rawScalarFunctionImpl, parseOptions ...parser.ParseOption) (ScalarFunctionImpl, error) {
+	args, err := convertFuncParameters(rawImpl.Args, parseOptions...)
+	if err != nil {
+		return ScalarFunctionImpl{}, err
+	}
+	returnType, err := parseTypeExpression(rawImpl.Return, parseOptions...)
+	if err != nil {
+		return ScalarFunctionImpl{}, fmt.Errorf("return: %w", err)
+	}
+	deterministic := true
+	if rawImpl.Deterministic != nil {
+		deterministic = *rawImpl.Deterministic
+	}
+	return ScalarFunctionImpl{
+		Args:             args,
+		Options:          rawImpl.Options,
+		Variadic:         rawImpl.Variadic,
+		SessionDependent: rawImpl.SessionDependent,
+		Deterministic:    deterministic,
+		Nullability:      rawImpl.Nullability,
+		Return:           &returnType,
+		Implementation:   rawImpl.Implementation,
+	}, nil
+}
+
+func convertFuncParameters(rawArgs []rawFuncParameter, parseOptions ...parser.ParseOption) (FuncParameterList, error) {
+	args := make(FuncParameterList, len(rawArgs))
+	for i, rawArg := range rawArgs {
+		arg, err := convertFuncParameter(rawArg, parseOptions...)
+		if err != nil {
+			return nil, fmt.Errorf("arg %d: %w", i, err)
+		}
+		args[i] = arg
+	}
+	return args, nil
+}
+
+func convertFuncParameter(rawArg rawFuncParameter, parseOptions ...parser.ParseOption) (FuncParameter, error) {
+	if len(rawArg.Options) > 0 {
+		return EnumArg{Name: rawArg.Name, Description: rawArg.Description, Options: rawArg.Options}, nil
+	}
+	if rawArg.Value != nil {
+		value, err := parseTypeExpression(rawArg.Value, parseOptions...)
+		if err != nil {
+			return nil, err
+		}
+		return ValueArg{Name: rawArg.Name, Description: rawArg.Description, Value: &value, Constant: rawArg.Constant}, nil
+	}
+	if rawArg.Type != nil {
+		typ, err := parseTypeExpression(rawArg.Type, parseOptions...)
+		if err != nil {
+			return nil, err
+		}
+		return TypeArg{Name: rawArg.Name, Description: rawArg.Description, Type: &typ}, nil
+	}
+	return nil, substraitgo.ErrInvalidSimpleExtention
+}
+
+func parseTypeExpression(value any, parseOptions ...parser.ParseOption) (parser.TypeExpression, error) {
+	if value == nil {
+		return parser.TypeExpression{}, nil
+	}
+	typeString, ok := value.(string)
+	if !ok {
+		return parser.TypeExpression{}, substraitgo.ErrInvalidType
+	}
+	typ, err := parser.ParseType(typeString, parseOptions...)
+	if err != nil {
+		return parser.TypeExpression{}, err
+	}
+	return parser.TypeExpression{ValueType: typ}, nil
+}

--- a/extensions/simple_extension_test.go
+++ b/extensions/simple_extension_test.go
@@ -47,6 +47,9 @@ types:
 func TestUnmarshalCustomScalarFunction(t *testing.T) {
 	const customDef = `
 urn: extension:test:test_ext
+types:
+  - name: customtype1
+  - name: customtype2
 scalar_functions:
   - name: "scalar1"
     impls:
@@ -83,6 +86,47 @@ scalar_functions:
 	assert.NoError(t, err)
 	assert.IsType(t, &types.UserDefinedType{}, typ)
 	assert.Equal(t, proto.Type_NULLABILITY_NULLABLE, typ.GetNullability(), "expected NULLABILITY_NULLABLE")
+}
+
+func TestUnmarshalSimpleExtensionRejectsUndeclaredUserDefinedType(t *testing.T) {
+	const customDef = `
+urn: extension:test:test_ext
+scalar_functions:
+  - name: "scalar1"
+    impls:
+      - args:
+          - name: arg1
+            value: u!missing_type
+        return: i64
+`
+
+	var f extensions.SimpleExtensionFile
+	err := yaml.Unmarshal([]byte(customDef), &f)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `user-defined type "missing_type" is not declared`)
+}
+
+func TestUnmarshalSimpleExtensionResolvesUserDefinedTypeURN(t *testing.T) {
+	const customDef = `
+urn: extension:test:test_ext
+types:
+  - name: customtype
+scalar_functions:
+  - name: "scalar1"
+    impls:
+      - args:
+          - name: arg1
+            value: i64
+        return: u!customtype
+`
+
+	var f extensions.SimpleExtensionFile
+	require.NoError(t, yaml.Unmarshal([]byte(customDef), &f))
+
+	udt, ok := f.ScalarFunctions[0].Impls[0].Return.ValueType.(*types.ParameterizedUserDefinedType)
+	require.True(t, ok)
+	assert.Equal(t, "extension:test:test_ext", udt.URN)
 }
 
 func TestUnmarshalSimpleExtensionScalarFunction(t *testing.T) {

--- a/extensions/variants.go
+++ b/extensions/variants.go
@@ -148,7 +148,11 @@ func EvaluateTypeExpression(urn string, nullHandling NullabilityHandling, return
 	// For other types like AnyType, the TypeReference is already correctly set.
 	if udt, ok := outType.(*types.UserDefinedType); ok {
 		if paramUDT, ok := returnTypeExpr.(*types.ParameterizedUserDefinedType); ok {
-			udt.TypeReference = registry.GetTypeAnchor(ID{Name: paramUDT.Name, URN: urn})
+			udtURN := paramUDT.URN
+			if udtURN == "" {
+				udtURN = urn
+			}
+			udt.TypeReference = registry.GetTypeAnchor(ID{Name: paramUDT.Name, URN: udtURN})
 		}
 	}
 

--- a/extensions/variants.go
+++ b/extensions/variants.go
@@ -281,7 +281,7 @@ func parseFuncName(compoundName string) (name string, args FuncParameterList) {
 	}
 	splitArgs := strings.Split(argsStr, "_")
 	for _, argStr := range splitArgs {
-		parsed, err := parser.ParseType(argStr)
+		parsed, err := parser.ParseType(argStr, nil)
 		if err != nil {
 			panic(err)
 		}
@@ -426,7 +426,7 @@ func NewAggFuncVariantOpts(id ID, opts AggVariantOptions) *AggregateFunctionVari
 				substraitgo.ErrInvalidExpr, id))
 		}
 
-		intermediate, err := parser.ParseType(opts.IntermediateOutputType)
+		intermediate, err := parser.ParseType(opts.IntermediateOutputType, nil)
 		if err != nil {
 			panic(err)
 		}
@@ -553,7 +553,7 @@ func NewWindowFuncVariantOpts(id ID, opts WindowVariantOpts) *WindowFunctionVari
 				substraitgo.ErrInvalidExpr, id))
 		}
 
-		intermediate, err := parser.ParseType(opts.IntermediateOutputType)
+		intermediate, err := parser.ParseType(opts.IntermediateOutputType, nil)
 		if err != nil {
 			panic(err)
 		}

--- a/extensions/variants_test.go
+++ b/extensions/variants_test.go
@@ -20,12 +20,12 @@ import (
 func TestEvaluateTypeExpression(t *testing.T) {
 	var (
 		// Function definition argument type shortcuts.
-		i64Null, _      = parser.ParseType("i64?")
-		i64NonNull, _   = parser.ParseType("i64")
-		strNull, _      = parser.ParseType("string?")
-		strNonNull, _   = parser.ParseType("string")
-		any1NonNull, _  = parser.ParseType("any1")
-		any1Nullable, _ = parser.ParseType("any1?")
+		i64Null, _      = parser.ParseType("i64?", nil)
+		i64NonNull, _   = parser.ParseType("i64", nil)
+		strNull, _      = parser.ParseType("string?", nil)
+		strNonNull, _   = parser.ParseType("string", nil)
+		any1NonNull, _  = parser.ParseType("any1", nil)
+		any1Nullable, _ = parser.ParseType("any1?", nil)
 		any1listNonNull = mkFuncArgList(any1NonNull)
 
 		// Few shortcut type definitions.
@@ -206,9 +206,9 @@ func TestEvaluateTypeExpression(t *testing.T) {
 
 func TestVariantWithVariadic(t *testing.T) {
 	var (
-		i64Null, _     = parser.ParseType("i64?")
-		i64NonNull, _  = parser.ParseType("i64")
-		varcharNull, _ = parser.ParseType("varchar?<20>")
+		i64Null, _     = parser.ParseType("i64?", nil)
+		i64NonNull, _  = parser.ParseType("i64", nil)
+		varcharNull, _ = parser.ParseType("varchar?<20>", nil)
 	)
 
 	tests := []struct {
@@ -473,7 +473,7 @@ func TestResolveType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// set up type registry
-			returnType, _ := parser.ParseType(tt.returnType)
+			returnType, _ := parser.ParseType(tt.returnType, func(name string) (string, error) { return "extension:org:item", nil })
 			registry := extensions.NewSet()
 			var expectedRef uint32
 			if tt.expectedUDT {
@@ -512,8 +512,8 @@ func TestResolveType(t *testing.T) {
 
 func TestResolveTypeErrorHandling(t *testing.T) {
 	// Test error propagation from EvaluateTypeExpression
-	returnType, _ := parser.ParseType("u!custom_type")
-	argType, _ := parser.ParseType("i64")
+	returnType, _ := parser.ParseType("u!custom_type", func(name string) (string, error) { return "extension:org:item", nil })
+	argType, _ := parser.ParseType("i64", nil)
 
 	// Create function parameter list that expects one argument
 	funcParams := extensions.FuncParameterList{valArg(argType)}

--- a/extensions/variants_test.go
+++ b/extensions/variants_test.go
@@ -473,7 +473,9 @@ func TestResolveType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// set up type registry
-			returnType, _ := parser.ParseType(tt.returnType, func(name string) (string, error) { return "extension:org:item", nil })
+			returnType, _ := parser.ParseType(tt.returnType, func(name string, nullability types.Nullability, parameters []types.UDTParameter) (*types.ParameterizedUserDefinedType, error) {
+				return &types.ParameterizedUserDefinedType{Name: name, URN: "extension:org:item", Nullability: nullability, TypeParameters: parameters}, nil
+			})
 			registry := extensions.NewSet()
 			var expectedRef uint32
 			if tt.expectedUDT {
@@ -512,7 +514,9 @@ func TestResolveType(t *testing.T) {
 
 func TestResolveTypeErrorHandling(t *testing.T) {
 	// Test error propagation from EvaluateTypeExpression
-	returnType, _ := parser.ParseType("u!custom_type", func(name string) (string, error) { return "extension:org:item", nil })
+	returnType, _ := parser.ParseType("u!custom_type", func(name string, nullability types.Nullability, parameters []types.UDTParameter) (*types.ParameterizedUserDefinedType, error) {
+		return &types.ParameterizedUserDefinedType{Name: name, URN: "extension:org:item", Nullability: nullability, TypeParameters: parameters}, nil
+	})
 	argType, _ := parser.ParseType("i64", nil)
 
 	// Create function parameter list that expects one argument

--- a/types/parameterized_user_defined_type.go
+++ b/types/parameterized_user_defined_type.go
@@ -110,6 +110,7 @@ type ParameterizedUserDefinedType struct {
 	TypeVariationRef uint32
 	TypeParameters   []UDTParameter
 	Name             string
+	URN              string
 }
 
 func (m *ParameterizedUserDefinedType) SetNullability(n Nullability) FuncDefArgType {

--- a/types/parser/parse.go
+++ b/types/parser/parse.go
@@ -1,10 +1,11 @@
 package parser
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/antlr4-go/antlr/v4"
-	substraitgo "github.com/substrait-io/substrait-go/v8"
+	"github.com/goccy/go-yaml"
 	"github.com/substrait-io/substrait-go/v8/types"
 	baseparser2 "github.com/substrait-io/substrait-go/v8/types/parser/baseparser"
 	"github.com/substrait-io/substrait-go/v8/types/parser/util"
@@ -16,48 +17,36 @@ type TypeExpression struct {
 
 type UserDefinedTypeResolver func(name string) (urn string, err error)
 
-type ParseOption func(*parseOptions)
+type userDefinedTypeResolverKey struct{}
 
-type parseOptions struct {
-	resolveUserDefinedType UserDefinedTypeResolver
+func ContextWithUserDefinedTypeResolver(ctx context.Context, resolver UserDefinedTypeResolver) context.Context {
+	return context.WithValue(ctx, userDefinedTypeResolverKey{}, resolver)
 }
 
-func WithUserDefinedTypeResolver(resolver UserDefinedTypeResolver) ParseOption {
-	return func(opts *parseOptions) {
-		opts.resolveUserDefinedType = resolver
-	}
+func UserDefinedTypeResolverFromContext(ctx context.Context) UserDefinedTypeResolver {
+	resolver, _ := ctx.Value(userDefinedTypeResolverKey{}).(UserDefinedTypeResolver)
+	return resolver
 }
 
 func (t *TypeExpression) MarshalYAML() (interface{}, error) {
 	return t.ValueType.String(), nil
 }
 
-func (t *TypeExpression) UnmarshalYAML(fn func(interface{}) error) error {
-	type Alias any
-	var alias Alias
-	if err := fn(&alias); err != nil {
+func (t *TypeExpression) UnmarshalYAML(ctx context.Context, data []byte) error {
+	var typeString string
+	if err := yaml.UnmarshalContext(ctx, data, &typeString); err != nil {
 		return err
 	}
 
-	switch v := alias.(type) {
-	case string:
-		exp, err := ParseType(v)
-		if err != nil {
-			return err
-		}
-		t.ValueType = exp
-		return nil
+	exp, err := ParseType(typeString, UserDefinedTypeResolverFromContext(ctx))
+	if err != nil {
+		return err
 	}
-
-	return substraitgo.ErrNotImplemented
+	t.ValueType = exp
+	return nil
 }
 
-func ParseType(input string, options ...ParseOption) (types.FuncDefArgType, error) {
-	var opts parseOptions
-	for _, option := range options {
-		option(&opts)
-	}
-
+func ParseType(input string, resolveUserDefinedType UserDefinedTypeResolver) (types.FuncDefArgType, error) {
 	is := antlr.NewInputStream(input)
 	lexer := baseparser2.NewSubstraitTypeLexer(is)
 	stream := antlr.NewCommonTokenStream(lexer, 0)
@@ -66,7 +55,7 @@ func ParseType(input string, options ...ParseOption) (types.FuncDefArgType, erro
 	p.AddErrorListener(errorListener)
 	p.GetInterpreter().SetPredictionMode(antlr.PredictionModeSLL)
 
-	visitor := &TypeVisitor{ResolveUserDefinedType: opts.resolveUserDefinedType, ErrorListener: errorListener}
+	visitor := &TypeVisitor{ResolveUserDefinedType: resolveUserDefinedType, ErrorListener: errorListener}
 	ret, err := parseType(input, p, errorListener, visitor)
 	if err != nil {
 		return nil, err

--- a/types/parser/parse.go
+++ b/types/parser/parse.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/antlr4-go/antlr/v4"
@@ -17,28 +16,21 @@ type TypeExpression struct {
 
 type UserDefinedTypeResolver func(name string, nullability types.Nullability, parameters []types.UDTParameter) (*types.ParameterizedUserDefinedType, error)
 
-type userDefinedTypeResolverKey struct{}
-
-func ContextWithUserDefinedTypeResolver(ctx context.Context, resolver UserDefinedTypeResolver) context.Context {
-	return context.WithValue(ctx, userDefinedTypeResolverKey{}, resolver)
-}
-
-func UserDefinedTypeResolverFromContext(ctx context.Context) UserDefinedTypeResolver {
-	resolver, _ := ctx.Value(userDefinedTypeResolverKey{}).(UserDefinedTypeResolver)
-	return resolver
+type TypeParser struct {
+	ResolveUserDefinedType UserDefinedTypeResolver
 }
 
 func (t *TypeExpression) MarshalYAML() (interface{}, error) {
 	return t.ValueType.String(), nil
 }
 
-func (t *TypeExpression) UnmarshalYAML(ctx context.Context, data []byte) error {
+func (t *TypeExpression) UnmarshalYAML(data []byte) error {
 	var typeString string
-	if err := yaml.UnmarshalContext(ctx, data, &typeString); err != nil {
+	if err := yaml.Unmarshal(data, &typeString); err != nil {
 		return err
 	}
 
-	exp, err := ParseType(typeString, UserDefinedTypeResolverFromContext(ctx))
+	exp, err := TypeParser{}.Parse(typeString)
 	if err != nil {
 		return err
 	}
@@ -47,6 +39,10 @@ func (t *TypeExpression) UnmarshalYAML(ctx context.Context, data []byte) error {
 }
 
 func ParseType(input string, resolveUserDefinedType UserDefinedTypeResolver) (types.FuncDefArgType, error) {
+	return TypeParser{ResolveUserDefinedType: resolveUserDefinedType}.Parse(input)
+}
+
+func (tp TypeParser) Parse(input string) (types.FuncDefArgType, error) {
 	is := antlr.NewInputStream(input)
 	lexer := baseparser2.NewSubstraitTypeLexer(is)
 	stream := antlr.NewCommonTokenStream(lexer, 0)
@@ -55,7 +51,7 @@ func ParseType(input string, resolveUserDefinedType UserDefinedTypeResolver) (ty
 	p.AddErrorListener(errorListener)
 	p.GetInterpreter().SetPredictionMode(antlr.PredictionModeSLL)
 
-	visitor := &TypeVisitor{ResolveUserDefinedType: resolveUserDefinedType, ErrorListener: errorListener}
+	visitor := &TypeVisitor{ResolveUserDefinedType: tp.ResolveUserDefinedType, ErrorListener: errorListener}
 	ret, err := parseType(input, p, errorListener, visitor)
 	if err != nil {
 		return nil, err

--- a/types/parser/parse.go
+++ b/types/parser/parse.go
@@ -15,7 +15,7 @@ type TypeExpression struct {
 	ValueType types.FuncDefArgType
 }
 
-type UserDefinedTypeResolver func(name string) (urn string, err error)
+type UserDefinedTypeResolver func(name string, nullability types.Nullability, parameters []types.UDTParameter) (*types.ParameterizedUserDefinedType, error)
 
 type userDefinedTypeResolverKey struct{}
 

--- a/types/parser/parse.go
+++ b/types/parser/parse.go
@@ -14,6 +14,20 @@ type TypeExpression struct {
 	ValueType types.FuncDefArgType
 }
 
+type UserDefinedTypeResolver func(name string) (urn string, err error)
+
+type ParseOption func(*parseOptions)
+
+type parseOptions struct {
+	resolveUserDefinedType UserDefinedTypeResolver
+}
+
+func WithUserDefinedTypeResolver(resolver UserDefinedTypeResolver) ParseOption {
+	return func(opts *parseOptions) {
+		opts.resolveUserDefinedType = resolver
+	}
+}
+
 func (t *TypeExpression) MarshalYAML() (interface{}, error) {
 	return t.ValueType.String(), nil
 }
@@ -38,7 +52,12 @@ func (t *TypeExpression) UnmarshalYAML(fn func(interface{}) error) error {
 	return substraitgo.ErrNotImplemented
 }
 
-func ParseType(input string) (types.FuncDefArgType, error) {
+func ParseType(input string, options ...ParseOption) (types.FuncDefArgType, error) {
+	var opts parseOptions
+	for _, option := range options {
+		option(&opts)
+	}
+
 	is := antlr.NewInputStream(input)
 	lexer := baseparser2.NewSubstraitTypeLexer(is)
 	stream := antlr.NewCommonTokenStream(lexer, 0)
@@ -47,7 +66,7 @@ func ParseType(input string) (types.FuncDefArgType, error) {
 	p.AddErrorListener(errorListener)
 	p.GetInterpreter().SetPredictionMode(antlr.PredictionModeSLL)
 
-	visitor := &TypeVisitor{}
+	visitor := &TypeVisitor{ResolveUserDefinedType: opts.resolveUserDefinedType, ErrorListener: errorListener}
 	ret, err := parseType(input, p, errorListener, visitor)
 	if err != nil {
 		return nil, err

--- a/types/parser/parse_test.go
+++ b/types/parser/parse_test.go
@@ -121,7 +121,9 @@ func TestParseFuncDefArgType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got, err := ParseType(tt.input, func(name string) (string, error) { return "extension:test:test", nil })
+			got, err := ParseType(tt.input, func(name string, nullability types.Nullability, parameters []types.UDTParameter) (*types.ParameterizedUserDefinedType, error) {
+				return &types.ParameterizedUserDefinedType{Name: name, URN: "extension:test:test", Nullability: nullability, TypeParameters: parameters}, nil
+			})
 			require.NoError(t, err)
 			require.NotNil(t, got)
 			assert.Equal(t, tt.expected, got.String())

--- a/types/parser/parse_test.go
+++ b/types/parser/parse_test.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -53,7 +52,7 @@ func TestParseSimpleTypes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got, err := ParseType(tt.input)
+			got, err := ParseType(tt.input, nil)
 			assert.NoError(t, err)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ParseSubstraitType() = %v, want %v", got, tt.want)
@@ -113,16 +112,16 @@ func TestParseFuncDefArgType(t *testing.T) {
 		{"struct<list?<decimal<P,S>>, i16>", "struct<list?<decimal<P,S>>, i16>", "struct", &types.ParameterizedStructType{Types: []types.FuncDefArgType{&types.ParameterizedListType{Type: &types.ParameterizedDecimalType{Precision: &variableIntP, Scale: &variableIntS, Nullability: types.NullabilityRequired}, Nullability: types.NullabilityNullable}, &types.Int16Type{Nullability: types.NullabilityRequired}}, Nullability: types.NullabilityRequired}},
 		{"map<decimal<P,S>, i16>", "map<decimal<P,S>, i16>", "map", &types.ParameterizedMapType{Key: &types.ParameterizedDecimalType{Precision: &variableIntP, Scale: &variableIntS, Nullability: types.NullabilityRequired}, Value: &types.Int16Type{Nullability: types.NullabilityRequired}, Nullability: types.NullabilityRequired}},
 		{"precision_timestamp_tz?<L1>", "precision_timestamp_tz?<L1>", "ptstz", &types.ParameterizedPrecisionTimestampTzType{IntegerOption: &variableIntL1, Nullability: types.NullabilityNullable}},
-		{"u!test", "u!test", "u!test", &types.ParameterizedUserDefinedType{Name: "test", Nullability: types.NullabilityRequired}},
-		{"u!test?", "u!test?", "u!test", &types.ParameterizedUserDefinedType{Name: "test", Nullability: types.NullabilityNullable}},
-		{"u!test<10>", "u!test<10>", "u!test", &types.ParameterizedUserDefinedType{Name: "test", Nullability: types.NullabilityRequired, TypeParameters: []types.UDTParameter{&types.IntegerUDTParam{Integer: 10}}}},
-		{"u!test?<10>", "u!test?<10>", "u!test", &types.ParameterizedUserDefinedType{Name: "test", Nullability: types.NullabilityNullable, TypeParameters: []types.UDTParameter{&types.IntegerUDTParam{Integer: 10}}}},
-		{"u!test<L1>", "u!test<L1>", "u!test", &types.ParameterizedUserDefinedType{Name: "test", Nullability: types.NullabilityRequired, TypeParameters: []types.UDTParameter{&types.StringUDTParam{StringVal: "L1"}}}},
-		{"u!test<decimal<P,S>>", "u!test<decimal<P,S>>", "u!test", &types.ParameterizedUserDefinedType{Name: "test", Nullability: types.NullabilityRequired, TypeParameters: []types.UDTParameter{&types.DataTypeUDTParam{Type: &types.ParameterizedDecimalType{Precision: &variableIntP, Scale: &variableIntS, Nullability: types.NullabilityRequired}}}}},
+		{"u!test", "u!test", "u!test", &types.ParameterizedUserDefinedType{Name: "test", URN: "extension:test:test", Nullability: types.NullabilityRequired}},
+		{"u!test?", "u!test?", "u!test", &types.ParameterizedUserDefinedType{Name: "test", URN: "extension:test:test", Nullability: types.NullabilityNullable}},
+		{"u!test<10>", "u!test<10>", "u!test", &types.ParameterizedUserDefinedType{Name: "test", URN: "extension:test:test", Nullability: types.NullabilityRequired, TypeParameters: []types.UDTParameter{&types.IntegerUDTParam{Integer: 10}}}},
+		{"u!test?<10>", "u!test?<10>", "u!test", &types.ParameterizedUserDefinedType{Name: "test", URN: "extension:test:test", Nullability: types.NullabilityNullable, TypeParameters: []types.UDTParameter{&types.IntegerUDTParam{Integer: 10}}}},
+		{"u!test<L1>", "u!test<L1>", "u!test", &types.ParameterizedUserDefinedType{Name: "test", URN: "extension:test:test", Nullability: types.NullabilityRequired, TypeParameters: []types.UDTParameter{&types.StringUDTParam{StringVal: "L1"}}}},
+		{"u!test<decimal<P,S>>", "u!test<decimal<P,S>>", "u!test", &types.ParameterizedUserDefinedType{Name: "test", URN: "extension:test:test", Nullability: types.NullabilityRequired, TypeParameters: []types.UDTParameter{&types.DataTypeUDTParam{Type: &types.ParameterizedDecimalType{Precision: &variableIntP, Scale: &variableIntS, Nullability: types.NullabilityRequired}}}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got, err := ParseType(tt.input)
+			got, err := ParseType(tt.input, func(name string) (string, error) { return "extension:test:test", nil })
 			require.NoError(t, err)
 			require.NotNil(t, got)
 			assert.Equal(t, tt.expected, got.String())
@@ -147,7 +146,7 @@ func TestParseErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			_, err := ParseType(tt.input)
+			_, err := ParseType(tt.input, nil)
 			assert.Error(t, err)
 		})
 	}
@@ -194,15 +193,7 @@ func TestTypeExpression_UnmarshalYAML1(t1 *testing.T) {
 	for _, tt := range tests {
 		t1.Run(tt.name, func(t1 *testing.T) {
 			t := &TypeExpression{}
-			dummyFunc := func(arg interface{}) error {
-				argPtr := reflect.ValueOf(arg)
-				if argPtr.Kind() == reflect.Ptr && !argPtr.IsNil() {
-					argPtr.Elem().Set(reflect.ValueOf(tt.name))
-					return nil
-				}
-				return fmt.Errorf("expected pointer argument")
-			}
-			err := t.UnmarshalYAML(dummyFunc)
+			err := yaml.Unmarshal([]byte(tt.name), t)
 			if tt.hasError {
 				require.Error(t1, err)
 				return
@@ -237,7 +228,7 @@ func TestParseOutputDerivation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseType(tt.input)
+			got, err := ParseType(tt.input, nil)
 			require.NoError(t, err)
 			derivation, ok := got.(*types.OutputDerivation)
 			require.True(t, ok)

--- a/types/parser/visitor.go
+++ b/types/parser/visitor.go
@@ -209,7 +209,9 @@ func (v *TypeVisitor) VisitUserDefined(ctx *baseparser2.UserDefinedContext) inte
 	}
 	name := ctx.Identifier().GetText()
 	var urn string
-	if v.ResolveUserDefinedType != nil {
+	if v.ResolveUserDefinedType == nil {
+		v.ErrorListener.ReportVisitError(ctx, fmt.Errorf("user-defined type resolver is required"))
+	} else {
 		resolvedURN, err := v.ResolveUserDefinedType(name)
 		if err != nil {
 			v.ErrorListener.ReportVisitError(ctx, err)

--- a/types/parser/visitor.go
+++ b/types/parser/visitor.go
@@ -14,7 +14,8 @@ import (
 
 type TypeVisitor struct {
 	baseparser2.SubstraitTypeVisitor
-	ErrorListener util.VisitErrorListener
+	ErrorListener          util.VisitErrorListener
+	ResolveUserDefinedType UserDefinedTypeResolver
 }
 
 var _ baseparser2.SubstraitTypeVisitor = &TypeVisitor{}
@@ -207,7 +208,15 @@ func (v *TypeVisitor) VisitUserDefined(ctx *baseparser2.UserDefinedContext) inte
 		}
 	}
 	name := ctx.Identifier().GetText()
-	return &types.ParameterizedUserDefinedType{Name: name, Nullability: nullability, TypeParameters: params}
+	var urn string
+	if v.ResolveUserDefinedType != nil {
+		resolvedURN, err := v.ResolveUserDefinedType(name)
+		if err != nil {
+			v.ErrorListener.ReportVisitError(ctx, err)
+		}
+		urn = resolvedURN
+	}
+	return &types.ParameterizedUserDefinedType{Name: name, URN: urn, Nullability: nullability, TypeParameters: params}
 }
 
 func (v *TypeVisitor) VisitFixedChar(ctx *baseparser2.FixedCharContext) interface{} {

--- a/types/parser/visitor.go
+++ b/types/parser/visitor.go
@@ -208,17 +208,17 @@ func (v *TypeVisitor) VisitUserDefined(ctx *baseparser2.UserDefinedContext) inte
 		}
 	}
 	name := ctx.Identifier().GetText()
-	var urn string
 	if v.ResolveUserDefinedType == nil {
 		v.ErrorListener.ReportVisitError(ctx, fmt.Errorf("user-defined type resolver is required"))
-	} else {
-		resolvedURN, err := v.ResolveUserDefinedType(name)
-		if err != nil {
-			v.ErrorListener.ReportVisitError(ctx, err)
-		}
-		urn = resolvedURN
+		return nil
 	}
-	return &types.ParameterizedUserDefinedType{Name: name, URN: urn, Nullability: nullability, TypeParameters: params}
+
+	udt, err := v.ResolveUserDefinedType(name, nullability, params)
+	if err != nil {
+		v.ErrorListener.ReportVisitError(ctx, err)
+		return nil
+	}
+	return udt
 }
 
 func (v *TypeVisitor) VisitFixedChar(ctx *baseparser2.FixedCharContext) interface{} {

--- a/types/type_derivation_test.go
+++ b/types/type_derivation_test.go
@@ -18,7 +18,7 @@ type testcase struct {
 }
 
 func parseAndTestTypeDerivation(t *testing.T, tt *testcase) {
-	resultType, err := parser.ParseType(tt.expr)
+	resultType, err := parser.ParseType(tt.expr, nil)
 	require.NoError(t, err)
 	require.NotNil(t, resultType)
 	derivation, ok := resultType.(*types.OutputDerivation)
@@ -161,7 +161,7 @@ decimal<prec,scale>`
 		t.Run(tt.name, func(t *testing.T) {
 			funcParameters := parseFuncParameters(t, tt.parameters)
 			funcArguments := parseFuncArguments(t, tt.args)
-			resultType, err := parser.ParseType(tt.expr)
+			resultType, err := parser.ParseType(tt.expr, nil)
 			require.NoError(t, err)
 			require.NotNil(t, resultType)
 			derivation, ok := resultType.(*types.OutputDerivation)
@@ -190,7 +190,7 @@ func parseFuncParameters(t *testing.T, params []string) []types.FuncDefArgType {
 	result := make([]types.FuncDefArgType, len(params))
 	for i, p := range params {
 		var err error
-		result[i], err = parser.ParseType(p)
+		result[i], err = parser.ParseType(p, nil)
 		require.NoError(t, err)
 	}
 	return result
@@ -199,7 +199,7 @@ func parseFuncParameters(t *testing.T, params []string) []types.FuncDefArgType {
 func parseFuncArguments(t *testing.T, args []string) []types.Type {
 	result := make([]types.Type, len(args))
 	for i, a := range args {
-		funcDefArgType, err := parser.ParseType(a)
+		funcDefArgType, err := parser.ParseType(a, nil)
 		require.NoError(t, err)
 		result[i], err = funcDefArgType.WithParameters(nil)
 		require.NoError(t, err)


### PR DESCRIPTION
Draft alternative to the stacked dependency/UDT validation work.

This explores resolving user-defined type references while parsing extension YAML type expressions instead of constructing unresolved `u!name` nodes and inferring their URN later from the function variant.

Key changes:
- adds parser options with a `UserDefinedTypeResolver`
- stores the resolved URN on `types.ParameterizedUserDefinedType`
- parses extension YAML function signatures with resolver context from the current file's `urn` and `types:` declarations
- rejects undeclared local UDT references during extension YAML parsing
- uses the resolved UDT URN when assigning type anchors

This intentionally starts with local UDT resolution. Dependency-qualified references can build on the same resolver shape by resolving aliases to dependency URNs.

Tests:
- `go test ./...`

---
Note: This PR was developed with AI assistance. All changes have been reviewed, and I take full responsibility for this contribution.