### PR TITLE
fix: return error when function outputType is nil in ExprFromProto

### DIFF
--- a/expr/expression.go
+++ b/expr/expression.go
@@ -64,6 +64,10 @@ func ExprFromProto(e *proto.Expression, baseSchema types.Type, reg ExtensionRegi
 			}
 		}
 
+		if et.ScalarFunction.OutputType == nil {
+			return nil, fmt.Errorf("%w: scalar function missing output type", substraitgo.ErrInvalidExpr)
+		}
+
 		id, ok := reg.DecodeFunc(et.ScalarFunction.FunctionReference)
 		if !ok {
 			return nil, substraitgo.ErrNotFound
@@ -102,6 +106,10 @@ func ExprFromProto(e *proto.Expression, baseSchema types.Type, reg ExtensionRegi
 			if sorts[i], err = SortFieldFromProto(s, baseSchema, reg); err != nil {
 				return nil, err
 			}
+		}
+
+		if et.WindowFunction.OutputType == nil {
+			return nil, fmt.Errorf("%w: window function missing output type", substraitgo.ErrInvalidExpr)
 		}
 
 		id, ok := reg.DecodeFunc(et.WindowFunction.FunctionReference)

--- a/expr/missing_output_type_test.go
+++ b/expr/missing_output_type_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package expr_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/substrait-io/substrait-go/v8/expr"
+	"github.com/substrait-io/substrait-go/v8/extensions"
+	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
+)
+
+func TestScalarFunctionMissingOutputTypeReturnsError(t *testing.T) {
+	registry := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+	functionReference := registry.GetFuncAnchor(extensions.ID{
+		URN:  "extension:io.substrait:functions_arithmetic",
+		Name: "add:i64_i64",
+	})
+
+	_, err := expr.ExprFromProto(&proto.Expression{
+		RexType: &proto.Expression_ScalarFunction_{ScalarFunction: &proto.Expression_ScalarFunction{
+			FunctionReference: functionReference,
+			// OutputType intentionally omitted.
+			Arguments: []*proto.FunctionArgument{
+				literalI64Arg(1),
+				literalI64Arg(2),
+			},
+		}},
+	}, nil, registry)
+
+	require.Error(t, err)
+}
+
+func TestScalarFunctionWithOutputTypeDoesNotError(t *testing.T) {
+	registry := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+	functionReference := registry.GetFuncAnchor(extensions.ID{
+		URN:  "extension:io.substrait:functions_arithmetic",
+		Name: "add:i64_i64",
+	})
+
+	_, err := expr.ExprFromProto(&proto.Expression{
+		RexType: &proto.Expression_ScalarFunction_{ScalarFunction: &proto.Expression_ScalarFunction{
+			FunctionReference: functionReference,
+			OutputType:        &proto.Type{Kind: &proto.Type_I64_{I64: &proto.Type_I64{Nullability: proto.Type_NULLABILITY_REQUIRED}}},
+			Arguments: []*proto.FunctionArgument{
+				literalI64Arg(1),
+				literalI64Arg(2),
+			},
+		}},
+	}, nil, registry)
+
+	require.NoError(t, err)
+}
+
+func TestWindowFunctionMissingOutputTypeReturnsError(t *testing.T) {
+	registry := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+	functionReference := registry.GetFuncAnchor(extensions.ID{
+		URN:  "extension:io.substrait:functions_arithmetic",
+		Name: "sum:i64",
+	})
+
+	_, err := expr.ExprFromProto(&proto.Expression{
+		RexType: &proto.Expression_WindowFunction_{WindowFunction: &proto.Expression_WindowFunction{
+			FunctionReference: functionReference,
+			// OutputType intentionally omitted.
+		}},
+	}, nil, registry)
+
+	require.Error(t, err)
+}
+
+func TestWindowFunctionWithOutputTypeDoesNotError(t *testing.T) {
+	registry := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+	functionReference := registry.GetFuncAnchor(extensions.ID{
+		URN:  "extension:io.substrait:functions_arithmetic",
+		Name: "sum:i64",
+	})
+
+	_, err := expr.ExprFromProto(&proto.Expression{
+		RexType: &proto.Expression_WindowFunction_{WindowFunction: &proto.Expression_WindowFunction{
+			FunctionReference: functionReference,
+			OutputType:        &proto.Type{Kind: &proto.Type_I64_{I64: &proto.Type_I64{Nullability: proto.Type_NULLABILITY_REQUIRED}}},
+		}},
+	}, nil, registry)
+
+	require.NoError(t, err)
+}
+
+func literalI64Arg(value int64) *proto.FunctionArgument {
+	return &proto.FunctionArgument{ArgType: &proto.FunctionArgument_Value{Value: &proto.Expression{
+		RexType: &proto.Expression_Literal_{Literal: &proto.Expression_Literal{
+			LiteralType: &proto.Expression_Literal_I64{I64: value},
+		}},
+	}}}
+}


### PR DESCRIPTION
closes #242

also fixed the same nil dereference for window functions since they had the same code path