### PR TITLE
feat: support new ComparisonJoinKey field in HashJoinRel/MergeJoinRel

### DIFF
--- a/plan/comparison_join_key_test.go
+++ b/plan/comparison_join_key_test.go
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package plan
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/substrait-io/substrait-go/v8/expr"
+	"github.com/substrait-io/substrait-go/v8/extensions"
+	"github.com/substrait-io/substrait-go/v8/types"
+	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+// createJoinInput builds a named table read rel with three required int64 columns.
+func createJoinInput(name string) *NamedTableReadRel {
+	schema := types.NamedStruct{
+		Names: []string{"x", "y", "z"},
+		Struct: types.StructType{
+			Nullability: types.NullabilityRequired,
+			Types:       []types.Type{&types.Int64Type{}, &types.Int64Type{}, &types.Int64Type{}},
+		},
+	}
+	return &NamedTableReadRel{names: []string{name}, baseReadRel: baseReadRel{baseSchema: schema}}
+}
+
+func keyRef(t *testing.T, rel Rel, idx int32) *expr.FieldReference {
+	t.Helper()
+	base := rel.RecordType()
+	ref, err := expr.NewRootFieldRef(expr.NewStructFieldRef(idx), &base)
+	require.NoError(t, err)
+	return ref
+}
+
+func joinTestRegistry() expr.ExtensionRegistry {
+	return expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+}
+
+// All joins below have a left and right input with three int64 columns each.
+func joinInputs() (Rel, Rel) {
+	return createJoinInput("L"), createJoinInput("R")
+}
+
+func eqKeys(t *testing.T, left, right Rel) []*ComparisonJoinKey {
+	return []*ComparisonJoinKey{
+		NewEqualityJoinKey(keyRef(t, left, 0), keyRef(t, right, 2)),
+		NewEqualityJoinKey(keyRef(t, left, 1), keyRef(t, right, 0)),
+	}
+}
+
+// Producing a join must only populate the new keys field, never the deprecated ones.
+func TestJoinProducesOnlyNewKeys(t *testing.T) {
+	left, right := joinInputs()
+	keys := eqKeys(t, left, right)
+
+	hash := (&HashJoinRel{left: left, right: right, joinType: HashMergeInner, keys: keys}).ToProto().GetHashJoin()
+	assert.Len(t, hash.GetKeys(), 2)
+	assert.Empty(t, hash.GetLeftKeys())
+	assert.Empty(t, hash.GetRightKeys())
+
+	merge := (&MergeJoinRel{left: left, right: right, joinType: HashMergeInner, keys: keys}).ToProto().GetMergeJoin()
+	assert.Len(t, merge.GetKeys(), 2)
+	assert.Empty(t, merge.GetLeftKeys())
+	assert.Empty(t, merge.GetRightKeys())
+}
+
+// The deprecated accessors derive their values from the keys.
+func TestJoinDeprecatedKeyAccessors(t *testing.T) {
+	left, right := joinInputs()
+	keys := eqKeys(t, left, right)
+	wantLeft := []*expr.FieldReference{keyRef(t, left, 0), keyRef(t, left, 1)}
+	wantRight := []*expr.FieldReference{keyRef(t, right, 2), keyRef(t, right, 0)}
+
+	hash := &HashJoinRel{left: left, right: right, joinType: HashMergeInner, keys: keys}
+	assert.Equal(t, wantLeft, hash.LeftKeys())
+	assert.Equal(t, wantRight, hash.RightKeys())
+
+	merge := &MergeJoinRel{left: left, right: right, joinType: HashMergeInner, keys: keys}
+	assert.Equal(t, wantLeft, merge.LeftKeys())
+	assert.Equal(t, wantRight, merge.RightKeys())
+}
+
+// A plan from a legacy producer (only deprecated fields set) is consumed and
+// mapped to keys with EQ comparisons.
+func TestJoinConsumesLegacyKeys(t *testing.T) {
+	left, right := joinInputs()
+	reg := joinTestRegistry()
+
+	for _, tc := range []struct {
+		name  string
+		build func(hj *proto.HashJoinRel) *proto.Rel
+		keys  func(rel Rel) []*ComparisonJoinKey
+	}{
+		{
+			name:  "hash",
+			build: func(hj *proto.HashJoinRel) *proto.Rel { return &proto.Rel{RelType: &proto.Rel_HashJoin{HashJoin: hj}} },
+			keys:  func(rel Rel) []*ComparisonJoinKey { return rel.(*HashJoinRel).Keys() },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			legacy := tc.build(&proto.HashJoinRel{
+				Common: &proto.RelCommon{},
+				Left:   left.ToProto(),
+				Right:  right.ToProto(),
+				Type:   proto.HashJoinRel_JOIN_TYPE_INNER,
+				LeftKeys: []*proto.Expression_FieldReference{
+					keyRef(t, left, 0).ToProtoFieldRef(), keyRef(t, left, 1).ToProtoFieldRef()},
+				RightKeys: []*proto.Expression_FieldReference{
+					keyRef(t, right, 2).ToProtoFieldRef(), keyRef(t, right, 0).ToProtoFieldRef()},
+			})
+
+			rel, err := RelFromProto(legacy, reg)
+			require.NoError(t, err)
+
+			keys := tc.keys(rel)
+			require.Len(t, keys, 2)
+			for _, k := range keys {
+				assert.Equal(t, SimpleComparison{Type: SimpleComparisonTypeEq}, k.Comparison())
+			}
+
+			// Re-emitting must only set the new keys field.
+			hj := rel.ToProto().GetHashJoin()
+			assert.Len(t, hj.GetKeys(), 2)
+			assert.Empty(t, hj.GetLeftKeys())
+			assert.Empty(t, hj.GetRightKeys())
+		})
+	}
+}
+
+// When both the deprecated fields and the new keys are present, keys wins.
+func TestJoinPrefersNewKeysOverDeprecated(t *testing.T) {
+	left, right := joinInputs()
+	reg := joinTestRegistry()
+	keys := eqKeys(t, left, right)
+
+	both := &proto.Rel{RelType: &proto.Rel_HashJoin{HashJoin: &proto.HashJoinRel{
+		Common: &proto.RelCommon{},
+		Left:   left.ToProto(),
+		Right:  right.ToProto(),
+		Type:   proto.HashJoinRel_JOIN_TYPE_INNER,
+		Keys:   comparisonJoinKeysToProto(keys),
+		// Bogus deprecated keys pointing at different fields than the real keys.
+		LeftKeys:  []*proto.Expression_FieldReference{keyRef(t, left, 2).ToProtoFieldRef()},
+		RightKeys: []*proto.Expression_FieldReference{keyRef(t, right, 1).ToProtoFieldRef()},
+	}}}
+
+	rel, err := RelFromProto(both, reg)
+	require.NoError(t, err)
+	got := rel.ToProto().GetHashJoin().GetKeys()
+	if diff := cmp.Diff(comparisonJoinKeysToProto(keys), got, protocmp.Transform()); diff != "" {
+		t.Errorf("expected new keys to win, diff:\n%v", diff)
+	}
+}
+
+// Equality, non-EQ simple comparisons and custom comparison functions all
+// survive a round trip through proto.
+func TestJoinKeysRoundTrip(t *testing.T) {
+	left, right := joinInputs()
+	reg := joinTestRegistry()
+
+	keys := []*ComparisonJoinKey{
+		NewEqualityJoinKey(keyRef(t, left, 0), keyRef(t, right, 2)),
+		NewComparisonJoinKey(keyRef(t, left, 1), keyRef(t, right, 0),
+			SimpleComparison{Type: SimpleComparisonTypeIsNotDistinctFrom}),
+		NewComparisonJoinKey(keyRef(t, left, 2), keyRef(t, right, 1),
+			CustomComparison{FunctionReference: 42}),
+	}
+
+	for _, tc := range []struct {
+		name string
+		rel  Rel
+	}{
+		{"hash", &HashJoinRel{left: left, right: right, joinType: HashMergeInner, keys: keys}},
+		{"merge", &MergeJoinRel{left: left, right: right, joinType: HashMergeInner, keys: keys}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := tc.rel.ToProto()
+			roundTripped, err := RelFromProto(out, reg)
+			require.NoError(t, err)
+
+			if diff := cmp.Diff(out, roundTripped.ToProto(), protocmp.Transform()); diff != "" {
+				t.Errorf("join did not round trip, diff:\n%v", diff)
+			}
+
+			// The comparison kinds are preserved on the model side.
+			var gotKeys []*ComparisonJoinKey
+			switch r := roundTripped.(type) {
+			case *HashJoinRel:
+				gotKeys = r.Keys()
+			case *MergeJoinRel:
+				gotKeys = r.Keys()
+			}
+			require.Len(t, gotKeys, 3)
+			assert.Equal(t, SimpleComparison{Type: SimpleComparisonTypeEq}, gotKeys[0].Comparison())
+			assert.Equal(t, SimpleComparison{Type: SimpleComparisonTypeIsNotDistinctFrom}, gotKeys[1].Comparison())
+			assert.Equal(t, CustomComparison{FunctionReference: 42}, gotKeys[2].Comparison())
+		})
+	}
+}
+
+// badFieldRef builds a proto field reference to an out-of-range struct field,
+// which fails to resolve against the join inputs' three-column schema.
+func badFieldRef() *proto.Expression_FieldReference {
+	return &proto.Expression_FieldReference{
+		ReferenceType: &proto.Expression_FieldReference_DirectReference{
+			DirectReference: &proto.Expression_ReferenceSegment{
+				ReferenceType: &proto.Expression_ReferenceSegment_StructField_{
+					StructField: &proto.Expression_ReferenceSegment_StructField{Field: 99},
+				},
+			},
+		},
+		RootType: &proto.Expression_FieldReference_RootReference_{
+			RootReference: &proto.Expression_FieldReference_RootReference{},
+		},
+	}
+}
+
+// joinFields holds the key-bearing fields shared by HashJoinRel and
+// MergeJoinRel so an error case can be exercised against both join types.
+type joinFields struct {
+	keys      []*proto.ComparisonJoinKey
+	leftKeys  []*proto.Expression_FieldReference
+	rightKeys []*proto.Expression_FieldReference
+}
+
+func (f joinFields) hashProto(left, right Rel) *proto.Rel {
+	return &proto.Rel{RelType: &proto.Rel_HashJoin{HashJoin: &proto.HashJoinRel{
+		Common: &proto.RelCommon{}, Type: proto.HashJoinRel_JOIN_TYPE_INNER,
+		Left: left.ToProto(), Right: right.ToProto(),
+		Keys: f.keys, LeftKeys: f.leftKeys, RightKeys: f.rightKeys,
+	}}}
+}
+
+func (f joinFields) mergeProto(left, right Rel) *proto.Rel {
+	return &proto.Rel{RelType: &proto.Rel_MergeJoin{MergeJoin: &proto.MergeJoinRel{
+		Common: &proto.RelCommon{}, Type: proto.MergeJoinRel_JOIN_TYPE_INNER,
+		Left: left.ToProto(), Right: right.ToProto(),
+		Keys: f.keys, LeftKeys: f.leftKeys, RightKeys: f.rightKeys,
+	}}}
+}
+
+// Error paths in comparisonJoinKeysFromProto / joinKeyComparisonFromProto,
+// exercised against both hash and merge joins.
+func TestJoinKeysFromProtoErrors(t *testing.T) {
+	left, right := joinInputs()
+	reg := joinTestRegistry()
+	goodLeft := keyRef(t, left, 0).ToProtoFieldRef()
+	goodRight := keyRef(t, right, 0).ToProtoFieldRef()
+	eq := SimpleComparison{Type: SimpleComparisonTypeEq}.toProto()
+
+	for _, tc := range []struct {
+		name   string
+		fields joinFields
+	}{
+		{
+			name:   "keys path: bad left ref",
+			fields: joinFields{keys: []*proto.ComparisonJoinKey{{Left: badFieldRef(), Right: goodRight, Comparison: eq}}},
+		},
+		{
+			name:   "keys path: bad right ref",
+			fields: joinFields{keys: []*proto.ComparisonJoinKey{{Left: goodLeft, Right: badFieldRef(), Comparison: eq}}},
+		},
+		{
+			name:   "keys path: unset comparison",
+			fields: joinFields{keys: []*proto.ComparisonJoinKey{{Left: goodLeft, Right: goodRight, Comparison: &proto.ComparisonJoinKey_ComparisonType{}}}},
+		},
+		{
+			name:   "legacy path: bad left ref",
+			fields: joinFields{leftKeys: []*proto.Expression_FieldReference{badFieldRef()}, rightKeys: []*proto.Expression_FieldReference{goodRight}},
+		},
+		{
+			name:   "legacy path: bad right ref",
+			fields: joinFields{leftKeys: []*proto.Expression_FieldReference{goodLeft}, rightKeys: []*proto.Expression_FieldReference{badFieldRef()}},
+		},
+		{
+			name:   "legacy path: mismatched lengths",
+			fields: joinFields{leftKeys: []*proto.Expression_FieldReference{goodLeft}, rightKeys: []*proto.Expression_FieldReference{}},
+		},
+	} {
+		t.Run("hash/"+tc.name, func(t *testing.T) {
+			_, err := RelFromProto(tc.fields.hashProto(left, right), reg)
+			require.Error(t, err)
+		})
+		t.Run("merge/"+tc.name, func(t *testing.T) {
+			_, err := RelFromProto(tc.fields.mergeProto(left, right), reg)
+			require.Error(t, err)
+		})
+	}
+}
+
+// A merge join whose right input fails to decode surfaces an error.
+func TestMergeJoinBadRightInput(t *testing.T) {
+	left, _ := joinInputs()
+	rel := &proto.Rel{RelType: &proto.Rel_MergeJoin{MergeJoin: &proto.MergeJoinRel{
+		Common: &proto.RelCommon{},
+		Type:   proto.MergeJoinRel_JOIN_TYPE_INNER,
+		Left:   left.ToProto(),
+		Right:  &proto.Rel{}, // nil RelType -> RelFromProto errors
+	}}}
+
+	_, err := RelFromProto(rel, joinTestRegistry())
+	require.ErrorContains(t, err, "right input to MergeJoinRel")
+}
+
+// Exercises the join accessors and the ComparisonJoinKey getters, and covers
+// the post-join-filter branch of ToProto via a round trip.
+func TestJoinAccessorsAndPostJoinFilter(t *testing.T) {
+	left, right := joinInputs()
+	reg := joinTestRegistry()
+	keys := eqKeys(t, left, right)
+	postFilter := expr.NewPrimitiveLiteral(true, false)
+
+	k := keys[0]
+	assert.Equal(t, keyRef(t, left, 0), k.Left())
+	assert.Equal(t, keyRef(t, right, 2), k.Right())
+	assert.Equal(t, SimpleComparison{Type: SimpleComparisonTypeEq}, k.Comparison())
+
+	// With no post-join filter set, the accessor returns the default filter.
+	noFilter := &HashJoinRel{left: left, right: right, joinType: HashMergeInner, keys: keys}
+	assert.Equal(t, defFilter, noFilter.PostJoinFilter())
+
+	for _, tc := range []struct {
+		name string
+		rel  Rel
+	}{
+		{"hash", &HashJoinRel{left: left, right: right, joinType: HashMergeInner, keys: keys, postJoinFilter: postFilter}},
+		{"merge", &MergeJoinRel{left: left, right: right, joinType: HashMergeInner, keys: keys, postJoinFilter: postFilter}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			switch r := tc.rel.(type) {
+			case *HashJoinRel:
+				assert.Equal(t, left, r.Left())
+				assert.Equal(t, right, r.Right())
+				assert.Equal(t, HashMergeInner, r.Type())
+				assert.Equal(t, postFilter, r.PostJoinFilter())
+			case *MergeJoinRel:
+				assert.Equal(t, left, r.Left())
+				assert.Equal(t, right, r.Right())
+				assert.Equal(t, HashMergeInner, r.Type())
+				assert.Equal(t, postFilter, r.PostJoinFilter())
+			}
+
+			out := tc.rel.ToProto()
+			roundTripped, err := RelFromProto(out, reg)
+			require.NoError(t, err)
+			if diff := cmp.Diff(out, roundTripped.ToProto(), protocmp.Transform()); diff != "" {
+				t.Errorf("join with post-join filter did not round trip, diff:\n%v", diff)
+			}
+		})
+	}
+}

