### PR TITLE
fix(testcases): preserve parsed UDT extension IDs

### DIFF
--- a/testcases/parser/nodes.go
+++ b/testcases/parser/nodes.go
@@ -331,17 +331,18 @@ func (tc *TestCase) CompoundFunctionName() string {
 	return tc.FuncName + ":" + tc.signatureKey()
 }
 
-func (tc *TestCase) ID() extensions.FunctionID {
-	baseURN := tc.BaseURI
-	if strings.HasPrefix(baseURN, "/") {
-		// Convert from URI path format like "/extensions/functions_arithmetic.yaml"
-		// to URN format like "extension:io.substrait:functions_arithmetic"
-		path := strings.TrimPrefix(baseURN, "/extensions/")
+func extensionReferenceToURN(ref string) string {
+	if strings.HasPrefix(ref, "/") {
+		path := strings.TrimPrefix(ref, "/extensions/")
 		path = strings.TrimSuffix(path, ".yaml")
-		baseURN = extensions.SubstraitDefaultURNPrefix + path
+		return extensions.SubstraitDefaultURNPrefix + path
 	}
+	return ref
+}
+
+func (tc *TestCase) ID() extensions.FunctionID {
 	return extensions.FunctionID{
-		URN:  baseURN,
+		URN:  extensionReferenceToURN(tc.BaseURI),
 		Name: tc.CompoundFunctionName(),
 	}
 }

--- a/testcases/parser/parse_test.go
+++ b/testcases/parser/parse_test.go
@@ -141,6 +141,19 @@ lt('2016-12-31T13:30:15'::ts, '2017-12-31T13:30:15'::ts) = true::bool
 	assert.Equal(t, ScalarFuncType, testFile.TestCases[0].FuncType)
 }
 
+func TestParseUserDefinedNullArgPreservesTypeID(t *testing.T) {
+	header := makeHeader("v1.0", "/extensions/functions_geometry.yaml")
+
+	testFile, err := ParseTestCasesFromString(header + "# basic\nf1(null::u!geometry?) = 1::i8")
+	require.NoError(t, err)
+
+	arg := testFile.TestCases[0].Args[0]
+	udt, ok := arg.Type.(*types.UserDefinedType)
+	require.True(t, ok, "expected *types.UserDefinedType, got %T", arg.Type)
+	assert.Equal(t, extensions.TypeID{URN: extensions.SubstraitDefaultURNPrefix + "functions_geometry", Name: "geometry"}, udt.ID)
+	assert.Contains(t, arg.String(), "geometry")
+}
+
 func TestParseDecimalExample(t *testing.T) {
 	header := makeHeader("v1.0", "extensions/functions_arithmetic_decimal.yaml")
 	tests := `# basic

--- a/testcases/parser/visitor.go
+++ b/testcases/parser/visitor.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/substrait-io/substrait-go/v8/expr"
+	"github.com/substrait-io/substrait-go/v8/extensions"
 	"github.com/substrait-io/substrait-go/v8/literal"
 	"github.com/substrait-io/substrait-go/v8/testcases/parser/baseparser"
 	"github.com/substrait-io/substrait-go/v8/types"
@@ -29,6 +30,7 @@ type TestCaseVisitor struct {
 	ErrorListener        util.VisitErrorListener
 	literalTypeInContext types.Type
 	testFuncType         TestFuncType
+	currentTypeURN       string
 }
 
 func (v *TestCaseVisitor) getLiteralTypeInContext() types.Type {
@@ -77,6 +79,7 @@ func (v *TestCaseVisitor) VisitDoc(ctx *baseparser.DocContext) interface{} {
 func (v *TestCaseVisitor) VisitHeader(ctx *baseparser.HeaderContext) interface{} {
 	header := v.Visit(ctx.Version()).(*TestFileHeader)
 	header.IncludedURI = v.Visit(ctx.Include()).(string)
+	v.currentTypeURN = extensionReferenceToURN(header.IncludedURI)
 	return header
 }
 
@@ -946,6 +949,13 @@ func (v *TestCaseVisitor) VisitDataType(ctx *baseparser.DataTypeContext) interfa
 	}
 	v.ErrorListener.ReportVisitError(ctx, fmt.Errorf("invalid data type %v", ctx.GetText()))
 	return nil
+}
+
+func (v *TestCaseVisitor) VisitUserDefined(ctx *baseparser.UserDefinedContext) interface{} {
+	return &types.UserDefinedType{
+		Nullability: getNullability(ctx),
+		ID:          extensions.TypeID{URN: v.currentTypeURN, Name: ctx.Identifier().GetText()},
+	}
 }
 
 func (v *TestCaseVisitor) VisitParameterizedType(ctx *baseparser.ParameterizedTypeContext) interface{} {


### PR DESCRIPTION
The testcase parser was losing the semantic UDT name when parsing `u!type` references, which made parsed types fall back to anchor-like placeholders instead of the declared extension type identity.

This keeps the parsed type name and current extension URN so testcase UDTs line up with the semantic UDT model.

---
Note: This PR was developed with AI assistance. All changes have been reviewed, and I take full responsibility for this contribution.