### PR TITLE
feat(protoenc): decode UDT type anchors

### DIFF
--- a/expr/expression.go
+++ b/expr/expression.go
@@ -9,6 +9,7 @@ import (
 
 	substraitgo "github.com/substrait-io/substrait-go/v8"
 	"github.com/substrait-io/substrait-go/v8/extensions"
+	"github.com/substrait-io/substrait-go/v8/protoenc"
 	"github.com/substrait-io/substrait-go/v8/types"
 	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
 )
@@ -45,7 +46,7 @@ func FuncArgFromProto(e *proto.FunctionArgument, baseSchema *types.RecordType, r
 	case *proto.FunctionArgument_Enum:
 		return types.Enum(et.Enum), nil
 	case *proto.FunctionArgument_Type:
-		return types.TypeFromProto(et.Type), nil
+		return protoenc.TypeFromProto(et.Type, reg.Set)
 	case *proto.FunctionArgument_Value:
 		return ExprFromProto(et.Value, baseSchema, reg)
 	}
@@ -59,7 +60,11 @@ func ExprFromProto(e *proto.Expression, baseSchema *types.RecordType, reg Extens
 
 	switch et := e.RexType.(type) {
 	case *proto.Expression_Literal_:
-		return LiteralFromProto(et.Literal), nil
+		lit := LiteralFromProtoWithRegistry(et.Literal, reg.Set)
+		if lit == nil {
+			return nil, fmt.Errorf("%w: failed to decode literal", substraitgo.ErrInvalidExpr)
+		}
+		return lit, nil
 	case *proto.Expression_Selection:
 		return FieldReferenceFromProto(et.Selection, baseSchema, reg)
 	case *proto.Expression_ScalarFunction_:
@@ -76,17 +81,23 @@ func ExprFromProto(e *proto.Expression, baseSchema *types.RecordType, reg Extens
 			return nil, substraitgo.ErrNotFound
 		}
 
+		outputType, err := protoenc.TypeFromProto(et.ScalarFunction.OutputType, reg.Set)
+		if err != nil {
+			return nil, err
+		}
+
 		decl, ok := reg.LookupScalarFunction(et.ScalarFunction.FunctionReference)
 		if !ok {
-			return NewCustomScalarFunc(reg, extensions.NewScalarFuncVariant(id), types.TypeFromProto(et.ScalarFunction.OutputType), et.ScalarFunction.Options, args...)
+			return NewCustomScalarFunc(reg, extensions.NewScalarFuncVariant(id), outputType, et.ScalarFunction.Options, args...)
 		}
 
 		return &ScalarFunction{
 			funcRef:     et.ScalarFunction.FunctionReference,
 			declaration: decl,
+			extSet:      reg.Set,
 			args:        args,
 			options:     et.ScalarFunction.Options,
-			outputType:  types.TypeFromProto(et.ScalarFunction.OutputType),
+			outputType:  outputType,
 		}, nil
 	case *proto.Expression_WindowFunction_:
 		var err error
@@ -115,9 +126,14 @@ func ExprFromProto(e *proto.Expression, baseSchema *types.RecordType, reg Extens
 		if !ok {
 			return nil, substraitgo.ErrNotFound
 		}
+		outputType, err := protoenc.TypeFromProto(et.WindowFunction.OutputType, reg.Set)
+		if err != nil {
+			return nil, err
+		}
+
 		decl, ok := reg.LookupWindowFunction(et.WindowFunction.FunctionReference)
 		if !ok {
-			fn, err := NewCustomWindowFunc(reg, extensions.NewWindowFuncVariant(id), types.TypeFromProto(et.WindowFunction.OutputType),
+			fn, err := NewCustomWindowFunc(reg, extensions.NewWindowFuncVariant(id), outputType,
 				et.WindowFunction.Options, et.WindowFunction.Invocation, et.WindowFunction.Phase, args...)
 			if err != nil {
 				return nil, err
@@ -134,9 +150,10 @@ func ExprFromProto(e *proto.Expression, baseSchema *types.RecordType, reg Extens
 		return &WindowFunction{
 			funcRef:     et.WindowFunction.FunctionReference,
 			declaration: decl,
+			extSet:      reg.Set,
 			args:        args,
 			options:     et.WindowFunction.Options,
-			outputType:  types.TypeFromProto(et.WindowFunction.OutputType),
+			outputType:  outputType,
 			phase:       et.WindowFunction.Phase,
 			invocation:  et.WindowFunction.Invocation,
 			Partitions:  parts,
@@ -245,8 +262,12 @@ func ExprFromProto(e *proto.Expression, baseSchema *types.RecordType, reg Extens
 			return nil, err
 		}
 
+		castType, err := protoenc.TypeFromProto(et.Cast.Type, reg.Set)
+		if err != nil {
+			return nil, err
+		}
 		return &Cast{
-			Type:            types.TypeFromProto(et.Cast.Type),
+			Type:            castType,
 			Input:           input,
 			FailureBehavior: et.Cast.FailureBehavior,
 		}, nil
@@ -320,8 +341,12 @@ func ExprFromProto(e *proto.Expression, baseSchema *types.RecordType, reg Extens
 		if et.DynamicParameter == nil {
 			return nil, fmt.Errorf("%w: dynamic parameter is nil", substraitgo.ErrInvalidExpr)
 		}
+		outputType, err := protoenc.TypeFromProto(et.DynamicParameter.Type, reg.Set)
+		if err != nil {
+			return nil, err
+		}
 		return &DynamicParameter{
-			OutputType:         types.TypeFromProto(et.DynamicParameter.Type),
+			OutputType:         outputType,
 			ParameterReference: et.DynamicParameter.ParameterReference,
 		}, nil
 	case *proto.Expression_Enum_:
@@ -340,8 +365,12 @@ func ExprFromProto(e *proto.Expression, baseSchema *types.RecordType, reg Extens
 		}
 
 		paramTypes := make([]types.Type, len(et.Lambda.Parameters.Types))
+		var err error
 		for i, pt := range et.Lambda.Parameters.Types {
-			paramTypes[i] = types.TypeFromProto(pt)
+			paramTypes[i], err = protoenc.TypeFromProto(pt, reg.Set)
+			if err != nil {
+				return nil, err
+			}
 		}
 		params := &types.StructType{
 			Types:            paramTypes,

--- a/expr/functions.go
+++ b/expr/functions.go
@@ -859,9 +859,14 @@ func NewAggregateFunctionFromProto(
 	if !ok {
 		return nil, substraitgo.ErrNotFound
 	}
+	outputType, err := protoenc.TypeFromProto(agg.OutputType, reg.Set)
+	if err != nil {
+		return nil, err
+	}
+
 	decl, ok := reg.LookupAggregateFunction(agg.FunctionReference)
 	if !ok {
-		return NewCustomAggregateFunc(reg, extensions.NewAggFuncVariant(id), types.TypeFromProto(agg.OutputType), agg.Options, agg.Invocation, agg.Phase, sorts, args...)
+		return NewCustomAggregateFunc(reg, extensions.NewAggFuncVariant(id), outputType, agg.Options, agg.Invocation, agg.Phase, sorts, args...)
 	}
 
 	return &AggregateFunction{
@@ -870,7 +875,7 @@ func NewAggregateFunctionFromProto(
 		extSet:      reg.Set,
 		args:        args,
 		options:     agg.Options,
-		outputType:  types.TypeFromProto(agg.OutputType),
+		outputType:  outputType,
 		phase:       agg.Phase,
 		invocation:  agg.Invocation,
 		Sorts:       sorts,

--- a/expr/literals.go
+++ b/expr/literals.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/uuid"
 	substraitgo "github.com/substrait-io/substrait-go/v8"
 	"github.com/substrait-io/substrait-go/v8/extensions"
+	"github.com/substrait-io/substrait-go/v8/protoenc"
 	"github.com/substrait-io/substrait-go/v8/types"
 	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
 )
@@ -1004,6 +1005,17 @@ func NewLiteral[T allLiteralTypes](val T, nullable bool) (Literal, error) {
 // LiteralFromProto constructs the appropriate Literal struct from
 // a protobuf message.
 func LiteralFromProto(l *proto.Expression_Literal) Literal {
+	return LiteralFromProtoWithRegistry(l, nil)
+}
+
+func typeFromProtoForLiteral(t *proto.Type, extSet extensions.Set) (types.Type, error) {
+	if extSet == nil {
+		return types.TypeFromProto(t), nil
+	}
+	return protoenc.TypeFromProto(t, extSet)
+}
+
+func LiteralFromProtoWithRegistry(l *proto.Expression_Literal, extSet extensions.Set) Literal {
 	nullability := getNullability(l.Nullable)
 
 	switch lit := l.LiteralType.(type) {
@@ -1159,12 +1171,16 @@ func LiteralFromProto(l *proto.Expression_Literal) Literal {
 				Nullability:      nullability,
 			}}
 	case *proto.Expression_Literal_Null:
-		return &NullLiteral{Type: types.TypeFromProto(lit.Null)}
+		typ, err := typeFromProtoForLiteral(lit.Null, extSet)
+		if err != nil {
+			return nil
+		}
+		return &NullLiteral{Type: typ}
 	case *proto.Expression_Literal_Struct_:
 		typeList := make([]types.Type, len(lit.Struct.Fields))
 		fields := make([]Literal, len(lit.Struct.Fields))
 		for i, f := range lit.Struct.Fields {
-			fields[i] = LiteralFromProto(f)
+			fields[i] = LiteralFromProtoWithRegistry(f, extSet)
 			typeList[i] = fields[i].GetType()
 		}
 
@@ -1178,8 +1194,8 @@ func LiteralFromProto(l *proto.Expression_Literal) Literal {
 	case *proto.Expression_Literal_Map_:
 		ret := make(MapLiteralValue, len(lit.Map.KeyValues))
 		for i, kv := range lit.Map.KeyValues {
-			ret[i].Key = LiteralFromProto(kv.Key)
-			ret[i].Value = LiteralFromProto(kv.Value)
+			ret[i].Key = LiteralFromProtoWithRegistry(kv.Key, extSet)
+			ret[i].Value = LiteralFromProtoWithRegistry(kv.Value, extSet)
 		}
 		return &MapLiteral{
 			Value: ret,
@@ -1192,7 +1208,7 @@ func LiteralFromProto(l *proto.Expression_Literal) Literal {
 	case *proto.Expression_Literal_List_:
 		ret := make(ListLiteralValue, len(lit.List.Values))
 		for i, v := range lit.List.Values {
-			ret[i] = LiteralFromProto(v)
+			ret[i] = LiteralFromProtoWithRegistry(v, extSet)
 		}
 		return &NestedLiteral[ListLiteralValue]{
 			Value: ListLiteralValue(ret),
@@ -1202,33 +1218,63 @@ func LiteralFromProto(l *proto.Expression_Literal) Literal {
 				Type:             ret[0].GetType(),
 			}}
 	case *proto.Expression_Literal_EmptyList:
+		typ, err := typeFromProtoForLiteral(lit.EmptyList.Type, extSet)
+		if err != nil {
+			return nil
+		}
 		return &NestedLiteral[ListLiteralValue]{
 			Value: nil,
 			Type: &types.ListType{
 				Nullability:      nullability,
 				TypeVariationRef: l.TypeVariationReference,
-				Type:             types.TypeFromProto(lit.EmptyList.Type),
+				Type:             typ,
 			}}
 	case *proto.Expression_Literal_EmptyMap:
+		key, err := typeFromProtoForLiteral(lit.EmptyMap.Key, extSet)
+		if err != nil {
+			return nil
+		}
+		value, err := typeFromProtoForLiteral(lit.EmptyMap.Value, extSet)
+		if err != nil {
+			return nil
+		}
 		return &MapLiteral{
 			Value: nil,
 			Type: &types.MapType{
 				Nullability:      nullability,
 				TypeVariationRef: l.TypeVariationReference,
-				Key:              types.TypeFromProto(lit.EmptyMap.Key),
-				Value:            types.TypeFromProto(lit.EmptyMap.Value),
+				Key:              key,
+				Value:            value,
 			}}
 	case *proto.Expression_Literal_UserDefined_:
 		params := make([]types.TypeParam, len(lit.UserDefined.TypeParameters))
 		for i, p := range lit.UserDefined.TypeParameters {
-			params[i] = types.TypeParamFromProto(p)
+			if extSet != nil {
+				var err error
+				params[i], err = protoenc.TypeParamFromProto(p, extSet)
+				if err != nil {
+					return nil
+				}
+			} else {
+				params[i] = types.TypeParamFromProto(p)
+			}
+		}
+		var id extensions.TypeID
+		if extSet != nil {
+			var ok bool
+			id, ok = extSet.DecodeType(lit.UserDefined.GetTypeReference())
+			if !ok {
+				return nil
+			}
 		}
 
 		return &ProtoLiteral{
-			Value: lit.UserDefined.Val,
+			Value:  lit.UserDefined.Val,
+			extSet: extSet,
 			Type: &types.UserDefinedType{
 				Nullability:      nullability,
 				TypeVariationRef: l.TypeVariationReference,
+				ID:               id,
 				TypeParameters:   params,
 			},
 		}

--- a/protoenc/types.go
+++ b/protoenc/types.go
@@ -1,6 +1,8 @@
 package protoenc
 
 import (
+	"fmt"
+
 	"github.com/substrait-io/substrait-go/v8/extensions"
 	"github.com/substrait-io/substrait-go/v8/types"
 	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
@@ -13,7 +15,7 @@ func TypeToProto(t types.Type, extSet extensions.Set) *proto.Type {
 	case *types.UserDefinedType:
 		params := make([]*proto.Type_Parameter, len(t.TypeParameters))
 		for i, p := range t.TypeParameters {
-			params[i] = typeParamToProto(p, extSet)
+			params[i] = TypeParamToProto(p, extSet)
 		}
 		return &proto.Type{Kind: &proto.Type_UserDefined_{
 			UserDefined: &proto.Type_UserDefined{
@@ -46,16 +48,111 @@ func TypeToProto(t types.Type, extSet extensions.Set) *proto.Type {
 			Key:                    TypeToProto(t.Key, extSet),
 			Value:                  TypeToProto(t.Value, extSet),
 		}}}
+	case *types.FuncType:
+		params := make([]*proto.Type, len(t.ParameterTypes))
+		for i, param := range t.ParameterTypes {
+			params[i] = TypeToProto(param, extSet)
+		}
+		return &proto.Type{Kind: &proto.Type_Func_{Func: &proto.Type_Func{
+			Nullability:    t.Nullability,
+			ParameterTypes: params,
+			ReturnType:     TypeToProto(t.ReturnType, extSet),
+		}}}
 	default:
 		return types.TypeToProto(t)
 	}
 }
 
-func typeParamToProto(p types.TypeParam, extSet extensions.Set) *proto.Type_Parameter {
+func TypeParamToProto(p types.TypeParam, extSet extensions.Set) *proto.Type_Parameter {
 	if data, ok := p.(*types.DataTypeParameter); ok {
 		return &proto.Type_Parameter{Parameter: &proto.Type_Parameter_DataType{
 			DataType: TypeToProto(data.Type, extSet),
 		}}
 	}
 	return p.ToProto()
+}
+
+func TypeFromProto(t *proto.Type, extSet extensions.Set) (types.Type, error) {
+	switch t := t.Kind.(type) {
+	case *proto.Type_UserDefined_:
+		id, ok := extSet.DecodeType(t.UserDefined.TypeReference)
+		if !ok {
+			return nil, fmt.Errorf("user-defined type anchor %d is not registered", t.UserDefined.TypeReference)
+		}
+		params, err := typeParamsFromProto(t.UserDefined.TypeParameters, extSet)
+		if err != nil {
+			return nil, err
+		}
+		return &types.UserDefinedType{
+			Nullability:      t.UserDefined.Nullability,
+			TypeVariationRef: t.UserDefined.TypeVariationReference,
+			ID:               id,
+			TypeParameters:   params,
+		}, nil
+	case *proto.Type_Struct_:
+		children := make([]types.Type, len(t.Struct.Types))
+		for i, child := range t.Struct.Types {
+			var err error
+			children[i], err = TypeFromProto(child, extSet)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return &types.StructType{Nullability: t.Struct.Nullability, TypeVariationRef: t.Struct.TypeVariationReference, Types: children}, nil
+	case *proto.Type_List_:
+		child, err := TypeFromProto(t.List.Type, extSet)
+		if err != nil {
+			return nil, err
+		}
+		return &types.ListType{Nullability: t.List.Nullability, TypeVariationRef: t.List.TypeVariationReference, Type: child}, nil
+	case *proto.Type_Map_:
+		key, err := TypeFromProto(t.Map.Key, extSet)
+		if err != nil {
+			return nil, err
+		}
+		value, err := TypeFromProto(t.Map.Value, extSet)
+		if err != nil {
+			return nil, err
+		}
+		return &types.MapType{Nullability: t.Map.Nullability, TypeVariationRef: t.Map.TypeVariationReference, Key: key, Value: value}, nil
+	case *proto.Type_Func_:
+		params := make([]types.Type, len(t.Func.ParameterTypes))
+		for i, param := range t.Func.ParameterTypes {
+			var err error
+			params[i], err = TypeFromProto(param, extSet)
+			if err != nil {
+				return nil, err
+			}
+		}
+		ret, err := TypeFromProto(t.Func.ReturnType, extSet)
+		if err != nil {
+			return nil, err
+		}
+		return &types.FuncType{Nullability: t.Func.Nullability, ParameterTypes: params, ReturnType: ret}, nil
+	default:
+		return types.TypeFromProto(&proto.Type{Kind: t}), nil
+	}
+}
+
+func TypeParamFromProto(p *proto.Type_Parameter, extSet extensions.Set) (types.TypeParam, error) {
+	if data := p.GetDataType(); data != nil {
+		t, err := TypeFromProto(data, extSet)
+		if err != nil {
+			return nil, err
+		}
+		return &types.DataTypeParameter{Type: t}, nil
+	}
+	return types.TypeParamFromProto(p), nil
+}
+
+func typeParamsFromProto(params []*proto.Type_Parameter, extSet extensions.Set) ([]types.TypeParam, error) {
+	out := make([]types.TypeParam, len(params))
+	for i, param := range params {
+		var err error
+		out[i], err = TypeParamFromProto(param, extSet)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
 }

--- a/protoenc/types_test.go
+++ b/protoenc/types_test.go
@@ -71,3 +71,42 @@ func TestTypeToProtoDelegatesNonUserDefinedTypes(t *testing.T) {
 	require.NotNil(t, protoType.GetBool())
 	require.Equal(t, types.NullabilityRequired, protoType.GetBool().Nullability)
 }
+
+func TestTypeFromProtoResolvesUserDefinedTypeAnchors(t *testing.T) {
+	extSet := extensions.NewSet()
+	pointID := extensions.TypeID{URN: "extension:test:types", Name: "point"}
+	typeAnchor := extSet.GetTypeAnchor(pointID)
+
+	protoType := protoenc.TypeToProto(&types.FuncType{
+		Nullability: types.NullabilityRequired,
+		ParameterTypes: []types.Type{
+			&types.ListType{Type: &types.UserDefinedType{ID: pointID, Nullability: types.NullabilityNullable}},
+		},
+		ReturnType: &types.UserDefinedType{
+			Nullability: types.NullabilityRequired,
+			ID:          pointID,
+			TypeParameters: []types.TypeParam{
+				&types.DataTypeParameter{Type: &types.Int32Type{Nullability: types.NullabilityRequired}},
+			},
+		},
+	}, extSet)
+
+	decoded, err := protoenc.TypeFromProto(protoType, extSet)
+	require.NoError(t, err)
+
+	fn := decoded.(*types.FuncType)
+	paramUDT := fn.ParameterTypes[0].(*types.ListType).Type.(*types.UserDefinedType)
+	require.Equal(t, pointID, paramUDT.ID)
+
+	returnUDT := fn.ReturnType.(*types.UserDefinedType)
+	require.Equal(t, pointID, returnUDT.ID)
+	require.Equal(t, typeAnchor, protoType.GetFunc().ReturnType.GetUserDefined().TypeReference)
+	require.Len(t, returnUDT.TypeParameters, 1)
+}
+
+func TestTypeFromProtoRejectsUnknownUserDefinedTypeAnchor(t *testing.T) {
+	protoType := protoenc.TypeToProto(&types.UserDefinedType{ID: extensions.TypeID{URN: "extension:test:types", Name: "point"}}, extensions.NewSet())
+
+	_, err := protoenc.TypeFromProto(protoType, extensions.NewSet())
+	require.ErrorContains(t, err, "user-defined type anchor")
+}


### PR DESCRIPTION
UDT serialization now assigns anchors from semantic extension type IDs, but the decode path also needs registry context to recover those IDs from protobuf anchors.

This adds the registry-aware type decode path and uses it from expression and literal decoding paths that already have an extension registry available.

---
Note: This PR was developed with AI assistance. All changes have been reviewed, and I take full responsibility for this contribution.