--- a/plan/comparison_join_key_test.go
+++ b/plan/comparison_join_key_test.go
@@ -62,19 +62,28 @@ func TestJoinWritesLegacyKeysForEqualityOnly(t *testing.T) {
 		keyRef(t, right, 2).ToProtoFieldRef(), keyRef(t, right, 0).ToProtoFieldRef()}
 
 	// All-EQ keys: new keys field plus mirrored deprecated fields.
-	t.Run("all EQ mirrors deprecated fields", func(t *testing.T) {
-		keys := eqKeys(t, left, right)
+	for _, tc := range []struct {
+		name string
+		keys []*ComparisonJoinKey
+	}{
+		{name: "value comparison", keys: eqKeys(t, left, right)},
+		{name: "pointer comparison", keys: []*ComparisonJoinKey{
+			NewComparisonJoinKey(keyRef(t, left, 0), keyRef(t, right, 2), &SimpleComparison{Type: SimpleComparisonTypeEq}),
+			NewComparisonJoinKey(keyRef(t, left, 1), keyRef(t, right, 0), &SimpleComparison{Type: SimpleComparisonTypeEq}),
+		}},
+	} {
+		t.Run("all EQ mirrors deprecated fields: "+tc.name, func(t *testing.T) {
+			hash := (&HashJoinRel{left: left, right: right, joinType: HashMergeInner, keys: tc.keys}).ToProto().GetHashJoin()
+			assert.Len(t, hash.GetKeys(), 2)
+			assert.Empty(t, cmp.Diff(wantLeft, hash.GetLeftKeys(), protocmp.Transform()))
+			assert.Empty(t, cmp.Diff(wantRight, hash.GetRightKeys(), protocmp.Transform()))
 
-		hash := (&HashJoinRel{left: left, right: right, joinType: HashMergeInner, keys: keys}).ToProto().GetHashJoin()
-		assert.Len(t, hash.GetKeys(), 2)
-		assert.Empty(t, cmp.Diff(wantLeft, hash.GetLeftKeys(), protocmp.Transform()))
-		assert.Empty(t, cmp.Diff(wantRight, hash.GetRightKeys(), protocmp.Transform()))
-
-		merge := (&MergeJoinRel{left: left, right: right, joinType: HashMergeInner, keys: keys}).ToProto().GetMergeJoin()
-		assert.Len(t, merge.GetKeys(), 2)
-		assert.Empty(t, cmp.Diff(wantLeft, merge.GetLeftKeys(), protocmp.Transform()))
-		assert.Empty(t, cmp.Diff(wantRight, merge.GetRightKeys(), protocmp.Transform()))
-	})
+			merge := (&MergeJoinRel{left: left, right: right, joinType: HashMergeInner, keys: tc.keys}).ToProto().GetMergeJoin()
+			assert.Len(t, merge.GetKeys(), 2)
+			assert.Empty(t, cmp.Diff(wantLeft, merge.GetLeftKeys(), protocmp.Transform()))
+			assert.Empty(t, cmp.Diff(wantRight, merge.GetRightKeys(), protocmp.Transform()))
+		})
+	}
 
 	// A non-EQ comparison anywhere makes the legacy fields lossy, so they are
 	// omitted entirely and only the new keys field is written.
@@ -192,23 +201,48 @@ func TestJoinPrefersNewKeysOverDeprecated(t *testing.T) {
 	reg := joinTestRegistry()
 	keys := eqKeys(t, left, right)
 
-	both := &proto.Rel{RelType: &proto.Rel_HashJoin{HashJoin: &proto.HashJoinRel{
-		Common: &proto.RelCommon{},
-		Left:   left.ToProto(),
-		Right:  right.ToProto(),
-		Type:   proto.HashJoinRel_JOIN_TYPE_INNER,
-		Keys:   comparisonJoinKeysToProto(keys),
-		// Bogus deprecated keys pointing at different fields than the real keys.
-		LeftKeys:  []*proto.Expression_FieldReference{keyRef(t, left, 2).ToProtoFieldRef()},
-		RightKeys: []*proto.Expression_FieldReference{keyRef(t, right, 1).ToProtoFieldRef()},
-	}}}
+	bogusLeft := []*proto.Expression_FieldReference{keyRef(t, left, 2).ToProtoFieldRef()}
+	bogusRight := []*proto.Expression_FieldReference{keyRef(t, right, 1).ToProtoFieldRef()}
 
-	rel, err := RelFromProto(both, reg)
-	require.NoError(t, err)
-	got := rel.ToProto().GetHashJoin().GetKeys()
-	if diff := cmp.Diff(comparisonJoinKeysToProto(keys), got, protocmp.Transform()); diff != "" {
-		t.Errorf("expected new keys to win, diff:\n%v", diff)
-	}
+	t.Run("hash", func(t *testing.T) {
+		both := &proto.Rel{RelType: &proto.Rel_HashJoin{HashJoin: &proto.HashJoinRel{
+			Common: &proto.RelCommon{},
+			Left:   left.ToProto(),
+			Right:  right.ToProto(),
+			Type:   proto.HashJoinRel_JOIN_TYPE_INNER,
+			Keys:   comparisonJoinKeysToProto(keys),
+			// Bogus deprecated keys pointing at different fields than the real keys.
+			LeftKeys:  bogusLeft,
+			RightKeys: bogusRight,
+		}}}
+
+		rel, err := RelFromProto(both, reg)
+		require.NoError(t, err)
+		got := rel.ToProto().GetHashJoin().GetKeys()
+		if diff := cmp.Diff(comparisonJoinKeysToProto(keys), got, protocmp.Transform()); diff != "" {
+			t.Errorf("expected new keys to win, diff:\n%v", diff)
+		}
+	})
+
+	t.Run("merge", func(t *testing.T) {
+		both := &proto.Rel{RelType: &proto.Rel_MergeJoin{MergeJoin: &proto.MergeJoinRel{
+			Common: &proto.RelCommon{},
+			Left:   left.ToProto(),
+			Right:  right.ToProto(),
+			Type:   proto.MergeJoinRel_JOIN_TYPE_INNER,
+			Keys:   comparisonJoinKeysToProto(keys),
+			// Bogus deprecated keys pointing at different fields than the real keys.
+			LeftKeys:  bogusLeft,
+			RightKeys: bogusRight,
+		}}}
+
+		rel, err := RelFromProto(both, reg)
+		require.NoError(t, err)
+		got := rel.ToProto().GetMergeJoin().GetKeys()
+		if diff := cmp.Diff(comparisonJoinKeysToProto(keys), got, protocmp.Transform()); diff != "" {
+			t.Errorf("expected new keys to win, diff:\n%v", diff)
+		}
+	})
 }
 
 // Equality, non-EQ simple comparisons and custom comparison functions all

--- a/plan/comparison_join_key_test.go
+++ b/plan/comparison_join_key_test.go
@@ -51,20 +51,58 @@ func eqKeys(t *testing.T, left, right Rel) []*ComparisonJoinKey {
 	}
 }
 
-// Producing a join must only populate the new keys field, never the deprecated ones.
-func TestJoinProducesOnlyNewKeys(t *testing.T) {
+// Producing a join always writes the new keys field, and additionally
+// mirrors the deprecated left_keys/right_keys when every key is a plain EQ
+// comparison so old consumers keep working for equality joins.
+func TestJoinWritesLegacyKeysForEqualityOnly(t *testing.T) {
 	left, right := joinInputs()
-	keys := eqKeys(t, left, right)
+	wantLeft := []*proto.Expression_FieldReference{
+		keyRef(t, left, 0).ToProtoFieldRef(), keyRef(t, left, 1).ToProtoFieldRef()}
+	wantRight := []*proto.Expression_FieldReference{
+		keyRef(t, right, 2).ToProtoFieldRef(), keyRef(t, right, 0).ToProtoFieldRef()}
 
-	hash := (&HashJoinRel{left: left, right: right, joinType: HashMergeInner, keys: keys}).ToProto().GetHashJoin()
-	assert.Len(t, hash.GetKeys(), 2)
-	assert.Empty(t, hash.GetLeftKeys())
-	assert.Empty(t, hash.GetRightKeys())
+	// All-EQ keys: new keys field plus mirrored deprecated fields.
+	t.Run("all EQ mirrors deprecated fields", func(t *testing.T) {
+		keys := eqKeys(t, left, right)
 
-	merge := (&MergeJoinRel{left: left, right: right, joinType: HashMergeInner, keys: keys}).ToProto().GetMergeJoin()
-	assert.Len(t, merge.GetKeys(), 2)
-	assert.Empty(t, merge.GetLeftKeys())
-	assert.Empty(t, merge.GetRightKeys())
+		hash := (&HashJoinRel{left: left, right: right, joinType: HashMergeInner, keys: keys}).ToProto().GetHashJoin()
+		assert.Len(t, hash.GetKeys(), 2)
+		assert.Empty(t, cmp.Diff(wantLeft, hash.GetLeftKeys(), protocmp.Transform()))
+		assert.Empty(t, cmp.Diff(wantRight, hash.GetRightKeys(), protocmp.Transform()))
+
+		merge := (&MergeJoinRel{left: left, right: right, joinType: HashMergeInner, keys: keys}).ToProto().GetMergeJoin()
+		assert.Len(t, merge.GetKeys(), 2)
+		assert.Empty(t, cmp.Diff(wantLeft, merge.GetLeftKeys(), protocmp.Transform()))
+		assert.Empty(t, cmp.Diff(wantRight, merge.GetRightKeys(), protocmp.Transform()))
+	})
+
+	// A non-EQ comparison anywhere makes the legacy fields lossy, so they are
+	// omitted entirely and only the new keys field is written.
+	for _, tc := range []struct {
+		name       string
+		comparison JoinKeyComparison
+	}{
+		{"is not distinct from", SimpleComparison{Type: SimpleComparisonTypeIsNotDistinctFrom}},
+		{"might equal", SimpleComparison{Type: SimpleComparisonTypeMightEqual}},
+		{"custom", CustomComparison{FunctionReference: 7}},
+	} {
+		t.Run("non-EQ omits deprecated fields: "+tc.name, func(t *testing.T) {
+			keys := []*ComparisonJoinKey{
+				NewEqualityJoinKey(keyRef(t, left, 0), keyRef(t, right, 2)),
+				NewComparisonJoinKey(keyRef(t, left, 1), keyRef(t, right, 0), tc.comparison),
+			}
+
+			hash := (&HashJoinRel{left: left, right: right, joinType: HashMergeInner, keys: keys}).ToProto().GetHashJoin()
+			assert.Len(t, hash.GetKeys(), 2)
+			assert.Empty(t, hash.GetLeftKeys())
+			assert.Empty(t, hash.GetRightKeys())
+
+			merge := (&MergeJoinRel{left: left, right: right, joinType: HashMergeInner, keys: keys}).ToProto().GetMergeJoin()
+			assert.Len(t, merge.GetKeys(), 2)
+			assert.Empty(t, merge.GetLeftKeys())
+			assert.Empty(t, merge.GetRightKeys())
+		})
+	}
 }
 
 // The deprecated accessors derive their values from the keys.
@@ -121,11 +159,12 @@ func TestJoinConsumesLegacyKeys(t *testing.T) {
 				assert.Equal(t, SimpleComparison{Type: SimpleComparisonTypeEq}, k.Comparison())
 			}
 
-			// Re-emitting must only set the new keys field.
+			// Re-emitting sets the new keys field and, because these are all
+			// EQ comparisons, mirrors the deprecated fields back as well.
 			hj := rel.ToProto().GetHashJoin()
 			assert.Len(t, hj.GetKeys(), 2)
-			assert.Empty(t, hj.GetLeftKeys())
-			assert.Empty(t, hj.GetRightKeys())
+			assert.Len(t, hj.GetLeftKeys(), 2)
+			assert.Len(t, hj.GetRightKeys(), 2)
 		})
 	}
 }

--- a/plan/comparison_join_key_test.go
+++ b/plan/comparison_join_key_test.go
@@ -121,52 +121,69 @@ func TestJoinDeprecatedKeyAccessors(t *testing.T) {
 	assert.Equal(t, wantRight, merge.RightKeys())
 }
 
-// A plan from a legacy producer (only deprecated fields set) is consumed and
-// mapped to keys with EQ comparisons.
-func TestJoinConsumesLegacyKeys(t *testing.T) {
+// assertConsumedLegacyKeys checks that the keys decoded from a legacy producer
+// are the expected pair of EQ comparisons.
+func assertConsumedLegacyKeys(t *testing.T, keys []*ComparisonJoinKey) {
+	t.Helper()
+	require.Len(t, keys, 2)
+	for _, k := range keys {
+		assert.Equal(t, SimpleComparison{Type: SimpleComparisonTypeEq}, k.Comparison())
+	}
+}
+
+// A hash join plan from a legacy producer (only deprecated fields set) is
+// consumed and mapped to keys with EQ comparisons. Re-emitting sets the new
+// keys field and, because these are all EQ comparisons, mirrors the deprecated
+// fields back as well.
+func TestHashJoinConsumesLegacyKeys(t *testing.T) {
 	left, right := joinInputs()
 	reg := joinTestRegistry()
 
-	for _, tc := range []struct {
-		name  string
-		build func(hj *proto.HashJoinRel) *proto.Rel
-		keys  func(rel Rel) []*ComparisonJoinKey
-	}{
-		{
-			name:  "hash",
-			build: func(hj *proto.HashJoinRel) *proto.Rel { return &proto.Rel{RelType: &proto.Rel_HashJoin{HashJoin: hj}} },
-			keys:  func(rel Rel) []*ComparisonJoinKey { return rel.(*HashJoinRel).Keys() },
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			legacy := tc.build(&proto.HashJoinRel{
-				Common: &proto.RelCommon{},
-				Left:   left.ToProto(),
-				Right:  right.ToProto(),
-				Type:   proto.HashJoinRel_JOIN_TYPE_INNER,
-				LeftKeys: []*proto.Expression_FieldReference{
-					keyRef(t, left, 0).ToProtoFieldRef(), keyRef(t, left, 1).ToProtoFieldRef()},
-				RightKeys: []*proto.Expression_FieldReference{
-					keyRef(t, right, 2).ToProtoFieldRef(), keyRef(t, right, 0).ToProtoFieldRef()},
-			})
+	legacy := &proto.Rel{RelType: &proto.Rel_HashJoin{HashJoin: &proto.HashJoinRel{
+		Common: &proto.RelCommon{},
+		Left:   left.ToProto(),
+		Right:  right.ToProto(),
+		Type:   proto.HashJoinRel_JOIN_TYPE_INNER,
+		LeftKeys: []*proto.Expression_FieldReference{
+			keyRef(t, left, 0).ToProtoFieldRef(), keyRef(t, left, 1).ToProtoFieldRef()},
+		RightKeys: []*proto.Expression_FieldReference{
+			keyRef(t, right, 2).ToProtoFieldRef(), keyRef(t, right, 0).ToProtoFieldRef()},
+	}}}
 
-			rel, err := RelFromProto(legacy, reg)
-			require.NoError(t, err)
+	rel, err := RelFromProto(legacy, reg)
+	require.NoError(t, err)
+	assertConsumedLegacyKeys(t, rel.(*HashJoinRel).Keys())
 
-			keys := tc.keys(rel)
-			require.Len(t, keys, 2)
-			for _, k := range keys {
-				assert.Equal(t, SimpleComparison{Type: SimpleComparisonTypeEq}, k.Comparison())
-			}
+	hj := rel.ToProto().GetHashJoin()
+	assert.Len(t, hj.GetKeys(), 2)
+	assert.Len(t, hj.GetLeftKeys(), 2)
+	assert.Len(t, hj.GetRightKeys(), 2)
+}
 
-			// Re-emitting sets the new keys field and, because these are all
-			// EQ comparisons, mirrors the deprecated fields back as well.
-			hj := rel.ToProto().GetHashJoin()
-			assert.Len(t, hj.GetKeys(), 2)
-			assert.Len(t, hj.GetLeftKeys(), 2)
-			assert.Len(t, hj.GetRightKeys(), 2)
-		})
-	}
+// As TestHashJoinConsumesLegacyKeys, but for merge joins.
+func TestMergeJoinConsumesLegacyKeys(t *testing.T) {
+	left, right := joinInputs()
+	reg := joinTestRegistry()
+
+	legacy := &proto.Rel{RelType: &proto.Rel_MergeJoin{MergeJoin: &proto.MergeJoinRel{
+		Common: &proto.RelCommon{},
+		Left:   left.ToProto(),
+		Right:  right.ToProto(),
+		Type:   proto.MergeJoinRel_JOIN_TYPE_INNER,
+		LeftKeys: []*proto.Expression_FieldReference{
+			keyRef(t, left, 0).ToProtoFieldRef(), keyRef(t, left, 1).ToProtoFieldRef()},
+		RightKeys: []*proto.Expression_FieldReference{
+			keyRef(t, right, 2).ToProtoFieldRef(), keyRef(t, right, 0).ToProtoFieldRef()},
+	}}}
+
+	rel, err := RelFromProto(legacy, reg)
+	require.NoError(t, err)
+	assertConsumedLegacyKeys(t, rel.(*MergeJoinRel).Keys())
+
+	mj := rel.ToProto().GetMergeJoin()
+	assert.Len(t, mj.GetKeys(), 2)
+	assert.Len(t, mj.GetLeftKeys(), 2)
+	assert.Len(t, mj.GetRightKeys(), 2)
 }
 
 // When both the deprecated fields and the new keys are present, keys wins.
@@ -326,68 +343,6 @@ func TestJoinKeysFromProtoErrors(t *testing.T) {
 		t.Run("merge/"+tc.name, func(t *testing.T) {
 			_, err := RelFromProto(tc.fields.mergeProto(left, right), reg)
 			require.Error(t, err)
-		})
-	}
-}
-
-// A merge join whose right input fails to decode surfaces an error.
-func TestMergeJoinBadRightInput(t *testing.T) {
-	left, _ := joinInputs()
-	rel := &proto.Rel{RelType: &proto.Rel_MergeJoin{MergeJoin: &proto.MergeJoinRel{
-		Common: &proto.RelCommon{},
-		Type:   proto.MergeJoinRel_JOIN_TYPE_INNER,
-		Left:   left.ToProto(),
-		Right:  &proto.Rel{}, // nil RelType -> RelFromProto errors
-	}}}
-
-	_, err := RelFromProto(rel, joinTestRegistry())
-	require.ErrorContains(t, err, "right input to MergeJoinRel")
-}
-
-// Exercises the join accessors and the ComparisonJoinKey getters, and covers
-// the post-join-filter branch of ToProto via a round trip.
-func TestJoinAccessorsAndPostJoinFilter(t *testing.T) {
-	left, right := joinInputs()
-	reg := joinTestRegistry()
-	keys := eqKeys(t, left, right)
-	postFilter := expr.NewPrimitiveLiteral(true, false)
-
-	k := keys[0]
-	assert.Equal(t, keyRef(t, left, 0), k.Left())
-	assert.Equal(t, keyRef(t, right, 2), k.Right())
-	assert.Equal(t, SimpleComparison{Type: SimpleComparisonTypeEq}, k.Comparison())
-
-	// With no post-join filter set, the accessor returns the default filter.
-	noFilter := &HashJoinRel{left: left, right: right, joinType: HashMergeInner, keys: keys}
-	assert.Equal(t, defFilter, noFilter.PostJoinFilter())
-
-	for _, tc := range []struct {
-		name string
-		rel  Rel
-	}{
-		{"hash", &HashJoinRel{left: left, right: right, joinType: HashMergeInner, keys: keys, postJoinFilter: postFilter}},
-		{"merge", &MergeJoinRel{left: left, right: right, joinType: HashMergeInner, keys: keys, postJoinFilter: postFilter}},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			switch r := tc.rel.(type) {
-			case *HashJoinRel:
-				assert.Equal(t, left, r.Left())
-				assert.Equal(t, right, r.Right())
-				assert.Equal(t, HashMergeInner, r.Type())
-				assert.Equal(t, postFilter, r.PostJoinFilter())
-			case *MergeJoinRel:
-				assert.Equal(t, left, r.Left())
-				assert.Equal(t, right, r.Right())
-				assert.Equal(t, HashMergeInner, r.Type())
-				assert.Equal(t, postFilter, r.PostJoinFilter())
-			}
-
-			out := tc.rel.ToProto()
-			roundTripped, err := RelFromProto(out, reg)
-			require.NoError(t, err)
-			if diff := cmp.Diff(out, roundTripped.ToProto(), protocmp.Transform()); diff != "" {
-				t.Errorf("join with post-join filter did not round trip, diff:\n%v", diff)
-			}
 		})
 	}
 }

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -797,38 +797,18 @@ func RelFromProto(rel *proto.Rel, reg expr.ExtensionRegistry) (Rel, error) {
 			return nil, fmt.Errorf("error getting right input to HashJoin: %w", err)
 		}
 
-		if len(rel.HashJoin.LeftKeys) != len(rel.HashJoin.RightKeys) {
-			return nil, fmt.Errorf("%w: mismatched number of keys for hash join. Left: %d, Right: %d",
-				substraitgo.ErrInvalidRel, len(rel.HashJoin.LeftKeys), len(rel.HashJoin.RightKeys))
-		}
-
 		leftBase, rightBase := left.RecordType(), right.RecordType()
 
-		leftKeys := make([]*expr.FieldReference, len(rel.HashJoin.LeftKeys))
-		for i, k := range rel.HashJoin.LeftKeys {
-			leftKeys[i], err = expr.FieldReferenceFromProto(k, &leftBase, reg)
-			if err != nil {
-				return nil, fmt.Errorf("error getting left key %d for HashJoinRel: %w", i, err)
-			}
-		}
-
-		rightKeys := make([]*expr.FieldReference, len(rel.HashJoin.RightKeys))
-		for i, k := range rel.HashJoin.RightKeys {
-			rightKeys[i], err = expr.FieldReferenceFromProto(k, &rightBase, reg)
-			if err != nil {
-				return nil, fmt.Errorf("error getting right key %d for HashJoinRel: %w", i, err)
-			}
-		}
-
-		if len(leftKeys) != len(rightKeys) {
-			return nil, fmt.Errorf("%w: must have same number of keys in left and right keys for hash join", substraitgo.ErrInvalidRel)
+		keys, err := comparisonJoinKeysFromProto(
+			rel.HashJoin.Keys, rel.HashJoin.LeftKeys, rel.HashJoin.RightKeys, &leftBase, &rightBase, reg)
+		if err != nil {
+			return nil, fmt.Errorf("error getting keys for HashJoinRel: %w", err)
 		}
 
 		out := &HashJoinRel{
 			left:         left,
 			right:        right,
-			leftKeys:     leftKeys,
-			rightKeys:    rightKeys,
+			keys:         keys,
 			joinType:     HashMergeJoinType(rel.HashJoin.Type),
 			advExtension: rel.HashJoin.AdvancedExtension,
 		}
@@ -851,41 +831,21 @@ func RelFromProto(rel *proto.Rel, reg expr.ExtensionRegistry) (Rel, error) {
 
 		right, err := RelFromProto(rel.MergeJoin.Right, reg)
 		if err != nil {
-			return nil, fmt.Errorf("error getting right input to HashJoin: %w", err)
-		}
-
-		if len(rel.MergeJoin.LeftKeys) != len(rel.MergeJoin.RightKeys) {
-			return nil, fmt.Errorf("%w: mismatched number of keys for merge join. Left: %d, Right: %d",
-				substraitgo.ErrInvalidRel, len(rel.MergeJoin.LeftKeys), len(rel.MergeJoin.RightKeys))
+			return nil, fmt.Errorf("error getting right input to MergeJoinRel: %w", err)
 		}
 
 		leftBase, rightBase := left.RecordType(), right.RecordType()
 
-		leftKeys := make([]*expr.FieldReference, len(rel.MergeJoin.LeftKeys))
-		for i, k := range rel.MergeJoin.LeftKeys {
-			leftKeys[i], err = expr.FieldReferenceFromProto(k, &leftBase, reg)
-			if err != nil {
-				return nil, fmt.Errorf("error getting left key %d for MergeJoin: %w", i, err)
-			}
+		keys, err := comparisonJoinKeysFromProto(
+			rel.MergeJoin.Keys, rel.MergeJoin.LeftKeys, rel.MergeJoin.RightKeys, &leftBase, &rightBase, reg)
+		if err != nil {
+			return nil, fmt.Errorf("error getting keys for MergeJoinRel: %w", err)
 		}
 
-		rightKeys := make([]*expr.FieldReference, len(rel.MergeJoin.RightKeys))
-		for i, k := range rel.MergeJoin.RightKeys {
-			rightKeys[i], err = expr.FieldReferenceFromProto(k, &rightBase, reg)
-			if err != nil {
-				return nil, fmt.Errorf("error getting right key %d for MergeJoin: %w", i, err)
-			}
-		}
-
-		if len(leftKeys) != len(rightKeys) {
-			return nil, fmt.Errorf("%w: must have same number of keys in left and right keys for merge join", substraitgo.ErrInvalidRel)
-		}
-
-		out := &HashJoinRel{
+		out := &MergeJoinRel{
 			left:         left,
 			right:        right,
-			leftKeys:     leftKeys,
-			rightKeys:    rightKeys,
+			keys:         keys,
 			joinType:     HashMergeJoinType(rel.MergeJoin.Type),
 			advExtension: rel.MergeJoin.AdvancedExtension,
 		}

--- a/plan/relations.go
+++ b/plan/relations.go
@@ -1903,6 +1903,28 @@ func comparisonJoinKeysToProto(keys []*ComparisonJoinKey) []*proto.ComparisonJoi
 	return out
 }
 
+// legacyJoinKeysToProto returns the deprecated left_keys/right_keys
+// representation of the given join keys, but only when every key is a plain
+// SIMPLE_COMPARISON_TYPE_EQ comparison. Those are the only joins the deprecated
+// fields can express; IS_NOT_DISTINCT_FROM, MIGHT_EQUAL and custom comparisons
+// have no legacy encoding and an old consumer would silently treat them as
+// equality, so for those we emit nothing and rely on the modern keys field.
+func legacyJoinKeysToProto(keys []*ComparisonJoinKey) (leftKeys, rightKeys []*proto.Expression_FieldReference) {
+	for _, k := range keys {
+		simple, ok := k.comparison.(SimpleComparison)
+		if !ok || simple.Type != SimpleComparisonTypeEq {
+			return nil, nil
+		}
+	}
+	leftKeys = make([]*proto.Expression_FieldReference, len(keys))
+	rightKeys = make([]*proto.Expression_FieldReference, len(keys))
+	for i, k := range keys {
+		leftKeys[i] = k.left.ToProtoFieldRef()
+		rightKeys[i] = k.right.ToProtoFieldRef()
+	}
+	return leftKeys, rightKeys
+}
+
 // leftJoinKeys returns the left-hand field references of the given join keys.
 func leftJoinKeys(keys []*ComparisonJoinKey) []*expr.FieldReference {
 	out := make([]*expr.FieldReference, len(keys))
@@ -2032,12 +2054,15 @@ func (hr *HashJoinRel) SetAdvancedExtension(advExtension *extensions.AdvancedExt
 }
 
 func (hr *HashJoinRel) ToProto() *proto.Rel {
+	leftKeys, rightKeys := legacyJoinKeysToProto(hr.keys)
 	ret := &proto.Rel_HashJoin{
 		HashJoin: &proto.HashJoinRel{
 			Common:            hr.toProto(),
 			Left:              hr.left.ToProto(),
 			Right:             hr.right.ToProto(),
 			Keys:              comparisonJoinKeysToProto(hr.keys),
+			LeftKeys:          leftKeys,
+			RightKeys:         rightKeys,
 			Type:              proto.HashJoinRel_JoinType(hr.joinType),
 			AdvancedExtension: hr.advExtension,
 		},
@@ -2144,12 +2169,15 @@ func (mr *MergeJoinRel) SetAdvancedExtension(advExtension *extensions.AdvancedEx
 }
 
 func (mr *MergeJoinRel) ToProto() *proto.Rel {
+	leftKeys, rightKeys := legacyJoinKeysToProto(mr.keys)
 	ret := &proto.Rel_MergeJoin{
 		MergeJoin: &proto.MergeJoinRel{
 			Common:            mr.toProto(),
 			Left:              mr.left.ToProto(),
 			Right:             mr.right.ToProto(),
 			Keys:              comparisonJoinKeysToProto(mr.keys),
+			LeftKeys:          leftKeys,
+			RightKeys:         rightKeys,
 			Type:              proto.MergeJoinRel_JoinType(mr.joinType),
 			AdvancedExtension: mr.advExtension,
 		},

--- a/plan/relations.go
+++ b/plan/relations.go
@@ -1820,17 +1820,178 @@ const (
 	HashMergeRightAnti
 )
 
+// SimpleComparisonType describes one of the predefined comparison behaviors
+// used by a ComparisonJoinKey.
+type SimpleComparisonType = proto.ComparisonJoinKey_SimpleComparisonType
+
+const (
+	SimpleComparisonTypeUnspecified       = proto.ComparisonJoinKey_SIMPLE_COMPARISON_TYPE_UNSPECIFIED
+	SimpleComparisonTypeEq                = proto.ComparisonJoinKey_SIMPLE_COMPARISON_TYPE_EQ
+	SimpleComparisonTypeIsNotDistinctFrom = proto.ComparisonJoinKey_SIMPLE_COMPARISON_TYPE_IS_NOT_DISTINCT_FROM
+	SimpleComparisonTypeMightEqual        = proto.ComparisonJoinKey_SIMPLE_COMPARISON_TYPE_MIGHT_EQUAL
+)
+
+// JoinKeyComparison describes how the two sides of a ComparisonJoinKey are
+// compared. It is either a SimpleComparison or a CustomComparison. The
+// unexported toProto method seals it to this package.
+type JoinKeyComparison interface {
+	toProto() *proto.ComparisonJoinKey_ComparisonType
+}
+
+// SimpleComparison uses one of the predefined SimpleComparisonType behaviors.
+type SimpleComparison struct {
+	Type SimpleComparisonType
+}
+
+func (c SimpleComparison) toProto() *proto.ComparisonJoinKey_ComparisonType {
+	return &proto.ComparisonJoinKey_ComparisonType{
+		InnerType: &proto.ComparisonJoinKey_ComparisonType_Simple{Simple: c.Type},
+	}
+}
+
+// CustomComparison references a binary function with a boolean return type
+// describing a custom comparison behavior.
+type CustomComparison struct {
+	FunctionReference uint32
+}
+
+func (c CustomComparison) toProto() *proto.ComparisonJoinKey_ComparisonType {
+	return &proto.ComparisonJoinKey_ComparisonType{
+		InnerType: &proto.ComparisonJoinKey_ComparisonType_CustomFunctionReference{
+			CustomFunctionReference: c.FunctionReference,
+		},
+	}
+}
+
+// ComparisonJoinKey is a single key comparison used by HashJoinRel and
+// MergeJoinRel, pairing a left and right field reference with the comparison
+// describing how the two are matched.
+type ComparisonJoinKey struct {
+	left, right *expr.FieldReference
+	comparison  JoinKeyComparison
+}
+
+// NewComparisonJoinKey creates a join key with an explicit comparison.
+func NewComparisonJoinKey(left, right *expr.FieldReference, comparison JoinKeyComparison) *ComparisonJoinKey {
+	return &ComparisonJoinKey{left: left, right: right, comparison: comparison}
+}
+
+// NewEqualityJoinKey creates a join key using the common
+// SimpleComparisonTypeEq comparison.
+func NewEqualityJoinKey(left, right *expr.FieldReference) *ComparisonJoinKey {
+	return NewComparisonJoinKey(left, right, SimpleComparison{Type: SimpleComparisonTypeEq})
+}
+
+func (k *ComparisonJoinKey) Left() *expr.FieldReference    { return k.left }
+func (k *ComparisonJoinKey) Right() *expr.FieldReference   { return k.right }
+func (k *ComparisonJoinKey) Comparison() JoinKeyComparison { return k.comparison }
+
+func (k *ComparisonJoinKey) ToProto() *proto.ComparisonJoinKey {
+	return &proto.ComparisonJoinKey{
+		Left:       k.left.ToProtoFieldRef(),
+		Right:      k.right.ToProtoFieldRef(),
+		Comparison: k.comparison.toProto(),
+	}
+}
+
+// comparisonJoinKeysToProto converts a list of join keys to their proto form.
+func comparisonJoinKeysToProto(keys []*ComparisonJoinKey) []*proto.ComparisonJoinKey {
+	out := make([]*proto.ComparisonJoinKey, len(keys))
+	for i, k := range keys {
+		out[i] = k.ToProto()
+	}
+	return out
+}
+
+// leftJoinKeys returns the left-hand field references of the given join keys.
+func leftJoinKeys(keys []*ComparisonJoinKey) []*expr.FieldReference {
+	out := make([]*expr.FieldReference, len(keys))
+	for i, k := range keys {
+		out[i] = k.left
+	}
+	return out
+}
+
+// rightJoinKeys returns the right-hand field references of the given join keys.
+func rightJoinKeys(keys []*ComparisonJoinKey) []*expr.FieldReference {
+	out := make([]*expr.FieldReference, len(keys))
+	for i, k := range keys {
+		out[i] = k.right
+	}
+	return out
+}
+
+// joinKeyComparisonFromProto converts a proto comparison into its model form.
+func joinKeyComparisonFromProto(c *proto.ComparisonJoinKey_ComparisonType) (JoinKeyComparison, error) {
+	switch it := c.GetInnerType().(type) {
+	case *proto.ComparisonJoinKey_ComparisonType_Simple:
+		return SimpleComparison{Type: it.Simple}, nil
+	case *proto.ComparisonJoinKey_ComparisonType_CustomFunctionReference:
+		return CustomComparison{FunctionReference: it.CustomFunctionReference}, nil
+	default:
+		return nil, fmt.Errorf("%w: unsupported join key comparison type %T", substraitgo.ErrInvalidRel, it)
+	}
+}
+
+// comparisonJoinKeysFromProto builds the join keys for a hash/merge join,
+// preferring the keys field. The deprecated leftKeys/rightKeys are only used
+// when keys is empty, in which case they are paired with an EQ comparison.
+func comparisonJoinKeysFromProto(
+	keys []*proto.ComparisonJoinKey,
+	leftKeys, rightKeys []*proto.Expression_FieldReference,
+	leftBase, rightBase *types.RecordType,
+	reg expr.ExtensionRegistry,
+) ([]*ComparisonJoinKey, error) {
+	if len(keys) > 0 {
+		out := make([]*ComparisonJoinKey, len(keys))
+		for i, k := range keys {
+			left, err := expr.FieldReferenceFromProto(k.GetLeft(), leftBase, reg)
+			if err != nil {
+				return nil, fmt.Errorf("error getting left key %d for join: %w", i, err)
+			}
+			right, err := expr.FieldReferenceFromProto(k.GetRight(), rightBase, reg)
+			if err != nil {
+				return nil, fmt.Errorf("error getting right key %d for join: %w", i, err)
+			}
+			comparison, err := joinKeyComparisonFromProto(k.GetComparison())
+			if err != nil {
+				return nil, err
+			}
+			out[i] = NewComparisonJoinKey(left, right, comparison)
+		}
+		return out, nil
+	}
+
+	if len(leftKeys) != len(rightKeys) {
+		return nil, fmt.Errorf("%w: mismatched number of keys for join. Left: %d, Right: %d",
+			substraitgo.ErrInvalidRel, len(leftKeys), len(rightKeys))
+	}
+	out := make([]*ComparisonJoinKey, len(leftKeys))
+	for i := range leftKeys {
+		left, err := expr.FieldReferenceFromProto(leftKeys[i], leftBase, reg)
+		if err != nil {
+			return nil, fmt.Errorf("error getting left key %d for join: %w", i, err)
+		}
+		right, err := expr.FieldReferenceFromProto(rightKeys[i], rightBase, reg)
+		if err != nil {
+			return nil, fmt.Errorf("error getting right key %d for join: %w", i, err)
+		}
+		out[i] = NewEqualityJoinKey(left, right)
+	}
+	return out, nil
+}
+
 // HashJoinRel represents a relational operator to build a hash table out
 // of the right input based on a set of join keys. It will then probe
 // the hash table for incoming inputs, finding matches.
 type HashJoinRel struct {
 	RelCommon
 
-	left, right         Rel
-	leftKeys, rightKeys []*expr.FieldReference
-	postJoinFilter      expr.Expression
-	joinType            HashMergeJoinType
-	advExtension        *extensions.AdvancedExtension
+	left, right    Rel
+	keys           []*ComparisonJoinKey
+	postJoinFilter expr.Expression
+	joinType       HashMergeJoinType
+	advExtension   *extensions.AdvancedExtension
 }
 
 func (hr *HashJoinRel) directOutputSchema() types.RecordType {
@@ -1841,10 +2002,19 @@ func (hr *HashJoinRel) RecordType() types.RecordType {
 	return hr.remap(hr.directOutputSchema())
 }
 
-func (hr *HashJoinRel) Left() Rel                         { return hr.left }
-func (hr *HashJoinRel) Right() Rel                        { return hr.right }
-func (hr *HashJoinRel) LeftKeys() []*expr.FieldReference  { return hr.leftKeys }
-func (hr *HashJoinRel) RightKeys() []*expr.FieldReference { return hr.rightKeys }
+func (hr *HashJoinRel) Left() Rel                  { return hr.left }
+func (hr *HashJoinRel) Right() Rel                 { return hr.right }
+func (hr *HashJoinRel) Keys() []*ComparisonJoinKey { return hr.keys }
+
+// LeftKeys returns the left-hand sides of the join keys.
+//
+// Deprecated: use Keys instead.
+func (hr *HashJoinRel) LeftKeys() []*expr.FieldReference { return leftJoinKeys(hr.keys) }
+
+// RightKeys returns the right-hand sides of the join keys.
+//
+// Deprecated: use Keys instead.
+func (hr *HashJoinRel) RightKeys() []*expr.FieldReference { return rightJoinKeys(hr.keys) }
 func (hr *HashJoinRel) PostJoinFilter() expr.Expression {
 	if hr.postJoinFilter == nil {
 		return defFilter
@@ -1862,22 +2032,12 @@ func (hr *HashJoinRel) SetAdvancedExtension(advExtension *extensions.AdvancedExt
 }
 
 func (hr *HashJoinRel) ToProto() *proto.Rel {
-	keysLeft := make([]*proto.Expression_FieldReference, len(hr.leftKeys))
-	for i, k := range hr.leftKeys {
-		keysLeft[i] = k.ToProtoFieldRef()
-	}
-	keysRight := make([]*proto.Expression_FieldReference, len(hr.rightKeys))
-	for i, k := range hr.rightKeys {
-		keysRight[i] = k.ToProtoFieldRef()
-	}
-
 	ret := &proto.Rel_HashJoin{
 		HashJoin: &proto.HashJoinRel{
 			Common:            hr.toProto(),
 			Left:              hr.left.ToProto(),
 			Right:             hr.right.ToProto(),
-			LeftKeys:          keysLeft,
-			RightKeys:         keysRight,
+			Keys:              comparisonJoinKeysToProto(hr.keys),
 			Type:              proto.HashJoinRel_JoinType(hr.joinType),
 			AdvancedExtension: hr.advExtension,
 		},
@@ -1939,11 +2099,11 @@ func (hr *HashJoinRel) Remap(mapping ...int32) (Rel, error) {
 type MergeJoinRel struct {
 	RelCommon
 
-	left, right         Rel
-	leftKeys, rightKeys []*expr.FieldReference
-	postJoinFilter      expr.Expression
-	joinType            HashMergeJoinType
-	advExtension        *extensions.AdvancedExtension
+	left, right    Rel
+	keys           []*ComparisonJoinKey
+	postJoinFilter expr.Expression
+	joinType       HashMergeJoinType
+	advExtension   *extensions.AdvancedExtension
 }
 
 func (mr *MergeJoinRel) directOutputSchema() types.RecordType {
@@ -1954,10 +2114,19 @@ func (mr *MergeJoinRel) RecordType() types.RecordType {
 	return mr.remap(mr.directOutputSchema())
 }
 
-func (mr *MergeJoinRel) Left() Rel                         { return mr.left }
-func (mr *MergeJoinRel) Right() Rel                        { return mr.right }
-func (mr *MergeJoinRel) LeftKeys() []*expr.FieldReference  { return mr.leftKeys }
-func (mr *MergeJoinRel) RightKeys() []*expr.FieldReference { return mr.rightKeys }
+func (mr *MergeJoinRel) Left() Rel                  { return mr.left }
+func (mr *MergeJoinRel) Right() Rel                 { return mr.right }
+func (mr *MergeJoinRel) Keys() []*ComparisonJoinKey { return mr.keys }
+
+// LeftKeys returns the left-hand sides of the join keys.
+//
+// Deprecated: use Keys instead.
+func (mr *MergeJoinRel) LeftKeys() []*expr.FieldReference { return leftJoinKeys(mr.keys) }
+
+// RightKeys returns the right-hand sides of the join keys.
+//
+// Deprecated: use Keys instead.
+func (mr *MergeJoinRel) RightKeys() []*expr.FieldReference { return rightJoinKeys(mr.keys) }
 func (mr *MergeJoinRel) PostJoinFilter() expr.Expression {
 	if mr.postJoinFilter == nil {
 		return defFilter
@@ -1975,22 +2144,12 @@ func (mr *MergeJoinRel) SetAdvancedExtension(advExtension *extensions.AdvancedEx
 }
 
 func (mr *MergeJoinRel) ToProto() *proto.Rel {
-	keysLeft := make([]*proto.Expression_FieldReference, len(mr.leftKeys))
-	for i, k := range mr.leftKeys {
-		keysLeft[i] = k.ToProtoFieldRef()
-	}
-	keysRight := make([]*proto.Expression_FieldReference, len(mr.rightKeys))
-	for i, k := range mr.rightKeys {
-		keysRight[i] = k.ToProtoFieldRef()
-	}
-
 	ret := &proto.Rel_MergeJoin{
 		MergeJoin: &proto.MergeJoinRel{
 			Common:            mr.toProto(),
 			Left:              mr.left.ToProto(),
 			Right:             mr.right.ToProto(),
-			LeftKeys:          keysLeft,
-			RightKeys:         keysRight,
+			Keys:              comparisonJoinKeysToProto(mr.keys),
 			Type:              proto.MergeJoinRel_JoinType(mr.joinType),
 			AdvancedExtension: mr.advExtension,
 		},

--- a/plan/relations.go
+++ b/plan/relations.go
@@ -1903,17 +1903,26 @@ func comparisonJoinKeysToProto(keys []*ComparisonJoinKey) []*proto.ComparisonJoi
 	return out
 }
 
-// legacyJoinKeysToProto returns the deprecated left_keys/right_keys
-// representation of the given join keys, but only when every key is a plain
-// SIMPLE_COMPARISON_TYPE_EQ comparison. Those are the only joins the deprecated
-// fields can express; IS_NOT_DISTINCT_FROM, MIGHT_EQUAL and custom comparisons
-// have no legacy encoding and an old consumer would silently treat them as
-// equality, so for those we emit nothing and rely on the modern keys field.
-func legacyJoinKeysToProto(keys []*ComparisonJoinKey) (leftKeys, rightKeys []*proto.Expression_FieldReference) {
+// tryEqualityJoinKeysToLegacyProto returns the deprecated left_keys/right_keys
+// representation of the given join keys with ok=true, but only when every key
+// is a plain SIMPLE_COMPARISON_TYPE_EQ comparison. Those are the only joins the
+// deprecated fields can express; IS_NOT_DISTINCT_FROM, MIGHT_EQUAL and custom
+// comparisons have no legacy encoding and an old consumer would silently treat
+// them as equality, so for those it returns ok=false and the caller should emit
+// only the modern keys field.
+func tryEqualityJoinKeysToLegacyProto(keys []*ComparisonJoinKey) (leftKeys, rightKeys []*proto.Expression_FieldReference, ok bool) {
 	for _, k := range keys {
-		simple, ok := k.comparison.(SimpleComparison)
-		if !ok || simple.Type != SimpleComparisonTypeEq {
-			return nil, nil
+		switch simple := k.comparison.(type) {
+		case SimpleComparison:
+			if simple.Type != SimpleComparisonTypeEq {
+				return nil, nil, false
+			}
+		case *SimpleComparison:
+			if simple == nil || simple.Type != SimpleComparisonTypeEq {
+				return nil, nil, false
+			}
+		default:
+			return nil, nil, false
 		}
 	}
 	leftKeys = make([]*proto.Expression_FieldReference, len(keys))
@@ -1922,7 +1931,7 @@ func legacyJoinKeysToProto(keys []*ComparisonJoinKey) (leftKeys, rightKeys []*pr
 		leftKeys[i] = k.left.ToProtoFieldRef()
 		rightKeys[i] = k.right.ToProtoFieldRef()
 	}
-	return leftKeys, rightKeys
+	return leftKeys, rightKeys, true
 }
 
 // leftJoinKeys returns the left-hand field references of the given join keys.
@@ -1961,17 +1970,17 @@ func joinKeyComparisonFromProto(c *proto.ComparisonJoinKey_ComparisonType) (Join
 func comparisonJoinKeysFromProto(
 	keys []*proto.ComparisonJoinKey,
 	leftKeys, rightKeys []*proto.Expression_FieldReference,
-	leftBase, rightBase *types.RecordType,
+	leftSchema, rightSchema *types.RecordType,
 	reg expr.ExtensionRegistry,
 ) ([]*ComparisonJoinKey, error) {
 	if len(keys) > 0 {
 		out := make([]*ComparisonJoinKey, len(keys))
 		for i, k := range keys {
-			left, err := expr.FieldReferenceFromProto(k.GetLeft(), leftBase, reg)
+			left, err := expr.FieldReferenceFromProto(k.GetLeft(), leftSchema, reg)
 			if err != nil {
 				return nil, fmt.Errorf("error getting left key %d for join: %w", i, err)
 			}
-			right, err := expr.FieldReferenceFromProto(k.GetRight(), rightBase, reg)
+			right, err := expr.FieldReferenceFromProto(k.GetRight(), rightSchema, reg)
 			if err != nil {
 				return nil, fmt.Errorf("error getting right key %d for join: %w", i, err)
 			}
@@ -1990,11 +1999,11 @@ func comparisonJoinKeysFromProto(
 	}
 	out := make([]*ComparisonJoinKey, len(leftKeys))
 	for i := range leftKeys {
-		left, err := expr.FieldReferenceFromProto(leftKeys[i], leftBase, reg)
+		left, err := expr.FieldReferenceFromProto(leftKeys[i], leftSchema, reg)
 		if err != nil {
 			return nil, fmt.Errorf("error getting left key %d for join: %w", i, err)
 		}
-		right, err := expr.FieldReferenceFromProto(rightKeys[i], rightBase, reg)
+		right, err := expr.FieldReferenceFromProto(rightKeys[i], rightSchema, reg)
 		if err != nil {
 			return nil, fmt.Errorf("error getting right key %d for join: %w", i, err)
 		}
@@ -2054,18 +2063,20 @@ func (hr *HashJoinRel) SetAdvancedExtension(advExtension *extensions.AdvancedExt
 }
 
 func (hr *HashJoinRel) ToProto() *proto.Rel {
-	leftKeys, rightKeys := legacyJoinKeysToProto(hr.keys)
 	ret := &proto.Rel_HashJoin{
 		HashJoin: &proto.HashJoinRel{
 			Common:            hr.toProto(),
 			Left:              hr.left.ToProto(),
 			Right:             hr.right.ToProto(),
 			Keys:              comparisonJoinKeysToProto(hr.keys),
-			LeftKeys:          leftKeys,
-			RightKeys:         rightKeys,
 			Type:              proto.HashJoinRel_JoinType(hr.joinType),
 			AdvancedExtension: hr.advExtension,
 		},
+	}
+
+	if leftKeys, rightKeys, ok := tryEqualityJoinKeysToLegacyProto(hr.keys); ok {
+		ret.HashJoin.LeftKeys = leftKeys
+		ret.HashJoin.RightKeys = rightKeys
 	}
 
 	if hr.postJoinFilter != nil {
@@ -2169,18 +2180,20 @@ func (mr *MergeJoinRel) SetAdvancedExtension(advExtension *extensions.AdvancedEx
 }
 
 func (mr *MergeJoinRel) ToProto() *proto.Rel {
-	leftKeys, rightKeys := legacyJoinKeysToProto(mr.keys)
 	ret := &proto.Rel_MergeJoin{
 		MergeJoin: &proto.MergeJoinRel{
 			Common:            mr.toProto(),
 			Left:              mr.left.ToProto(),
 			Right:             mr.right.ToProto(),
 			Keys:              comparisonJoinKeysToProto(mr.keys),
-			LeftKeys:          leftKeys,
-			RightKeys:         rightKeys,
 			Type:              proto.MergeJoinRel_JoinType(mr.joinType),
 			AdvancedExtension: mr.advExtension,
 		},
+	}
+
+	if leftKeys, rightKeys, ok := tryEqualityJoinKeysToLegacyProto(mr.keys); ok {
+		ret.MergeJoin.LeftKeys = leftKeys
+		ret.MergeJoin.RightKeys = rightKeys
 	}
 
 	if mr.postJoinFilter != nil {

--- a/plan/relations_test.go
+++ b/plan/relations_test.go
@@ -77,10 +77,10 @@ func TestRelations_Copy(t *testing.T) {
 	extensionMultiRel := &ExtensionMultiRel{inputs: []Rel{createVirtualTableReadRel(1), createVirtualTableReadRel(2)}}
 	fetchRel := &FetchRel{input: createVirtualTableReadRel(1), offset: 1, count: 2}
 	filterRel := &FilterRel{input: createVirtualTableReadRel(1), cond: expr.NewPrimitiveLiteral(true, false)}
-	hashJoinRel := &HashJoinRel{left: createVirtualTableReadRel(1), right: createVirtualTableReadRel(2), joinType: HashMergeInner, leftKeys: []*expr.FieldReference{}, rightKeys: []*expr.FieldReference{}, postJoinFilter: expr.NewPrimitiveLiteral(true, false)}
+	hashJoinRel := &HashJoinRel{left: createVirtualTableReadRel(1), right: createVirtualTableReadRel(2), joinType: HashMergeInner, keys: []*ComparisonJoinKey{}, postJoinFilter: expr.NewPrimitiveLiteral(true, false)}
 	joinRel := &JoinRel{left: createVirtualTableReadRel(1), right: createVirtualTableReadRel(2), joinType: JoinTypeInner, expr: expr.NewPrimitiveLiteral(true, false), postJoinFilter: expr.NewPrimitiveLiteral(true, false)}
 	localFileReadRel := &LocalFileReadRel{items: []FileOrFiles{{Path: "path"}}, baseReadRel: baseReadRel{filter: expr.NewPrimitiveLiteral(true, false), bestEffortFilter: expr.NewPrimitiveLiteral(true, false)}}
-	mergeJoinRel := &MergeJoinRel{left: createVirtualTableReadRel(1), right: createVirtualTableReadRel(2), joinType: HashMergeInner, leftKeys: []*expr.FieldReference{}, rightKeys: []*expr.FieldReference{}, postJoinFilter: expr.NewPrimitiveLiteral(true, false)}
+	mergeJoinRel := &MergeJoinRel{left: createVirtualTableReadRel(1), right: createVirtualTableReadRel(2), joinType: HashMergeInner, keys: []*ComparisonJoinKey{}, postJoinFilter: expr.NewPrimitiveLiteral(true, false)}
 	namedTableReadRel := &NamedTableReadRel{names: []string{"mytest"}, baseReadRel: baseReadRel{filter: expr.NewPrimitiveLiteral(true, false), bestEffortFilter: expr.NewPrimitiveLiteral(true, false)}}
 	projectRel := &ProjectRel{input: createVirtualTableReadRel(1), exprs: []expr.Expression{createPrimitiveFloat(1.0), createPrimitiveFloat(2.0)}}
 	setRel := &SetRel{inputs: []Rel{createVirtualTableReadRel(1), createVirtualTableReadRel(2), createVirtualTableReadRel(3)}, op: SetOpUnionAll}
@@ -208,7 +208,7 @@ func TestRelations_Copy(t *testing.T) {
 			name:        "HashJoinRel Copy with new inputs",
 			relation:    hashJoinRel,
 			newInputs:   []Rel{createVirtualTableReadRel(6), createVirtualTableReadRel(7)},
-			expectedRel: &HashJoinRel{left: createVirtualTableReadRel(6), right: createVirtualTableReadRel(7), joinType: HashMergeInner, leftKeys: []*expr.FieldReference{}, rightKeys: []*expr.FieldReference{}, postJoinFilter: expr.NewPrimitiveLiteral(true, false)},
+			expectedRel: &HashJoinRel{left: createVirtualTableReadRel(6), right: createVirtualTableReadRel(7), joinType: HashMergeInner, keys: []*ComparisonJoinKey{}, postJoinFilter: expr.NewPrimitiveLiteral(true, false)},
 		},
 		{
 			name:        "JoinRel Copy with new inputs",
@@ -247,7 +247,7 @@ func TestRelations_Copy(t *testing.T) {
 			name:        "MergeJoinRel Copy with new inputs",
 			relation:    mergeJoinRel,
 			newInputs:   []Rel{createVirtualTableReadRel(6), createVirtualTableReadRel(7)},
-			expectedRel: &MergeJoinRel{left: createVirtualTableReadRel(6), right: createVirtualTableReadRel(7), joinType: HashMergeInner, leftKeys: []*expr.FieldReference{}, rightKeys: []*expr.FieldReference{}, postJoinFilter: expr.NewPrimitiveLiteral(true, false)},
+			expectedRel: &MergeJoinRel{left: createVirtualTableReadRel(6), right: createVirtualTableReadRel(7), joinType: HashMergeInner, keys: []*ComparisonJoinKey{}, postJoinFilter: expr.NewPrimitiveLiteral(true, false)},
 		},
 		{
 			name:            "NamedTableReadRel Copy with new inputs",
@@ -459,10 +459,10 @@ func TestRelations_AdvancedExtensions(t *testing.T) {
 	extensionMultiRel := &ExtensionMultiRel{inputs: []Rel{createVirtualTableReadRel(1), createVirtualTableReadRel(2)}}
 	fetchRel := &FetchRel{input: createVirtualTableReadRel(1), offset: 1, count: 2}
 	filterRel := &FilterRel{input: createVirtualTableReadRel(1), cond: expr.NewPrimitiveLiteral(true, false)}
-	hashJoinRel := &HashJoinRel{left: createVirtualTableReadRel(1), right: createVirtualTableReadRel(2), joinType: HashMergeInner, leftKeys: []*expr.FieldReference{}, rightKeys: []*expr.FieldReference{}, postJoinFilter: expr.NewPrimitiveLiteral(true, false)}
+	hashJoinRel := &HashJoinRel{left: createVirtualTableReadRel(1), right: createVirtualTableReadRel(2), joinType: HashMergeInner, keys: []*ComparisonJoinKey{}, postJoinFilter: expr.NewPrimitiveLiteral(true, false)}
 	joinRel := &JoinRel{left: createVirtualTableReadRel(1), right: createVirtualTableReadRel(2), joinType: JoinTypeInner, expr: expr.NewPrimitiveLiteral(true, false), postJoinFilter: expr.NewPrimitiveLiteral(true, false)}
 	localFileReadRel := &LocalFileReadRel{items: []FileOrFiles{{Path: "path"}}, baseReadRel: baseReadRel{filter: expr.NewPrimitiveLiteral(true, false), bestEffortFilter: expr.NewPrimitiveLiteral(true, false)}}
-	mergeJoinRel := &MergeJoinRel{left: createVirtualTableReadRel(1), right: createVirtualTableReadRel(2), joinType: HashMergeInner, leftKeys: []*expr.FieldReference{}, rightKeys: []*expr.FieldReference{}, postJoinFilter: expr.NewPrimitiveLiteral(true, false)}
+	mergeJoinRel := &MergeJoinRel{left: createVirtualTableReadRel(1), right: createVirtualTableReadRel(2), joinType: HashMergeInner, keys: []*ComparisonJoinKey{}, postJoinFilter: expr.NewPrimitiveLiteral(true, false)}
 	namedTableReadRel := &NamedTableReadRel{names: []string{"mytest"}, baseReadRel: baseReadRel{filter: expr.NewPrimitiveLiteral(true, false), bestEffortFilter: expr.NewPrimitiveLiteral(true, false)}}
 	projectRel := &ProjectRel{input: createVirtualTableReadRel(1), exprs: []expr.Expression{createPrimitiveFloat(1.0), createPrimitiveFloat(2.0)}}
 	setRel := &SetRel{inputs: []Rel{createVirtualTableReadRel(1), createVirtualTableReadRel(2), createVirtualTableReadRel(3)}, op: SetOpUnionAll}


### PR DESCRIPTION
## Summary

The deprecated `left_keys`/`right_keys` fields of `HashJoinRel` and `MergeJoinRel` are being replaced upstream by `repeated ComparisonJoinKey keys = 8`. This PR migrates substrait-go to **consume both** the old and new proto fields and to **always produce** the new `keys` field, while **additionally mirroring** the deprecated fields when doing so is lossless (i.e. every key is a plain equality). This keeps it working against the current proto and ready once the deprecated fields are removed, without breaking consumers that haven't adopted `keys` yet — mirroring the approach used for the [URI → URN migration](https://substrait.io/spec/breaking_change_policy/#uri-to-urn-migration).

The fields were deprecated in Jan 2024 via https://github.com/substrait-io/substrait/pull/585 and thus deprecated in Substrait since v0.42.0.

## Changes

- Add a `ComparisonJoinKey` type modelling the proto message, including the `comparison` oneof (`SimpleComparison` / `CustomComparison`) and a `SimpleComparisonType` alias over the proto enum (consistent with how `WriteOp`/`OutputMode` are aliased).
- `HashJoinRel` / `MergeJoinRel` now store `keys []*ComparisonJoinKey` and expose `Keys()`. `LeftKeys()` / `RightKeys()` are kept as `// Deprecated:` derived accessors so existing consumers keep working.
- `RelFromProto` prefers `keys` and falls back to the deprecated fields (paired with a `SIMPLE_COMPARISON_TYPE_EQ` comparison) when `keys` is empty.
- `ToProto` always emits `keys`, and additionally emits the deprecated `left_keys`/`right_keys` when **every** key is a plain `SIMPLE_COMPARISON_TYPE_EQ`. `IS_NOT_DISTINCT_FROM`, `MIGHT_EQUAL`, and custom comparisons have no legacy encoding and an old consumer would silently read them as equality, so those joins emit only the modern `keys` field.
- Fix two pre-existing bugs in the `MergeJoin` read path: it constructed a `HashJoinRel` instead of a `MergeJoinRel`, and it reported `"error getting right input to HashJoin"` when its right input failed to decode.

## Tests

New `comparison_join_key_test.go` covering:
- lossless write policy: all-EQ joins mirror the deprecated fields, while non-EQ/custom joins emit only `keys`,
- deprecated accessor derivation from `keys` (both hash and merge),
- consume-legacy (old fields → EQ keys),
- precedence (`keys` wins when both old and new are set),
- full-fidelity round trip including a non-EQ simple comparison and a custom comparison function, with and without a post-join filter,
- error paths in `comparisonJoinKeysFromProto` / `joinKeyComparisonFromProto` (bad field refs, unset comparison, mismatched legacy lengths) exercised against both join types, plus a bad merge-join input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
