### PR TITLE
feat(extensions)!: require function variant names

### DIFF
--- a/expr/binding_test.go
+++ b/expr/binding_test.go
@@ -19,29 +19,29 @@ var (
 	})
 
 	subID = extensions.FunctionID{
-		URN:  extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
-		Name: "subtract:i8_i8"}
+		URN:       extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
+		Signature: "subtract:i8_i8"}
 	addID = extensions.FunctionID{
-		URN:  extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
-		Name: "add:i8_i8"}
+		URN:       extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
+		Signature: "add:i8_i8"}
 	indexInID = extensions.FunctionID{
-		URN:  extensions.SubstraitDefaultURNPrefix + "functions_set",
-		Name: "index_in:any_list"}
+		URN:       extensions.SubstraitDefaultURNPrefix + "functions_set",
+		Signature: "index_in:any_list"}
 	rankID = extensions.FunctionID{
-		URN:  extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
-		Name: "rank:"}
+		URN:       extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
+		Signature: "rank:"}
 	firstValueID = extensions.FunctionID{
-		URN:  extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
-		Name: "first_value:any"}
+		URN:       extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
+		Signature: "first_value:any"}
 	extractID = extensions.FunctionID{
-		URN:  extensions.SubstraitDefaultURNPrefix + "functions_datetime",
-		Name: "extract:req_date"}
+		URN:       extensions.SubstraitDefaultURNPrefix + "functions_datetime",
+		Signature: "extract:req_date"}
 	ntileID = extensions.FunctionID{
-		URN:  extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
-		Name: "ntile:i32"}
+		URN:       extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
+		Signature: "ntile:i32"}
 	sumID = extensions.FunctionID{
-		URN:  extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
-		Name: "sum:i32"}
+		URN:       extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
+		Signature: "sum:i32"}
 
 	boringSchema = types.NamedStruct{
 		Names: []string{

--- a/expr/binding_test.go
+++ b/expr/binding_test.go
@@ -20,28 +20,28 @@ var (
 
 	subID = extensions.ID{
 		URN:  extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
-		Name: "subtract"}
+		Name: "subtract:i8_i8"}
 	addID = extensions.ID{
 		URN:  extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
-		Name: "add"}
+		Name: "add:i8_i8"}
 	indexInID = extensions.ID{
 		URN:  extensions.SubstraitDefaultURNPrefix + "functions_set",
-		Name: "index_in"}
+		Name: "index_in:any_list"}
 	rankID = extensions.ID{
 		URN:  extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
-		Name: "rank"}
+		Name: "rank:"}
 	firstValueID = extensions.ID{
 		URN:  extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
-		Name: "first_value"}
+		Name: "first_value:any"}
 	extractID = extensions.ID{
 		URN:  extensions.SubstraitDefaultURNPrefix + "functions_datetime",
-		Name: "extract"}
+		Name: "extract:req_date"}
 	ntileID = extensions.ID{
 		URN:  extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
-		Name: "ntile"}
+		Name: "ntile:i32"}
 	sumID = extensions.ID{
 		URN:  extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
-		Name: "sum"}
+		Name: "sum:i32"}
 
 	boringSchema = types.NamedStruct{
 		Names: []string{

--- a/expr/builder_test.go
+++ b/expr/builder_test.go
@@ -318,7 +318,7 @@ func TestBoundFromProto(t *testing.T) {
 	}
 }
 
-func TestResolveScalarFunctionVariant(t *testing.T) {
+func TestResolveFunctionVariant(t *testing.T) {
 	reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
 
 	addID, err := expr.ResolveScalarFunctionVariant(reg,
@@ -340,6 +340,22 @@ func TestResolveScalarFunctionVariant(t *testing.T) {
 		URN:       extensions.SubstraitDefaultURNPrefix + "functions_comparison",
 		Signature: "equal:any_any",
 	}, equalID)
+
+	countID, err := expr.ResolveAggregateFunctionVariant(reg,
+		extensions.SubstraitDefaultURNPrefix+"functions_aggregate_generic", "count")
+	require.NoError(t, err)
+	assert.Equal(t, extensions.FunctionID{
+		URN:       extensions.SubstraitDefaultURNPrefix + "functions_aggregate_generic",
+		Signature: "count:",
+	}, countID)
+
+	rankID, err := expr.ResolveWindowFunctionVariant(reg,
+		extensions.SubstraitDefaultURNPrefix+"functions_arithmetic", "rank")
+	require.NoError(t, err)
+	assert.Equal(t, extensions.FunctionID{
+		URN:       extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
+		Signature: "rank:",
+	}, rankID)
 }
 
 func TestAny1TypeParameterConsistency(t *testing.T) {

--- a/expr/builder_test.go
+++ b/expr/builder_test.go
@@ -21,9 +21,9 @@ func TestExprBuilder(t *testing.T) {
 		Reg:        expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError()),
 		BaseSchema: types.NewRecordTypeFromStruct(boringSchema.Struct),
 	}
-	addI32ID := extensions.FunctionID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Name: "add:i32_i32"}
-	addI64ID := extensions.FunctionID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Name: "add:i64_i64"}
-	subI32ID := extensions.FunctionID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Name: "subtract:i32_i32"}
+	addI32ID := extensions.FunctionID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Signature: "add:i32_i32"}
+	addI64ID := extensions.FunctionID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Signature: "add:i64_i64"}
+	subI32ID := extensions.FunctionID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Signature: "subtract:i32_i32"}
 	precomputedLiteral, _ := expr.NewLiteral(int32(3), false)
 	precomputedExpression, _ := b.ScalarFunc(addI32ID).Args(
 		b.Wrap(expr.NewLiteral(int32(3), false)),
@@ -177,8 +177,8 @@ window_functions:
 
 	// check scalar function
 	scalar, err := planBuilder.GetExprBuilder().ScalarFunc(extensions.FunctionID{
-		URN:  "extension:test:custom",
-		Name: "custom_function:u!custom_type2",
+		URN:       "extension:test:custom",
+		Signature: "custom_function:u!custom_type2",
 	}).Args(
 		customLiteral,
 	).BuildExpr()
@@ -192,8 +192,8 @@ window_functions:
 
 	// check aggregate function
 	aggr, err := planBuilder.GetExprBuilder().AggFunc(extensions.FunctionID{
-		URN:  "extension:test:custom",
-		Name: "custom_aggr:u!custom_type2",
+		URN:       "extension:test:custom",
+		Signature: "custom_aggr:u!custom_type2",
 	}).Args(
 		customLiteral,
 	).Build()
@@ -206,8 +206,8 @@ window_functions:
 
 	// check window function
 	window, err := planBuilder.GetExprBuilder().WindowFunc(extensions.FunctionID{
-		URN:  "extension:test:custom",
-		Name: "custom_window:u!custom_type2",
+		URN:       "extension:test:custom",
+		Signature: "custom_window:u!custom_type2",
 	}).Args(
 		customLiteral,
 	).Phase(types.AggPhaseInitialToResult).Build()
@@ -323,8 +323,8 @@ func TestAny1TypeParameterConsistency(t *testing.T) {
 	reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
 
 	equalID := extensions.FunctionID{
-		URN:  extensions.SubstraitDefaultURNPrefix + "functions_comparison",
-		Name: "equal:any_any",
+		URN:       extensions.SubstraitDefaultURNPrefix + "functions_comparison",
+		Signature: "equal:any_any",
 	}
 
 	t.Run("non-variadic any1 - invalid", func(t *testing.T) {
@@ -353,8 +353,8 @@ func TestAny1TypeParameterConsistency(t *testing.T) {
 
 	// coalesce(any1, any1, ...) -> any1 (min: 2 args)
 	coalesceID := extensions.FunctionID{
-		URN:  extensions.SubstraitDefaultURNPrefix + "functions_comparison",
-		Name: "coalesce:any",
+		URN:       extensions.SubstraitDefaultURNPrefix + "functions_comparison",
+		Signature: "coalesce:any",
 	}
 
 	t.Run("variadic any1 - invalid", func(t *testing.T) {

--- a/expr/builder_test.go
+++ b/expr/builder_test.go
@@ -318,6 +318,30 @@ func TestBoundFromProto(t *testing.T) {
 	}
 }
 
+func TestResolveScalarFunctionVariant(t *testing.T) {
+	reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+
+	addID, err := expr.ResolveScalarFunctionVariant(reg,
+		extensions.SubstraitDefaultURNPrefix+"functions_arithmetic", "add",
+		expr.NewPrimitiveLiteral(int32(1), false),
+		expr.NewPrimitiveLiteral(int32(2), false))
+	require.NoError(t, err)
+	assert.Equal(t, extensions.FunctionID{
+		URN:       extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
+		Signature: "add:i32_i32",
+	}, addID)
+
+	equalID, err := expr.ResolveScalarFunctionVariant(reg,
+		extensions.SubstraitDefaultURNPrefix+"functions_comparison", "equal",
+		expr.NewPrimitiveLiteral(int32(1), false),
+		expr.NewPrimitiveLiteral(int32(2), false))
+	require.NoError(t, err)
+	assert.Equal(t, extensions.FunctionID{
+		URN:       extensions.SubstraitDefaultURNPrefix + "functions_comparison",
+		Signature: "equal:any_any",
+	}, equalID)
+}
+
 func TestAny1TypeParameterConsistency(t *testing.T) {
 	// equal(any1, any1) -> boolean
 	reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())

--- a/expr/builder_test.go
+++ b/expr/builder_test.go
@@ -21,8 +21,11 @@ func TestExprBuilder(t *testing.T) {
 		Reg:        expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError()),
 		BaseSchema: types.NewRecordTypeFromStruct(boringSchema.Struct),
 	}
+	addI32ID := extensions.ID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Name: "add:i32_i32"}
+	addI64ID := extensions.ID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Name: "add:i64_i64"}
+	subI32ID := extensions.ID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Name: "subtract:i32_i32"}
 	precomputedLiteral, _ := expr.NewLiteral(int32(3), false)
-	precomputedExpression, _ := b.ScalarFunc(addID).Args(
+	precomputedExpression, _ := b.ScalarFunc(addI32ID).Args(
 		b.Wrap(expr.NewLiteral(int32(3), false)),
 		b.Wrap(expr.NewLiteral(int32(3), false))).BuildExpr()
 
@@ -51,22 +54,22 @@ func TestExprBuilder(t *testing.T) {
 				b.Wrap(expr.NewLiteral(int32(5), false)),
 				b.Literal(expr.NewEmptyListLiteral(&types.Int32Type{}, false))), ""},
 		{"with cast", "subtract(.field(3) => i32, cast(.field(6) => fp32 AS i32, fail: FAILURE_BEHAVIOR_THROW_EXCEPTION)) => i32?",
-			b.ScalarFunc(subID).Args(
+			b.ScalarFunc(subI32ID).Args(
 				b.RootRef(expr.NewStructFieldRef(3)),
 				b.Cast(b.RootRef(expr.NewStructFieldRef(6)), &types.Int32Type{}).
 					FailBehavior(types.BehaviorThrowException),
 			), ""},
 		{"expression with lit", "subtract(.field(3) => i32, i32(3)) => i32",
-			b.ScalarFunc(subID).Args(b.RootRef(expr.NewStructFieldRef(3)),
+			b.ScalarFunc(subI32ID).Args(b.RootRef(expr.NewStructFieldRef(3)),
 				b.Expression(precomputedLiteral)), ""},
 		{"expression with expr", "subtract(.field(3) => i32, add(i32(3), i32(3)) => i32) => i32",
-			b.ScalarFunc(subID).Args(b.RootRef(expr.NewStructFieldRef(3)),
+			b.ScalarFunc(subI32ID).Args(b.RootRef(expr.NewStructFieldRef(3)),
 				b.Expression(precomputedExpression)), ""},
 		{"wrap expression", "subtract(.field(3) => i32, i32(3)) => i32",
-			b.ScalarFunc(subID).Args(b.RootRef(expr.NewStructFieldRef(3)),
+			b.ScalarFunc(subI32ID).Args(b.RootRef(expr.NewStructFieldRef(3)),
 				b.Wrap(expr.NewLiteral(int32(3), false))), ""},
 		{"window func", "",
-			b.WindowFunc(rankID), "invalid expression: non-decomposable window or agg function '{extension:io.substrait:functions_arithmetic rank}' must use InitialToResult phase"},
+			b.WindowFunc(rankID), "invalid expression: non-decomposable window or agg function '{extension:io.substrait:functions_arithmetic rank:}' must use InitialToResult phase"},
 		{"window func", "rank(; phase: AGGREGATION_PHASE_INITIAL_TO_RESULT, invocation: AGGREGATION_INVOCATION_UNSPECIFIED) => i64?",
 			b.WindowFunc(rankID).Phase(types.AggPhaseInitialToResult), ""},
 		{"window func",
@@ -81,7 +84,7 @@ func TestExprBuilder(t *testing.T) {
 				Phase(types.AggPhaseInitialToResult).
 				Partitions(b.RootRef(expr.NewStructFieldRef(0))), ""},
 		{"nested funcs", "add(extract(YEAR, date(2000-01-01)) => i64, rank(; phase: AGGREGATION_PHASE_INITIAL_TO_RESULT, invocation: AGGREGATION_INVOCATION_ALL) => i64?) => i64?",
-			b.ScalarFunc(addID).Args(
+			b.ScalarFunc(addI64ID).Args(
 				b.ScalarFunc(extractID).Args(b.Enum("YEAR"),
 					b.Wrap(expr.NewLiteral(types.Date(10957), false))),
 				b.WindowFunc(rankID).Phase(types.AggPhaseInitialToResult).Invocation(types.AggInvocationAll)), ""},
@@ -97,7 +100,7 @@ func TestExprBuilder(t *testing.T) {
 					Kind: types.SortAscNullsFirst}), ""},
 		{"window func arg error", "",
 			b.WindowFunc(ntileID).Args(b.ScalarFunc(extensions.ID{})),
-			"not found: could not find matching function for id: { :}"},
+			"not found: could not find matching function for id: { }"},
 	}
 
 	for _, tt := range tests {
@@ -175,7 +178,7 @@ window_functions:
 	// check scalar function
 	scalar, err := planBuilder.GetExprBuilder().ScalarFunc(extensions.ID{
 		URN:  "extension:test:custom",
-		Name: "custom_function",
+		Name: "custom_function:u!custom_type2",
 	}).Args(
 		customLiteral,
 	).BuildExpr()
@@ -190,7 +193,7 @@ window_functions:
 	// check aggregate function
 	aggr, err := planBuilder.GetExprBuilder().AggFunc(extensions.ID{
 		URN:  "extension:test:custom",
-		Name: "custom_aggr",
+		Name: "custom_aggr:u!custom_type2",
 	}).Args(
 		customLiteral,
 	).Build()
@@ -204,7 +207,7 @@ window_functions:
 	// check window function
 	window, err := planBuilder.GetExprBuilder().WindowFunc(extensions.ID{
 		URN:  "extension:test:custom",
-		Name: "custom_window",
+		Name: "custom_window:u!custom_type2",
 	}).Args(
 		customLiteral,
 	).Phase(types.AggPhaseInitialToResult).Build()
@@ -321,7 +324,7 @@ func TestAny1TypeParameterConsistency(t *testing.T) {
 
 	equalID := extensions.ID{
 		URN:  extensions.SubstraitDefaultURNPrefix + "functions_comparison",
-		Name: "equal",
+		Name: "equal:any_any",
 	}
 
 	t.Run("non-variadic any1 - invalid", func(t *testing.T) {
@@ -351,7 +354,7 @@ func TestAny1TypeParameterConsistency(t *testing.T) {
 	// coalesce(any1, any1, ...) -> any1 (min: 2 args)
 	coalesceID := extensions.ID{
 		URN:  extensions.SubstraitDefaultURNPrefix + "functions_comparison",
-		Name: "coalesce",
+		Name: "coalesce:any",
 	}
 
 	t.Run("variadic any1 - invalid", func(t *testing.T) {

--- a/expr/dynamic_parameter_test.go
+++ b/expr/dynamic_parameter_test.go
@@ -141,7 +141,7 @@ func TestDynamicParameterTypeMismatchInFunction(t *testing.T) {
 	}{
 		{
 			name:   "i32 where i8 expected",
-			funcID: extensions.FunctionID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Name: "add:i8_i8"},
+			funcID: extensions.FunctionID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Signature: "add:i8_i8"},
 			dpType: &types.Int32Type{Nullability: types.NullabilityRequired},
 			lit:    func() (expr.Literal, error) { return expr.NewLiteral(int8(5), false) },
 		},

--- a/expr/expressions_test.go
+++ b/expr/expressions_test.go
@@ -248,8 +248,8 @@ func TestExpressionsRoundtrip(t *testing.T) {
 func TestScalarFunctionMissingOutputTypeReturnsError(t *testing.T) {
 	registry := expr.NewEmptyExtensionRegistry(ext.GetDefaultCollectionWithNoError())
 	functionReference := registry.GetFuncAnchor(ext.FunctionID{
-		URN:  "extension:io.substrait:functions_arithmetic",
-		Name: "add:i64_i64",
+		URN:       "extension:io.substrait:functions_arithmetic",
+		Signature: "add:i64_i64",
 	})
 
 	_, err := expr.ExprFromProto(&proto.Expression{
@@ -269,8 +269,8 @@ func TestScalarFunctionMissingOutputTypeReturnsError(t *testing.T) {
 func TestWindowFunctionMissingOutputTypeReturnsError(t *testing.T) {
 	registry := expr.NewEmptyExtensionRegistry(ext.GetDefaultCollectionWithNoError())
 	functionReference := registry.GetFuncAnchor(ext.FunctionID{
-		URN:  "extension:io.substrait:functions_arithmetic",
-		Name: "sum:i64",
+		URN:       "extension:io.substrait:functions_arithmetic",
+		Signature: "sum:i64",
 	})
 
 	_, err := expr.ExprFromProto(&proto.Expression{

--- a/expr/expressions_test.go
+++ b/expr/expressions_test.go
@@ -112,7 +112,7 @@ func ExampleExpression_scalarFunction() {
 	// having to construct the protobuf
 	const substraitext = `extension:io.substrait:functions_arithmetic`
 
-	var addVariant = ext.NewScalarFuncVariant(ext.FunctionID{URN: substraitext, Name: "add:i32_i32"})
+	var addVariant = ext.NewScalarFuncVariant(ext.FunctionID{URN: substraitext, Signature: "add:i32_i32"})
 
 	var ex expr.Expression
 	refArg, _ := expr.NewRootFieldRef(expr.NewStructFieldRef(0), types.NewRecordTypeFromTypes([]types.Type{&types.Int32Type{}}))
@@ -145,9 +145,9 @@ func ExampleExpression_scalarFunction() {
 
 func sampleNestedExpr(reg expr.ExtensionRegistry, substraitExtURN string) expr.Expression {
 	var (
-		add = ext.NewScalarFuncVariant(ext.FunctionID{URN: substraitExtURN, Name: "add"})
-		sub = ext.NewScalarFuncVariant(ext.FunctionID{URN: substraitExtURN, Name: "subtract"})
-		mul = ext.NewScalarFuncVariant(ext.FunctionID{URN: substraitExtURN, Name: "multiply"})
+		add = ext.NewScalarFuncVariant(ext.FunctionID{URN: substraitExtURN, Signature: "add"})
+		sub = ext.NewScalarFuncVariant(ext.FunctionID{URN: substraitExtURN, Signature: "subtract"})
+		mul = ext.NewScalarFuncVariant(ext.FunctionID{URN: substraitExtURN, Signature: "multiply"})
 	)
 
 	baseSchema := types.NewRecordTypeFromTypes(

--- a/expr/functions.go
+++ b/expr/functions.go
@@ -271,6 +271,22 @@ func ResolveScalarFunctionVariant(
 	return resolveFunctionVariant(reg, urn, name, args, reg.c.GetAllScalarFunctions())
 }
 
+// ResolveAggregateFunctionVariant resolves a simple aggregate function name and arguments
+// to the ID of a registered function variant.
+func ResolveAggregateFunctionVariant(
+	reg ExtensionRegistry, urn string, name string, args ...types.FuncArg,
+) (extensions.FunctionID, error) {
+	return resolveFunctionVariant(reg, urn, name, args, reg.c.GetAllAggregateFunctions())
+}
+
+// ResolveWindowFunctionVariant resolves a simple window function name and arguments
+// to the ID of a registered function variant.
+func ResolveWindowFunctionVariant(
+	reg ExtensionRegistry, urn string, name string, args ...types.FuncArg,
+) (extensions.FunctionID, error) {
+	return resolveFunctionVariant(reg, urn, name, args, reg.c.GetAllWindowFunctions())
+}
+
 func resolveVariant[T variant](
 	id extensions.FunctionID, reg ExtensionRegistry, getter func(extensions.FunctionID) (T, bool),
 	args []types.FuncArg,

--- a/expr/functions.go
+++ b/expr/functions.go
@@ -164,7 +164,7 @@ func BoundFromProto(b *proto.Expression_WindowFunction_Bound) Bound {
 }
 
 type FunctionInvocation interface {
-	Signature() string
+	CompoundName() string
 	ID() extensions.FunctionID
 	GetOptions() []*types.FunctionOption
 	GetArgTypes() []types.Type
@@ -207,7 +207,7 @@ func NewCustomScalarFunc(
 type variant interface {
 	*extensions.ScalarFunctionVariant | *extensions.AggregateFunctionVariant | *extensions.WindowFunctionVariant
 	Name() string
-	Signature() string
+	CompoundName() string
 	ID() extensions.FunctionID
 	ResolveType([]types.Type, extensions.Set) (types.Type, error)
 }
@@ -248,7 +248,7 @@ func resolveFunctionVariant[T variant](
 		if _, err := variant.ResolveType(argTypes, reg.Set); err != nil {
 			continue
 		}
-		if variant.Signature() == exactSignature {
+		if variant.CompoundName() == exactSignature {
 			return variant.ID(), nil
 		}
 		matches = append(matches, variant)
@@ -342,11 +342,8 @@ func NewScalarFunc(
 	}, nil
 }
 
-func (s *ScalarFunction) Name() string { return s.declaration.Name() }
-func (s *ScalarFunction) Signature() string {
-	return s.declaration.Signature()
-}
-
+func (s *ScalarFunction) Name() string                           { return s.declaration.Name() }
+func (s *ScalarFunction) CompoundName() string                   { return s.declaration.CompoundName() }
 func (s *ScalarFunction) ID() extensions.FunctionID              { return s.declaration.ID() }
 func (s *ScalarFunction) Variadic() *extensions.VariadicBehavior { return s.declaration.Variadic() }
 func (s *ScalarFunction) SessionDependant() bool                 { return s.declaration.SessionDependent() }
@@ -583,11 +580,8 @@ func NewWindowFunc(
 	}, nil
 }
 
-func (w *WindowFunction) Name() string { return w.declaration.Name() }
-func (w *WindowFunction) Signature() string {
-	return w.declaration.Signature()
-}
-
+func (w *WindowFunction) Name() string                            { return w.declaration.Name() }
+func (w *WindowFunction) CompoundName() string                    { return w.declaration.CompoundName() }
 func (w *WindowFunction) ID() extensions.FunctionID               { return w.declaration.ID() }
 func (w *WindowFunction) Variadic() *extensions.VariadicBehavior  { return w.declaration.Variadic() }
 func (w *WindowFunction) SessionDependant() bool                  { return w.declaration.SessionDependent() }
@@ -922,11 +916,8 @@ func NewAggregateFunctionFromProto(
 	}, nil
 }
 
-func (a *AggregateFunction) Name() string { return a.declaration.Name() }
-func (a *AggregateFunction) Signature() string {
-	return a.declaration.Signature()
-}
-
+func (a *AggregateFunction) Name() string                            { return a.declaration.Name() }
+func (a *AggregateFunction) CompoundName() string                    { return a.declaration.CompoundName() }
 func (a *AggregateFunction) ID() extensions.FunctionID               { return a.declaration.ID() }
 func (a *AggregateFunction) Variadic() *extensions.VariadicBehavior  { return a.declaration.Variadic() }
 func (a *AggregateFunction) SessionDependant() bool                  { return a.declaration.SessionDependent() }

--- a/expr/functions.go
+++ b/expr/functions.go
@@ -210,8 +210,7 @@ type variant interface {
 }
 
 func resolveVariant[T variant](
-	id extensions.ID, reg ExtensionRegistry, getter func(extensions.ID) (T, bool),
-	args []types.FuncArg,
+	id extensions.ID, reg ExtensionRegistry, getter func(extensions.ID) (T, bool), args []types.FuncArg,
 ) (T, types.Type, error) {
 	argTypes := make([]types.Type, 0, len(args))
 	for _, arg := range args {
@@ -225,32 +224,8 @@ func resolveVariant[T variant](
 
 	decl, found := getter(id)
 	if !found {
-		if strings.IndexByte(id.Name, ':') == -1 {
-			sigs := make([]string, len(argTypes))
-			for i, t := range argTypes {
-				if t == types.CommonEnumType {
-					// enum value
-					sigs[i] = extensions.EnumTypeString
-				} else if ud, ok := t.(*types.UserDefinedType); ok {
-					id, found := reg.DecodeType(ud.TypeReference)
-					if !found {
-						return nil, nil, fmt.Errorf("%w: could not find type for reference %d",
-							substraitgo.ErrNotFound, ud.TypeReference)
-					}
-					sigs[i] = "u!" + id.Name
-				} else {
-					sigs[i] = t.ShortString()
-				}
-			}
-			id.Name += ":" + strings.Join(sigs, "_")
-			if decl, found = getter(id); !found {
-				return nil, nil, fmt.Errorf("%w: could not find matching function for id: %s",
-					substraitgo.ErrNotFound, id)
-			}
-		} else {
-			return nil, nil, fmt.Errorf("%w: could not find matching function for id: %s",
-				substraitgo.ErrNotFound, id)
-		}
+		return nil, nil, fmt.Errorf("%w: could not find matching function for id: %s",
+			substraitgo.ErrNotFound, id)
 	}
 
 	outType, err := decl.ResolveType(argTypes, reg.Set)
@@ -263,12 +238,6 @@ func resolveVariant[T variant](
 
 // NewScalarFunc validates that the specified ID can be found in the
 // registry via LookupScalarFunction and retrieves a function anchor to use.
-//
-// If the name in the ID is not currently a compound signature and cannot
-// be found in the registry, we'll attempt to construct the compound signature
-// based on the types of the provided arguments and look it up that way.
-// If both attempts fail to lookup the function, a substraitgo.ErrNotFound
-// will be returned.
 //
 // Currently the options are not validated against the function declaration
 // but the number of arguments and their types will be validated in order to

--- a/expr/functions.go
+++ b/expr/functions.go
@@ -164,7 +164,7 @@ func BoundFromProto(b *proto.Expression_WindowFunction_Bound) Bound {
 }
 
 type FunctionInvocation interface {
-	CompoundName() string
+	Signature() string
 	ID() extensions.FunctionID
 	GetOptions() []*types.FunctionOption
 	GetArgTypes() []types.Type
@@ -206,7 +206,69 @@ func NewCustomScalarFunc(
 
 type variant interface {
 	*extensions.ScalarFunctionVariant | *extensions.AggregateFunctionVariant | *extensions.WindowFunctionVariant
+	Name() string
+	Signature() string
+	ID() extensions.FunctionID
 	ResolveType([]types.Type, extensions.Set) (types.Type, error)
+}
+
+func exactVariantSignature(name string, argTypes []types.Type, reg ExtensionRegistry) (string, error) {
+	signatures := make([]string, len(argTypes))
+	for i, argType := range argTypes {
+		if argType == types.CommonEnumType {
+			signatures[i] = extensions.EnumTypeString
+		} else if userDefinedType, ok := argType.(*types.UserDefinedType); ok {
+			id, found := reg.DecodeType(userDefinedType.TypeReference)
+			if !found {
+				return "", fmt.Errorf("%w: could not find type for reference %d",
+					substraitgo.ErrNotFound, userDefinedType.TypeReference)
+			}
+			signatures[i] = "u!" + id.Name
+		} else {
+			signatures[i] = argType.ShortString()
+		}
+	}
+	return name + ":" + strings.Join(signatures, "_"), nil
+}
+
+func resolveFunctionVariant[T variant](
+	reg ExtensionRegistry, urn string, name string, args []types.FuncArg, variants []T,
+) (extensions.FunctionID, error) {
+	argTypes := getArgTypes(args)
+	exactSignature, err := exactVariantSignature(name, argTypes, reg)
+	if err != nil {
+		return extensions.FunctionID{}, err
+	}
+
+	var matches []T
+	for _, variant := range variants {
+		if variant.ID().URN != urn || variant.Name() != name {
+			continue
+		}
+		if _, err := variant.ResolveType(argTypes, reg.Set); err != nil {
+			continue
+		}
+		if variant.Signature() == exactSignature {
+			return variant.ID(), nil
+		}
+		matches = append(matches, variant)
+	}
+
+	if len(matches) == 0 {
+		return extensions.FunctionID{}, fmt.Errorf("%w: could not find matching function for name: %s", substraitgo.ErrNotFound, name)
+	}
+	if len(matches) > 1 {
+		return extensions.FunctionID{}, fmt.Errorf("%w: found multiple matching function variants for name: %s", substraitgo.ErrInvalidExpr, name)
+	}
+	return matches[0].ID(), nil
+}
+
+// ResolveScalarFunctionVariant resolves a simple scalar function name and arguments
+// to the ID of a registered function variant.
+func ResolveScalarFunctionVariant(
+	reg ExtensionRegistry, urn string, name string, args ...types.FuncArg,
+) (extensions.FunctionID, error) {
+	return resolveFunctionVariant(reg, urn, name, args, reg.c.GetAllScalarFunctions())
 }
 
 func resolveVariant[T variant](
@@ -264,8 +326,11 @@ func NewScalarFunc(
 	}, nil
 }
 
-func (s *ScalarFunction) Name() string                           { return s.declaration.Name() }
-func (s *ScalarFunction) CompoundName() string                   { return s.declaration.CompoundName() }
+func (s *ScalarFunction) Name() string { return s.declaration.Name() }
+func (s *ScalarFunction) Signature() string {
+	return s.declaration.Signature()
+}
+
 func (s *ScalarFunction) ID() extensions.FunctionID              { return s.declaration.ID() }
 func (s *ScalarFunction) Variadic() *extensions.VariadicBehavior { return s.declaration.Variadic() }
 func (s *ScalarFunction) SessionDependant() bool                 { return s.declaration.SessionDependent() }
@@ -502,8 +567,11 @@ func NewWindowFunc(
 	}, nil
 }
 
-func (w *WindowFunction) Name() string                            { return w.declaration.Name() }
-func (w *WindowFunction) CompoundName() string                    { return w.declaration.CompoundName() }
+func (w *WindowFunction) Name() string { return w.declaration.Name() }
+func (w *WindowFunction) Signature() string {
+	return w.declaration.Signature()
+}
+
 func (w *WindowFunction) ID() extensions.FunctionID               { return w.declaration.ID() }
 func (w *WindowFunction) Variadic() *extensions.VariadicBehavior  { return w.declaration.Variadic() }
 func (w *WindowFunction) SessionDependant() bool                  { return w.declaration.SessionDependent() }
@@ -838,8 +906,11 @@ func NewAggregateFunctionFromProto(
 	}, nil
 }
 
-func (a *AggregateFunction) Name() string                            { return a.declaration.Name() }
-func (a *AggregateFunction) CompoundName() string                    { return a.declaration.CompoundName() }
+func (a *AggregateFunction) Name() string { return a.declaration.Name() }
+func (a *AggregateFunction) Signature() string {
+	return a.declaration.Signature()
+}
+
 func (a *AggregateFunction) ID() extensions.FunctionID               { return a.declaration.ID() }
 func (a *AggregateFunction) Variadic() *extensions.VariadicBehavior  { return a.declaration.Variadic() }
 func (a *AggregateFunction) SessionDependant() bool                  { return a.declaration.SessionDependent() }

--- a/expr/testdata/lambda/basic-lambda.json
+++ b/expr/testdata/lambda/basic-lambda.json
@@ -14,7 +14,7 @@
       "extensionFunction": {
         "extensionUrnReference": 1,
         "functionAnchor": 1,
-        "name": "transform"
+        "name": "transform:list_func"
       }
     }
   ],

--- a/expr/testdata/lambda/lambda-field-ref.json
+++ b/expr/testdata/lambda/lambda-field-ref.json
@@ -10,7 +10,7 @@
       "extensionFunction": {
         "extensionUrnReference": 1,
         "functionAnchor": 1,
-        "name": "transform"
+        "name": "transform:list_func"
       }
     }
   ],

--- a/expr/testdata/lambda/lambda-with-function.json
+++ b/expr/testdata/lambda/lambda-with-function.json
@@ -21,7 +21,7 @@
       "extensionFunction": {
         "extensionUrnReference": 2,
         "functionAnchor": 2,
-        "name": "transform"
+        "name": "transform:list_func"
       }
     }
   ],

--- a/expr/testdata/lambda/lambda-with-list-transform.json
+++ b/expr/testdata/lambda/lambda-with-list-transform.json
@@ -21,7 +21,7 @@
       "extensionFunction": {
         "extensionUrnReference": 2,
         "functionAnchor": 2,
-        "name": "transform"
+        "name": "transform:list_func"
       }
     }
   ],

--- a/expr/testdata/lambda/nested-lambda-outer-ref.json
+++ b/expr/testdata/lambda/nested-lambda-outer-ref.json
@@ -10,7 +10,7 @@
       "extensionFunction": {
         "extensionUrnReference": 1,
         "functionAnchor": 1,
-        "name": "transform"
+        "name": "transform:list_func"
       }
     }
   ],

--- a/expr/window_function_test.go
+++ b/expr/window_function_test.go
@@ -16,7 +16,7 @@ func TestWindowFunctionBoundsType(t *testing.T) {
 	col := extensions.GetDefaultCollectionWithNoError()
 	reg := expr.NewEmptyExtensionRegistry(col)
 
-	sumID := extensions.FunctionID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Name: "sum:i64"}
+	sumID := extensions.FunctionID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Signature: "sum:i64"}
 
 	schema := types.NewRecordTypeFromTypes([]types.Type{
 		&types.Int64Type{Nullability: types.NullabilityRequired},
@@ -70,7 +70,7 @@ func TestWindowFunctionBoundsTypeDefault(t *testing.T) {
 	col := extensions.GetDefaultCollectionWithNoError()
 	reg := expr.NewEmptyExtensionRegistry(col)
 
-	sumID := extensions.FunctionID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Name: "sum:i64"}
+	sumID := extensions.FunctionID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Signature: "sum:i64"}
 
 	schema := types.NewRecordTypeFromTypes([]types.Type{
 		&types.Int64Type{Nullability: types.NullabilityRequired},
@@ -101,7 +101,7 @@ func TestWindowFunctionRANGERequiresSingleSort(t *testing.T) {
 	col := extensions.GetDefaultCollectionWithNoError()
 	reg := expr.NewEmptyExtensionRegistry(col)
 
-	sumID := extensions.FunctionID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Name: "sum:i64"}
+	sumID := extensions.FunctionID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Signature: "sum:i64"}
 
 	schema := types.NewRecordTypeFromTypes([]types.Type{
 		&types.Int64Type{Nullability: types.NullabilityRequired},

--- a/expr/window_function_test.go
+++ b/expr/window_function_test.go
@@ -16,7 +16,7 @@ func TestWindowFunctionBoundsType(t *testing.T) {
 	col := extensions.GetDefaultCollectionWithNoError()
 	reg := expr.NewEmptyExtensionRegistry(col)
 
-	sumID := extensions.ID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Name: "sum"}
+	sumID := extensions.ID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Name: "sum:i64"}
 
 	schema := types.NewRecordTypeFromTypes([]types.Type{
 		&types.Int64Type{Nullability: types.NullabilityRequired},
@@ -70,7 +70,7 @@ func TestWindowFunctionBoundsTypeDefault(t *testing.T) {
 	col := extensions.GetDefaultCollectionWithNoError()
 	reg := expr.NewEmptyExtensionRegistry(col)
 
-	sumID := extensions.ID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Name: "sum"}
+	sumID := extensions.ID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Name: "sum:i64"}
 
 	schema := types.NewRecordTypeFromTypes([]types.Type{
 		&types.Int64Type{Nullability: types.NullabilityRequired},
@@ -101,7 +101,7 @@ func TestWindowFunctionRANGERequiresSingleSort(t *testing.T) {
 	col := extensions.GetDefaultCollectionWithNoError()
 	reg := expr.NewEmptyExtensionRegistry(col)
 
-	sumID := extensions.ID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Name: "sum"}
+	sumID := extensions.ID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Name: "sum:i64"}
 
 	schema := types.NewRecordTypeFromTypes([]types.Type{
 		&types.Int64Type{Nullability: types.NullabilityRequired},

--- a/extensions/extension_id.go
+++ b/extensions/extension_id.go
@@ -13,9 +13,13 @@ type ExtensionID struct {
 // TypeID is the unique identifier for a Substrait extension type.
 type TypeID ExtensionID
 
-// FunctionID is the unique identifier for a Substrait extension function.
-// Name is the registered compound function variant name.
-type FunctionID ExtensionID
+// FunctionID is the unique identifier for a Substrait extension function variant.
+type FunctionID struct {
+	// URN identifies the extension file that declares the function.
+	URN string
+	// Signature is the registered compound function variant name.
+	Signature string
+}
 
 // TypeVariationID is the unique identifier for a Substrait extension type variation.
 type TypeVariationID ExtensionID

--- a/extensions/extension_id.go
+++ b/extensions/extension_id.go
@@ -14,8 +14,7 @@ type ExtensionID struct {
 type TypeID ExtensionID
 
 // FunctionID is the unique identifier for a Substrait extension function.
-// For lookups, Name may be the simple function name. As a unique identifier,
-// Name is the compound function name.
+// Name is the registered compound function variant name.
 type FunctionID ExtensionID
 
 // TypeVariationID is the unique identifier for a Substrait extension type variation.

--- a/extensions/extension_mgr.go
+++ b/extensions/extension_mgr.go
@@ -130,7 +130,7 @@ var void = struct{}{}
 type variants interface {
 	*ScalarFunctionVariant | *AggregateFunctionVariant | *WindowFunctionVariant
 	Name() string
-	Signature() string
+	CompoundName() string
 }
 
 type extFn[T variants] interface {
@@ -139,7 +139,7 @@ type extFn[T variants] interface {
 
 func addToMaps[T variants](id FunctionID, fn extFn[T], m map[FunctionID]T) {
 	for _, v := range fn.GetVariants(id.URN) {
-		id.Signature = v.Signature()
+		id.Signature = v.CompoundName()
 		m[id] = v
 	}
 }

--- a/extensions/extension_mgr.go
+++ b/extensions/extension_mgr.go
@@ -130,7 +130,7 @@ var void = struct{}{}
 type variants interface {
 	*ScalarFunctionVariant | *AggregateFunctionVariant | *WindowFunctionVariant
 	Name() string
-	CompoundName() string
+	Signature() string
 }
 
 type extFn[T variants] interface {
@@ -139,7 +139,7 @@ type extFn[T variants] interface {
 
 func addToMaps[T variants](id FunctionID, fn extFn[T], m map[FunctionID]T) {
 	for _, v := range fn.GetVariants(id.URN) {
-		id.Signature = v.CompoundName()
+		id.Signature = v.Signature()
 		m[id] = v
 	}
 }

--- a/extensions/extension_mgr.go
+++ b/extensions/extension_mgr.go
@@ -94,15 +94,12 @@ func loadExtensionFile(collection *Collection, substraitFS embed.FS, ent fs.DirE
 // ID is the unique identifier for a substrait object
 type ID struct {
 	URN string
-	// Name of the object. For functions, a simple name may be used for lookups,
-	// but as a unique identifier the compound name will be used
+	// Name of the object.
 	Name string
 }
 
 type Collection struct {
 	urnSet map[string]struct{}
-
-	simpleNameMap map[ID]string
 
 	scalarMap        map[ID]*ScalarFunctionVariant
 	aggregateMap     map[ID]*AggregateFunctionVariant
@@ -136,58 +133,35 @@ type variants interface {
 	CompoundName() string
 }
 
-func checkMaps[T variants](id ID, m map[ID]T, simpleNames map[ID]string) (T, bool) {
-	if sv, ok := m[id]; ok {
-		return sv, true
-	}
-
-	if compound, ok := simpleNames[id]; ok {
-		id.Name = compound
-		if sv, ok := m[id]; ok {
-			return sv, true
-		}
-	}
-
-	return nil, false
-}
-
 type extFn[T variants] interface {
 	GetVariants(urn string) []T
 }
 
-func addToMaps[T variants](id ID, fn extFn[T], m map[ID]T, simpleMap map[string]string) {
-	variants := fn.GetVariants(id.URN)
-	for _, v := range variants {
+func addToMaps[T variants](id ID, fn extFn[T], m map[ID]T) {
+	for _, v := range fn.GetVariants(id.URN) {
 		id.Name = v.CompoundName()
 		m[id] = v
-	}
-
-	if len(variants) == 1 {
-		v := variants[0]
-		if _, ok := simpleMap[v.Name()]; ok {
-			delete(simpleMap, v.Name())
-		} else {
-			simpleMap[v.Name()] = v.CompoundName()
-		}
 	}
 }
 
 func (c *Collection) GetScalarFunc(id ID) (*ScalarFunctionVariant, bool) {
-	return checkMaps(id, c.scalarMap, c.simpleNameMap)
+	fn, ok := c.scalarMap[id]
+	return fn, ok
 }
 
 func (c *Collection) GetAggregateFunc(id ID) (*AggregateFunctionVariant, bool) {
-	return checkMaps(id, c.aggregateMap, c.simpleNameMap)
+	fn, ok := c.aggregateMap[id]
+	return fn, ok
 }
 
 func (c *Collection) GetWindowFunc(id ID) (*WindowFunctionVariant, bool) {
-	return checkMaps(id, c.windowMap, c.simpleNameMap)
+	fn, ok := c.windowMap[id]
+	return fn, ok
 }
 
 func (c *Collection) init() {
 	if c.urnSet == nil {
 		c.urnSet = make(map[string]struct{})
-		c.simpleNameMap = make(map[ID]string)
 		c.scalarMap = make(map[ID]*ScalarFunctionVariant)
 		c.aggregateMap = make(map[ID]*AggregateFunctionVariant)
 		c.windowMap = make(map[ID]*WindowFunctionVariant)
@@ -238,30 +212,25 @@ func (c *Collection) Load(r io.Reader) error {
 		c.typeVariationMap[id] = t
 	}
 
-	// if there is only one implementation for a given function
-	// it should be findable by its simple name in addition to the
-	// compound name.
-	simpleNames := make(map[string]string)
-
 	for _, f := range file.ScalarFunctions {
 		if err := defaults.Set(&f); err != nil {
 			return fmt.Errorf("failure setting defaults for scalar functions: %w", err)
 		}
-		addToMaps[*ScalarFunctionVariant](id, &f, c.scalarMap, simpleNames)
+		addToMaps[*ScalarFunctionVariant](id, &f, c.scalarMap)
 	}
 
 	for _, f := range file.AggregateFunctions {
 		if err := defaults.Set(&f); err != nil {
 			return fmt.Errorf("failure setting defaults for aggregate functions: %w", err)
 		}
-		addToMaps[*AggregateFunctionVariant](id, &f, c.aggregateMap, simpleNames)
+		addToMaps[*AggregateFunctionVariant](id, &f, c.aggregateMap)
 	}
 
 	for _, f := range file.WindowFunctions {
 		if err := defaults.Set(&f); err != nil {
 			return fmt.Errorf("failure setting defaults for window functions: %w", err)
 		}
-		addToMaps[*WindowFunctionVariant](id, &f, c.windowMap, simpleNames)
+		addToMaps[*WindowFunctionVariant](id, &f, c.windowMap)
 	}
 
 	// Aggregate functions can be used as Window Functions
@@ -284,13 +253,7 @@ func (c *Collection) Load(r io.Reader) error {
 		if err := defaults.Set(&wf); err != nil {
 			return fmt.Errorf("failure setting defaults for window functions: %w", err)
 		}
-		addToMaps[*WindowFunctionVariant](id, &wf, c.windowMap, simpleNames)
-	}
-
-	// add simple name aliases
-	for k, v := range simpleNames {
-		id.Name = k
-		c.simpleNameMap[id] = v
+		addToMaps[*WindowFunctionVariant](id, &wf, c.windowMap)
 	}
 
 	return nil

--- a/extensions/extension_mgr.go
+++ b/extensions/extension_mgr.go
@@ -159,6 +159,17 @@ func (c *Collection) GetWindowFunc(id ID) (*WindowFunctionVariant, bool) {
 	return fn, ok
 }
 
+func (c *Collection) IsRegisteredFunction(id ID) bool {
+	if _, ok := c.scalarMap[id]; ok {
+		return true
+	}
+	if _, ok := c.aggregateMap[id]; ok {
+		return true
+	}
+	_, ok := c.windowMap[id]
+	return ok
+}
+
 func (c *Collection) init() {
 	if c.urnSet == nil {
 		c.urnSet = make(map[string]struct{})

--- a/extensions/extension_mgr.go
+++ b/extensions/extension_mgr.go
@@ -139,7 +139,7 @@ type extFn[T variants] interface {
 
 func addToMaps[T variants](id FunctionID, fn extFn[T], m map[FunctionID]T) {
 	for _, v := range fn.GetVariants(id.URN) {
-		id.Name = v.CompoundName()
+		id.Signature = v.CompoundName()
 		m[id] = v
 	}
 }
@@ -408,7 +408,7 @@ func (e *set) ToProto(c *Collection) ([]*extensions.SimpleExtensionURN, []*exten
 				ExtensionFunction: &extensions.SimpleExtensionDeclaration_ExtensionFunction{
 					ExtensionUrnReference: urnBackRef[id.URN],
 					FunctionAnchor:        anchor,
-					Name:                  id.Name,
+					Name:                  id.Signature,
 				},
 			},
 		})
@@ -627,8 +627,8 @@ func GetExtensionSet(plan TopLevel, c *Collection) (Set, error) {
 				return nil, err
 			}
 			ret.encodeFunc(ef.FunctionAnchor, FunctionID{
-				URN:  urn,
-				Name: ef.Name,
+				URN:       urn,
+				Signature: ef.Name,
 			})
 		}
 	}

--- a/extensions/extension_mgr.go
+++ b/extensions/extension_mgr.go
@@ -159,6 +159,7 @@ func (c *Collection) GetWindowFunc(id ID) (*WindowFunctionVariant, bool) {
 	return fn, ok
 }
 
+// IsRegisteredFunction reports whether id resolves to a registered function variant.
 func (c *Collection) IsRegisteredFunction(id ID) bool {
 	if _, ok := c.scalarMap[id]; ok {
 		return true

--- a/extensions/extension_mgr_test.go
+++ b/extensions/extension_mgr_test.go
@@ -107,7 +107,7 @@ func TestLoadExtensionCollection(t *testing.T) {
 		assert.True(t, ok)
 
 		assert.Equal(t, "add", add.Name())
-		assert.Equal(t, "add:i8_i8", add.CompoundName())
+		assert.Equal(t, "add:i8_i8", add.Signature())
 		assert.Equal(t, "Add two values.", add.Description())
 		assert.Equal(t, urn, add.URN())
 		assert.Equal(t, map[string]extensions.Option{"overflow": {
@@ -134,7 +134,7 @@ func TestLoadExtensionCollection(t *testing.T) {
 		assert.True(t, c.IsRegisteredFunction(subID))
 
 		assert.Equal(t, "subtract", sub.Name())
-		assert.Equal(t, "subtract:i16_i16", sub.CompoundName())
+		assert.Equal(t, "subtract:i16_i16", sub.Signature())
 
 		i16Req := &types.Int16Type{Nullability: types.NullabilityRequired}
 		ty, err := sub.ResolveType([]types.Type{i16Req, i16Req}, extensions.NewSet())
@@ -216,13 +216,13 @@ func TestDefaultCollection(t *testing.T) {
 	)
 
 	tests := []struct {
-		typ          funcType
-		urn          string
-		name         string
-		compoundName string
-		nargs        int
-		options      map[string]extensions.Option
-		variadic     *extensions.VariadicBehavior
+		typ       funcType
+		urn       string
+		name      string
+		signature string
+		nargs     int
+		options   map[string]extensions.Option
+		variadic  *extensions.VariadicBehavior
 	}{
 		{scalarFunc, extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
 			"add", "add:i32_i32", 2, map[string]extensions.Option{"overflow": {Values: []string{"SILENT", "SATURATE", "ERROR"}}},
@@ -271,12 +271,12 @@ func TestDefaultCollection(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.compoundName, func(t *testing.T) {
+		t.Run(tt.signature, func(t *testing.T) {
 			var (
 				variant extensions.FunctionVariant
 				ok      bool
 
-				id = extensions.FunctionID{URN: tt.urn, Signature: tt.compoundName}
+				id = extensions.FunctionID{URN: tt.urn, Signature: tt.signature}
 			)
 			switch tt.typ {
 			case scalarFunc:
@@ -291,7 +291,7 @@ func TestDefaultCollection(t *testing.T) {
 			require.NotNil(t, variant)
 
 			assert.Equal(t, tt.name, variant.Name())
-			assert.Equal(t, tt.compoundName, variant.CompoundName())
+			assert.Equal(t, tt.signature, variant.Signature())
 			assert.Equal(t, tt.options, variant.Options())
 			assert.Equal(t, tt.urn, variant.URN())
 			assert.Len(t, variant.Args(), tt.nargs)
@@ -457,7 +457,7 @@ func TestAggregateToWindow(t *testing.T) {
 
 		// Check that basic properties are preserved
 		assert.Equal(t, aggFunc.Name(), winFunc.Name())
-		assert.Equal(t, aggFunc.CompoundName(), winFunc.CompoundName())
+		assert.Equal(t, aggFunc.Signature(), winFunc.Signature())
 		assert.Equal(t, aggFunc.Description(), winFunc.Description())
 		assert.Equal(t, aggFunc.URN(), winFunc.URN())
 		assert.Equal(t, aggFunc.Args(), winFunc.Args())

--- a/extensions/extension_mgr_test.go
+++ b/extensions/extension_mgr_test.go
@@ -107,7 +107,7 @@ func TestLoadExtensionCollection(t *testing.T) {
 		assert.True(t, ok)
 
 		assert.Equal(t, "add", add.Name())
-		assert.Equal(t, "add:i8_i8", add.Signature())
+		assert.Equal(t, "add:i8_i8", add.CompoundName())
 		assert.Equal(t, "Add two values.", add.Description())
 		assert.Equal(t, urn, add.URN())
 		assert.Equal(t, map[string]extensions.Option{"overflow": {
@@ -134,7 +134,7 @@ func TestLoadExtensionCollection(t *testing.T) {
 		assert.True(t, c.IsRegisteredFunction(subID))
 
 		assert.Equal(t, "subtract", sub.Name())
-		assert.Equal(t, "subtract:i16_i16", sub.Signature())
+		assert.Equal(t, "subtract:i16_i16", sub.CompoundName())
 
 		i16Req := &types.Int16Type{Nullability: types.NullabilityRequired}
 		ty, err := sub.ResolveType([]types.Type{i16Req, i16Req}, extensions.NewSet())
@@ -291,7 +291,7 @@ func TestDefaultCollection(t *testing.T) {
 			require.NotNil(t, variant)
 
 			assert.Equal(t, tt.name, variant.Name())
-			assert.Equal(t, tt.signature, variant.Signature())
+			assert.Equal(t, tt.signature, variant.CompoundName())
 			assert.Equal(t, tt.options, variant.Options())
 			assert.Equal(t, tt.urn, variant.URN())
 			assert.Len(t, variant.Args(), tt.nargs)
@@ -457,7 +457,7 @@ func TestAggregateToWindow(t *testing.T) {
 
 		// Check that basic properties are preserved
 		assert.Equal(t, aggFunc.Name(), winFunc.Name())
-		assert.Equal(t, aggFunc.Signature(), winFunc.Signature())
+		assert.Equal(t, aggFunc.CompoundName(), winFunc.CompoundName())
 		assert.Equal(t, aggFunc.Description(), winFunc.Description())
 		assert.Equal(t, aggFunc.URN(), winFunc.URN())
 		assert.Equal(t, aggFunc.Args(), winFunc.Args())

--- a/extensions/extension_mgr_test.go
+++ b/extensions/extension_mgr_test.go
@@ -103,7 +103,7 @@ func TestLoadExtensionCollection(t *testing.T) {
 	})
 
 	t.Run("compound func signature", func(t *testing.T) {
-		add, ok := c.GetScalarFunc(extensions.FunctionID{URN: urn, Name: "add:i8_i8"})
+		add, ok := c.GetScalarFunc(extensions.FunctionID{URN: urn, Signature: "add:i8_i8"})
 		assert.True(t, ok)
 
 		assert.Equal(t, "add", add.Name())
@@ -121,13 +121,13 @@ func TestLoadExtensionCollection(t *testing.T) {
 	})
 
 	t.Run("functions need compound names", func(t *testing.T) {
-		addID := extensions.FunctionID{URN: urn, Name: "add"}
+		addID := extensions.FunctionID{URN: urn, Signature: "add"}
 		add, ok := c.GetScalarFunc(addID)
 		assert.Nil(t, add)
 		assert.False(t, ok)
 		assert.False(t, c.IsRegisteredFunction(addID))
 
-		subID := extensions.FunctionID{URN: urn, Name: "subtract:i16_i16"}
+		subID := extensions.FunctionID{URN: urn, Signature: "subtract:i16_i16"}
 		sub, ok := c.GetScalarFunc(subID)
 		assert.True(t, ok)
 		assert.NotNil(t, sub)
@@ -143,11 +143,11 @@ func TestLoadExtensionCollection(t *testing.T) {
 	})
 
 	t.Run("same fn name different args", func(t *testing.T) {
-		ct, ok := c.GetAggregateFunc(extensions.FunctionID{URN: urn, Name: "count:"})
+		ct, ok := c.GetAggregateFunc(extensions.FunctionID{URN: urn, Signature: "count:"})
 		assert.True(t, ok)
 		assert.NotNil(t, ct)
 
-		ctArgs, ok := c.GetAggregateFunc(extensions.FunctionID{URN: urn, Name: "count:any"})
+		ctArgs, ok := c.GetAggregateFunc(extensions.FunctionID{URN: urn, Signature: "count:any"})
 		assert.True(t, ok)
 		assert.NotNil(t, ctArgs)
 
@@ -175,8 +175,7 @@ func TestExtensionSet(t *testing.T) {
 	assert.False(t, ok)
 
 	t.Run("add anchors", func(t *testing.T) {
-		id := extensions.FunctionID{URN: urn}
-		id.Name = "add:i8_i8"
+		id := extensions.FunctionID{URN: urn, Signature: "add:i8_i8"}
 
 		anchor := s.GetFuncAnchor(id)
 		assert.EqualValues(t, 1, anchor)
@@ -184,12 +183,12 @@ func TestExtensionSet(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, id, nid)
 
-		id.Name = "subtract:i8_i8"
+		id.Signature = "subtract:i8_i8"
 		anchor = s.GetFuncAnchor(id)
 		assert.EqualValues(t, 2, anchor)
 
-		id.Name = "point"
-		anchor = s.GetTypeAnchor(extensions.TypeID(id))
+		typeID := extensions.TypeID{URN: urn, Name: "point"}
+		anchor = s.GetTypeAnchor(typeID)
 		assert.EqualValues(t, 1, anchor)
 	})
 
@@ -277,7 +276,7 @@ func TestDefaultCollection(t *testing.T) {
 				variant extensions.FunctionVariant
 				ok      bool
 
-				id = extensions.FunctionID{URN: tt.urn, Name: tt.compoundName}
+				id = extensions.FunctionID{URN: tt.urn, Signature: tt.compoundName}
 			)
 			switch tt.typ {
 			case scalarFunc:
@@ -330,7 +329,7 @@ func TestCollection_GetAllScalarFunctions(t *testing.T) {
 		t.Run(tt.signature, func(t *testing.T) {
 			assert.True(t, tt.isScalar || tt.isAggregate || tt.isWindow)
 			if tt.isScalar {
-				sf, ok := defaultExtensions.GetScalarFunc(extensions.FunctionID{URN: tt.urn, Name: tt.signature})
+				sf, ok := defaultExtensions.GetScalarFunc(extensions.FunctionID{URN: tt.urn, Signature: tt.signature})
 				assert.True(t, ok)
 				assert.Contains(t, scalarFunctions, sf)
 				// verify that default nullability is set to MIRROR
@@ -339,12 +338,12 @@ func TestCollection_GetAllScalarFunctions(t *testing.T) {
 				assert.True(t, sf.Deterministic())
 			}
 			if tt.isAggregate {
-				af, ok := defaultExtensions.GetAggregateFunc(extensions.FunctionID{URN: tt.urn, Name: tt.signature})
+				af, ok := defaultExtensions.GetAggregateFunc(extensions.FunctionID{URN: tt.urn, Signature: tt.signature})
 				assert.True(t, ok)
 				assert.Contains(t, aggregateFunctions, af)
 			}
 			if tt.isWindow {
-				wf, ok := defaultExtensions.GetWindowFunc(extensions.FunctionID{URN: tt.urn, Name: tt.signature})
+				wf, ok := defaultExtensions.GetWindowFunc(extensions.FunctionID{URN: tt.urn, Signature: tt.signature})
 				assert.True(t, ok)
 				assert.Contains(t, windowFunctions, wf)
 			}
@@ -416,7 +415,7 @@ scalar_functions:
 				}
 			}
 
-			sf, ok := c.GetScalarFunc(extensions.FunctionID{URN: urn, Name: "f:i8"})
+			sf, ok := c.GetScalarFunc(extensions.FunctionID{URN: urn, Signature: "f:i8"})
 			require.True(t, ok)
 			assert.Equal(t, tt.expected, sf.Deterministic())
 		})
@@ -431,29 +430,29 @@ func TestAggregateToWindow(t *testing.T) {
 
 	t.Run("aggregate functions available as window functions", func(t *testing.T) {
 		// Test that the count function (with args) is available as both aggregate and window function
-		aggFunc, ok := c.GetAggregateFunc(extensions.FunctionID{URN: urn, Name: "count:any"})
+		aggFunc, ok := c.GetAggregateFunc(extensions.FunctionID{URN: urn, Signature: "count:any"})
 		require.True(t, ok)
 		require.NotNil(t, aggFunc)
 
-		winFunc, ok := c.GetWindowFunc(extensions.FunctionID{URN: urn, Name: "count:any"})
+		winFunc, ok := c.GetWindowFunc(extensions.FunctionID{URN: urn, Signature: "count:any"})
 		require.True(t, ok)
 		require.NotNil(t, winFunc)
 
 		// Test that the count function (without args) is available as both aggregate and window function
-		aggFuncNoArgs, ok := c.GetAggregateFunc(extensions.FunctionID{URN: urn, Name: "count:"})
+		aggFuncNoArgs, ok := c.GetAggregateFunc(extensions.FunctionID{URN: urn, Signature: "count:"})
 		require.True(t, ok)
 		require.NotNil(t, aggFuncNoArgs)
 
-		winFuncNoArgs, ok := c.GetWindowFunc(extensions.FunctionID{URN: urn, Name: "count:"})
+		winFuncNoArgs, ok := c.GetWindowFunc(extensions.FunctionID{URN: urn, Signature: "count:"})
 		require.True(t, ok)
 		require.NotNil(t, winFuncNoArgs)
 	})
 
 	t.Run("window functions preserve aggregate properties", func(t *testing.T) {
-		aggFunc, ok := c.GetAggregateFunc(extensions.FunctionID{URN: urn, Name: "count:any"})
+		aggFunc, ok := c.GetAggregateFunc(extensions.FunctionID{URN: urn, Signature: "count:any"})
 		require.True(t, ok)
 
-		winFunc, ok := c.GetWindowFunc(extensions.FunctionID{URN: urn, Name: "count:any"})
+		winFunc, ok := c.GetWindowFunc(extensions.FunctionID{URN: urn, Signature: "count:any"})
 		require.True(t, ok)
 
 		// Check that basic properties are preserved
@@ -482,7 +481,7 @@ func TestAggregateToWindow(t *testing.T) {
 	})
 
 	t.Run("aggregate functions used as window functions have streaming window type", func(t *testing.T) {
-		winFunc, ok := c.GetWindowFunc(extensions.FunctionID{URN: urn, Name: "count:any"})
+		winFunc, ok := c.GetWindowFunc(extensions.FunctionID{URN: urn, Signature: "count:any"})
 		require.True(t, ok)
 
 		// Check that the window type is STREAMING
@@ -490,10 +489,10 @@ func TestAggregateToWindow(t *testing.T) {
 	})
 
 	t.Run("type resolution works the same", func(t *testing.T) {
-		aggFunc, ok := c.GetAggregateFunc(extensions.FunctionID{URN: urn, Name: "count:any"})
+		aggFunc, ok := c.GetAggregateFunc(extensions.FunctionID{URN: urn, Signature: "count:any"})
 		require.True(t, ok)
 
-		winFunc, ok := c.GetWindowFunc(extensions.FunctionID{URN: urn, Name: "count:any"})
+		winFunc, ok := c.GetWindowFunc(extensions.FunctionID{URN: urn, Signature: "count:any"})
 		require.True(t, ok)
 
 		// Test type resolution with the same arguments
@@ -552,7 +551,7 @@ func TestAggregateToWindowWithDefaultCollection(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			id := extensions.FunctionID{URN: tc.urn, Name: tc.functionName}
+			id := extensions.FunctionID{URN: tc.urn, Signature: tc.functionName}
 
 			// Verify the aggregate function exists
 			aggFunc, ok := defaultExtensions.GetAggregateFunc(id)
@@ -984,7 +983,7 @@ scalar_functions:
 	var c extensions.Collection
 	require.NoError(t, c.Load(strings.NewReader(yaml)))
 
-	fn, _ := c.GetScalarFunc(extensions.FunctionID{URN: "extension:x:test", Name: "f:any"})
+	fn, _ := c.GetScalarFunc(extensions.FunctionID{URN: "extension:x:test", Signature: "f:any"})
 	i64 := &types.Int64Type{Nullability: types.NullabilityRequired}
 
 	result, err := fn.ResolveType([]types.Type{i64}, extensions.NewSet())
@@ -1011,7 +1010,7 @@ scalar_functions:
 	var c extensions.Collection
 	require.NoError(t, c.Load(strings.NewReader(yaml)))
 
-	fn, _ := c.GetScalarFunc(extensions.FunctionID{URN: "extension:x:test", Name: "f:any_any"})
+	fn, _ := c.GetScalarFunc(extensions.FunctionID{URN: "extension:x:test", Signature: "f:any_any"})
 	str := &types.StringType{Nullability: types.NullabilityRequired}
 	i64 := &types.Int64Type{Nullability: types.NullabilityRequired}
 
@@ -1041,7 +1040,7 @@ scalar_functions:
 	var c extensions.Collection
 	require.NoError(t, c.Load(strings.NewReader(yaml)))
 
-	fn, _ := c.GetScalarFunc(extensions.FunctionID{URN: "extension:x:test", Name: "f:any"})
+	fn, _ := c.GetScalarFunc(extensions.FunctionID{URN: "extension:x:test", Signature: "f:any"})
 	i64 := &types.Int64Type{Nullability: types.NullabilityRequired}
 
 	result, err := fn.ResolveType([]types.Type{i64}, extensions.NewSet())
@@ -1111,16 +1110,16 @@ window_functions:
 	typ, _ := c.GetType(extensions.TypeID{URN: urn, Name: "point"})
 	assert.Equal(t, "WGS84", typ.Metadata["coordinate_system"])
 
-	sf, _ := c.GetScalarFunc(extensions.FunctionID{URN: urn, Name: "distance:i32_i32"})
+	sf, _ := c.GetScalarFunc(extensions.FunctionID{URN: urn, Signature: "distance:i32_i32"})
 	assert.Equal(t, "vectorized", sf.Metadata()["performance_hint"])
 
-	af, _ := c.GetAggregateFunc(extensions.FunctionID{URN: urn, Name: "custom_sum:i32"})
+	af, _ := c.GetAggregateFunc(extensions.FunctionID{URN: urn, Signature: "custom_sum:i32"})
 	assert.Equal(t, "experimental", af.Metadata()["stability"])
 
-	wf, _ := c.GetWindowFunc(extensions.FunctionID{URN: urn, Name: "custom_rank:i32"})
+	wf, _ := c.GetWindowFunc(extensions.FunctionID{URN: urn, Signature: "custom_rank:i32"})
 	assert.Equal(t, "test-team", wf.Metadata()["author"])
 
-	wfFromAgg, _ := c.GetWindowFunc(extensions.FunctionID{URN: urn, Name: "custom_sum:i32"})
+	wfFromAgg, _ := c.GetWindowFunc(extensions.FunctionID{URN: urn, Signature: "custom_sum:i32"})
 	assert.Equal(t, "experimental", wfFromAgg.Metadata()["stability"])
 }
 
@@ -1128,6 +1127,6 @@ func TestDefaultCollectionHasNoMetadata(t *testing.T) {
 	c, err := extensions.GetDefaultCollection()
 	require.NoError(t, err)
 
-	addFunc, _ := c.GetScalarFunc(extensions.FunctionID{URN: "extension:io.substrait:functions_arithmetic", Name: "add:i32_i32"})
+	addFunc, _ := c.GetScalarFunc(extensions.FunctionID{URN: "extension:io.substrait:functions_arithmetic", Signature: "add:i32_i32"})
 	assert.Nil(t, addFunc.Metadata())
 }

--- a/extensions/extension_mgr_test.go
+++ b/extensions/extension_mgr_test.go
@@ -121,13 +121,17 @@ func TestLoadExtensionCollection(t *testing.T) {
 	})
 
 	t.Run("functions need compound names", func(t *testing.T) {
-		add, ok := c.GetScalarFunc(extensions.ID{URN: urn, Name: "add"})
+		addID := extensions.ID{URN: urn, Name: "add"}
+		add, ok := c.GetScalarFunc(addID)
 		assert.Nil(t, add)
 		assert.False(t, ok)
+		assert.False(t, c.IsRegisteredFunction(addID))
 
-		sub, ok := c.GetScalarFunc(extensions.ID{URN: urn, Name: "subtract:i16_i16"})
+		subID := extensions.ID{URN: urn, Name: "subtract:i16_i16"}
+		sub, ok := c.GetScalarFunc(subID)
 		assert.True(t, ok)
 		assert.NotNil(t, sub)
+		assert.True(t, c.IsRegisteredFunction(subID))
 
 		assert.Equal(t, "subtract", sub.Name())
 		assert.Equal(t, "subtract:i16_i16", sub.CompoundName())

--- a/extensions/extension_mgr_test.go
+++ b/extensions/extension_mgr_test.go
@@ -102,12 +102,9 @@ func TestLoadExtensionCollection(t *testing.T) {
 		assert.Equal(t, map[string]interface{}{"latitude": "i32", "longitude": "i32"}, ty.Structure)
 	})
 
-	t.Run("simple and compound func signature", func(t *testing.T) {
-		add, ok := c.GetScalarFunc(extensions.ID{URN: urn, Name: "add"})
+	t.Run("compound func signature", func(t *testing.T) {
+		add, ok := c.GetScalarFunc(extensions.ID{URN: urn, Name: "add:i8_i8"})
 		assert.True(t, ok)
-		addCompound, ok := c.GetScalarFunc(extensions.ID{URN: urn, Name: "add:i8_i8"})
-		assert.True(t, ok)
-		assert.Same(t, add, addCompound)
 
 		assert.Equal(t, "add", add.Name())
 		assert.Equal(t, "add:i8_i8", add.CompoundName())
@@ -123,12 +120,12 @@ func TestLoadExtensionCollection(t *testing.T) {
 		assert.Equal(t, i8Req, ty)
 	})
 
-	t.Run("multiple impls need compound", func(t *testing.T) {
-		sub, ok := c.GetScalarFunc(extensions.ID{URN: urn, Name: "subtract"})
-		assert.Nil(t, sub)
+	t.Run("functions need compound names", func(t *testing.T) {
+		add, ok := c.GetScalarFunc(extensions.ID{URN: urn, Name: "add"})
+		assert.Nil(t, add)
 		assert.False(t, ok)
 
-		sub, ok = c.GetScalarFunc(extensions.ID{URN: urn, Name: "subtract:i16_i16"})
+		sub, ok := c.GetScalarFunc(extensions.ID{URN: urn, Name: "subtract:i16_i16"})
 		assert.True(t, ok)
 		assert.NotNil(t, sub)
 
@@ -175,7 +172,7 @@ func TestExtensionSet(t *testing.T) {
 
 	t.Run("add anchors", func(t *testing.T) {
 		id := extensions.ID{URN: urn}
-		id.Name = "add"
+		id.Name = "add:i8_i8"
 
 		anchor := s.GetFuncAnchor(id)
 		assert.EqualValues(t, 1, anchor)

--- a/extensions/variants.go
+++ b/extensions/variants.go
@@ -15,8 +15,9 @@ import (
 type FunctionVariant interface {
 	// Name returns the simple function name without argument types.
 	Name() string
-	// Signature returns the registered compound function variant signature.
-	Signature() string
+	// CompoundName returns the registered compound function variant signature.
+	// TODO: Rename this to Signature in a future breaking change.
+	CompoundName() string
 	Description() string
 	Args() FuncParameterList
 	Options() map[string]Option
@@ -360,14 +361,15 @@ func (s *ScalarFunctionVariant) ResolveType(argumentTypes []types.Type, registry
 	return EvaluateTypeExpression(s.urn, s.impl.Nullability, s.impl.Return.ValueType, s.impl.Args, s.impl.Variadic, argumentTypes, registry)
 }
 
-// Signature returns the registered compound function variant signature.
-func (s *ScalarFunctionVariant) Signature() string {
+// CompoundName returns the registered compound function variant signature.
+// TODO: Rename this to Signature in a future breaking change.
+func (s *ScalarFunctionVariant) CompoundName() string {
 	return s.name + ":" + s.impl.signatureKey()
 }
 
 // ID returns the unique ID for this function variant.
 func (s *ScalarFunctionVariant) ID() FunctionID {
-	return FunctionID{URN: s.urn, Signature: s.Signature()}
+	return FunctionID{URN: s.urn, Signature: s.CompoundName()}
 }
 
 func (s *ScalarFunctionVariant) Match(argumentTypes []types.Type) (bool, error) {
@@ -480,14 +482,15 @@ func (s *AggregateFunctionVariant) ResolveType(argumentTypes []types.Type, regis
 	return EvaluateTypeExpression(s.urn, s.impl.Nullability, s.impl.Return.ValueType, s.impl.Args, s.impl.Variadic, argumentTypes, registry)
 }
 
-// Signature returns the registered compound function variant signature.
-func (s *AggregateFunctionVariant) Signature() string {
+// CompoundName returns the registered compound function variant signature.
+// TODO: Rename this to Signature in a future breaking change.
+func (s *AggregateFunctionVariant) CompoundName() string {
 	return s.name + ":" + s.impl.signatureKey()
 }
 
 // ID returns the unique ID for this function variant.
 func (s *AggregateFunctionVariant) ID() FunctionID {
-	return FunctionID{URN: s.urn, Signature: s.Signature()}
+	return FunctionID{URN: s.urn, Signature: s.CompoundName()}
 }
 func (s *AggregateFunctionVariant) Decomposability() DecomposeType { return s.impl.Decomposable }
 func (s *AggregateFunctionVariant) Intermediate() (types.FuncDefArgType, error) {
@@ -608,14 +611,15 @@ func (s *WindowFunctionVariant) ResolveType(argumentTypes []types.Type, registry
 	return EvaluateTypeExpression(s.urn, s.impl.Nullability, s.impl.Return.ValueType, s.impl.Args, s.impl.Variadic, argumentTypes, registry)
 }
 
-// Signature returns the registered compound function variant signature.
-func (s *WindowFunctionVariant) Signature() string {
+// CompoundName returns the registered compound function variant signature.
+// TODO: Rename this to Signature in a future breaking change.
+func (s *WindowFunctionVariant) CompoundName() string {
 	return s.name + ":" + s.impl.signatureKey()
 }
 
 // ID returns the unique ID for this function variant.
 func (s *WindowFunctionVariant) ID() FunctionID {
-	return FunctionID{URN: s.urn, Signature: s.Signature()}
+	return FunctionID{URN: s.urn, Signature: s.CompoundName()}
 }
 func (s *WindowFunctionVariant) Decomposability() DecomposeType { return s.impl.Decomposable }
 func (s *WindowFunctionVariant) Intermediate() (types.FuncDefArgType, error) {

--- a/extensions/variants.go
+++ b/extensions/variants.go
@@ -309,7 +309,7 @@ func maxArgumentCount(paramTypeList FuncParameterList, variadicBehavior *Variadi
 // an expression requires an output type argument. This is for creating an
 // on-the-fly function variant that will not be registered as an extension.
 func NewScalarFuncVariant(id FunctionID) *ScalarFunctionVariant {
-	simpleName, args := parseFuncName(id.Name)
+	simpleName, args := parseFuncName(id.Signature)
 	return &ScalarFunctionVariant{
 		name: simpleName,
 		urn:  id.URN,
@@ -321,7 +321,7 @@ func NewScalarFuncVariant(id FunctionID) *ScalarFunctionVariant {
 // setting the values for the SessionDependant, Variadic Behavior and Deterministic
 // properties.
 func NewScalarFuncVariantWithProps(id FunctionID, variadic *VariadicBehavior, sessionDependant, deterministic bool) *ScalarFunctionVariant {
-	simpleName, args := parseFuncName(id.Name)
+	simpleName, args := parseFuncName(id.Signature)
 	return &ScalarFunctionVariant{
 		name: simpleName,
 		urn:  id.URN,
@@ -359,7 +359,7 @@ func (s *ScalarFunctionVariant) CompoundName() string {
 	return s.name + ":" + s.impl.signatureKey()
 }
 func (s *ScalarFunctionVariant) ID() FunctionID {
-	return FunctionID{URN: s.urn, Name: s.CompoundName()}
+	return FunctionID{URN: s.urn, Signature: s.CompoundName()}
 }
 
 func (s *ScalarFunctionVariant) Match(argumentTypes []types.Type) (bool, error) {
@@ -385,7 +385,7 @@ func (s *ScalarFunctionVariant) MaxArgumentCount() int {
 // an expression requires an output type argument. This is for creating an
 // on-the-fly function variant that will not be registered as an extension.
 func NewAggFuncVariant(id FunctionID) *AggregateFunctionVariant {
-	simpleName, args := parseFuncName(id.Name)
+	simpleName, args := parseFuncName(id.Signature)
 	return &AggregateFunctionVariant{
 		name: simpleName,
 		urn:  id.URN,
@@ -429,7 +429,7 @@ func NewAggFuncVariantOpts(id FunctionID, opts AggVariantOptions) *AggregateFunc
 		aggIntermediate.ValueType = intermediate
 	}
 
-	simpleName, args := parseFuncName(id.Name)
+	simpleName, args := parseFuncName(id.Signature)
 	return &AggregateFunctionVariant{
 		name: simpleName,
 		urn:  id.URN,
@@ -473,7 +473,7 @@ func (s *AggregateFunctionVariant) CompoundName() string {
 	return s.name + ":" + s.impl.signatureKey()
 }
 func (s *AggregateFunctionVariant) ID() FunctionID {
-	return FunctionID{URN: s.urn, Name: s.CompoundName()}
+	return FunctionID{URN: s.urn, Signature: s.CompoundName()}
 }
 func (s *AggregateFunctionVariant) Decomposability() DecomposeType { return s.impl.Decomposable }
 func (s *AggregateFunctionVariant) Intermediate() (types.FuncDefArgType, error) {
@@ -507,7 +507,7 @@ type WindowFunctionVariant struct {
 }
 
 func NewWindowFuncVariant(id FunctionID) *WindowFunctionVariant {
-	simpleName, args := parseFuncName(id.Name)
+	simpleName, args := parseFuncName(id.Signature)
 	return &WindowFunctionVariant{
 		name: simpleName,
 		urn:  id.URN,
@@ -556,7 +556,7 @@ func NewWindowFuncVariantOpts(id FunctionID, opts WindowVariantOpts) *WindowFunc
 		aggIntermediate.ValueType = intermediate
 	}
 
-	simpleName, args := parseFuncName(id.Name)
+	simpleName, args := parseFuncName(id.Signature)
 	return &WindowFunctionVariant{
 		name: simpleName,
 		urn:  id.URN,
@@ -595,7 +595,7 @@ func (s *WindowFunctionVariant) CompoundName() string {
 	return s.name + ":" + s.impl.signatureKey()
 }
 func (s *WindowFunctionVariant) ID() FunctionID {
-	return FunctionID{URN: s.urn, Name: s.CompoundName()}
+	return FunctionID{URN: s.urn, Signature: s.CompoundName()}
 }
 func (s *WindowFunctionVariant) Decomposability() DecomposeType { return s.impl.Decomposable }
 func (s *WindowFunctionVariant) Intermediate() (types.FuncDefArgType, error) {

--- a/extensions/variants.go
+++ b/extensions/variants.go
@@ -13,8 +13,10 @@ import (
 )
 
 type FunctionVariant interface {
+	// Name returns the simple function name without argument types.
 	Name() string
-	CompoundName() string
+	// Signature returns the registered compound function variant signature.
+	Signature() string
 	Description() string
 	Args() FuncParameterList
 	Options() map[string]Option
@@ -270,8 +272,8 @@ func getFuncDefFromArgList(paramTypeList FuncParameterList) ([]types.FuncDefArgT
 	return out, nil
 }
 
-func parseFuncName(compoundName string) (name string, args FuncParameterList) {
-	name, argsStr, _ := strings.Cut(compoundName, ":")
+func parseFuncName(signature string) (name string, args FuncParameterList) {
+	name, argsStr, _ := strings.Cut(signature, ":")
 	if len(argsStr) == 0 {
 		return name, nil
 	}
@@ -342,7 +344,9 @@ type ScalarFunctionVariant struct {
 	metadata    map[string]any
 }
 
-func (s *ScalarFunctionVariant) Name() string                     { return s.name }
+// Name returns the simple function name without argument types.
+func (s *ScalarFunctionVariant) Name() string { return s.name }
+
 func (s *ScalarFunctionVariant) Description() string              { return s.description }
 func (s *ScalarFunctionVariant) Args() FuncParameterList          { return s.impl.Args }
 func (s *ScalarFunctionVariant) Options() map[string]Option       { return s.impl.Options }
@@ -355,11 +359,15 @@ func (s *ScalarFunctionVariant) Metadata() map[string]any         { return s.met
 func (s *ScalarFunctionVariant) ResolveType(argumentTypes []types.Type, registry Set) (types.Type, error) {
 	return EvaluateTypeExpression(s.urn, s.impl.Nullability, s.impl.Return.ValueType, s.impl.Args, s.impl.Variadic, argumentTypes, registry)
 }
-func (s *ScalarFunctionVariant) CompoundName() string {
+
+// Signature returns the registered compound function variant signature.
+func (s *ScalarFunctionVariant) Signature() string {
 	return s.name + ":" + s.impl.signatureKey()
 }
+
+// ID returns the unique ID for this function variant.
 func (s *ScalarFunctionVariant) ID() FunctionID {
-	return FunctionID{URN: s.urn, Signature: s.CompoundName()}
+	return FunctionID{URN: s.urn, Signature: s.Signature()}
 }
 
 func (s *ScalarFunctionVariant) Match(argumentTypes []types.Type) (bool, error) {
@@ -456,7 +464,9 @@ type AggregateFunctionVariant struct {
 	metadata    map[string]any
 }
 
-func (s *AggregateFunctionVariant) Name() string                     { return s.name }
+// Name returns the simple function name without argument types.
+func (s *AggregateFunctionVariant) Name() string { return s.name }
+
 func (s *AggregateFunctionVariant) Description() string              { return s.description }
 func (s *AggregateFunctionVariant) Args() FuncParameterList          { return s.impl.Args }
 func (s *AggregateFunctionVariant) Options() map[string]Option       { return s.impl.Options }
@@ -469,11 +479,15 @@ func (s *AggregateFunctionVariant) Metadata() map[string]any         { return s.
 func (s *AggregateFunctionVariant) ResolveType(argumentTypes []types.Type, registry Set) (types.Type, error) {
 	return EvaluateTypeExpression(s.urn, s.impl.Nullability, s.impl.Return.ValueType, s.impl.Args, s.impl.Variadic, argumentTypes, registry)
 }
-func (s *AggregateFunctionVariant) CompoundName() string {
+
+// Signature returns the registered compound function variant signature.
+func (s *AggregateFunctionVariant) Signature() string {
 	return s.name + ":" + s.impl.signatureKey()
 }
+
+// ID returns the unique ID for this function variant.
 func (s *AggregateFunctionVariant) ID() FunctionID {
-	return FunctionID{URN: s.urn, Signature: s.CompoundName()}
+	return FunctionID{URN: s.urn, Signature: s.Signature()}
 }
 func (s *AggregateFunctionVariant) Decomposability() DecomposeType { return s.impl.Decomposable }
 func (s *AggregateFunctionVariant) Intermediate() (types.FuncDefArgType, error) {
@@ -578,7 +592,9 @@ func NewWindowFuncVariantOpts(id FunctionID, opts WindowVariantOpts) *WindowFunc
 	}
 }
 
-func (s *WindowFunctionVariant) Name() string                     { return s.name }
+// Name returns the simple function name without argument types.
+func (s *WindowFunctionVariant) Name() string { return s.name }
+
 func (s *WindowFunctionVariant) Description() string              { return s.description }
 func (s *WindowFunctionVariant) Args() FuncParameterList          { return s.impl.Args }
 func (s *WindowFunctionVariant) Options() map[string]Option       { return s.impl.Options }
@@ -591,11 +607,15 @@ func (s *WindowFunctionVariant) Metadata() map[string]any         { return s.met
 func (s *WindowFunctionVariant) ResolveType(argumentTypes []types.Type, registry Set) (types.Type, error) {
 	return EvaluateTypeExpression(s.urn, s.impl.Nullability, s.impl.Return.ValueType, s.impl.Args, s.impl.Variadic, argumentTypes, registry)
 }
-func (s *WindowFunctionVariant) CompoundName() string {
+
+// Signature returns the registered compound function variant signature.
+func (s *WindowFunctionVariant) Signature() string {
 	return s.name + ":" + s.impl.signatureKey()
 }
+
+// ID returns the unique ID for this function variant.
 func (s *WindowFunctionVariant) ID() FunctionID {
-	return FunctionID{URN: s.urn, Signature: s.CompoundName()}
+	return FunctionID{URN: s.urn, Signature: s.Signature()}
 }
 func (s *WindowFunctionVariant) Decomposability() DecomposeType { return s.impl.Decomposable }
 func (s *WindowFunctionVariant) Intermediate() (types.FuncDefArgType, error) {

--- a/functions/dialect.go
+++ b/functions/dialect.go
@@ -220,7 +220,7 @@ func (d *dialectImpl) buildFunctionInfoMap(functions []dialectFunction) map[exte
 			if len(localName) == 0 {
 				localName = name
 			}
-			id := extensions.FunctionID{URN: urn, Name: name + ":" + kernel}
+			id := extensions.FunctionID{URN: urn, Signature: name + ":" + kernel}
 			localFunction := dialectFunctionInfo{
 				ID:        id,
 				Name:      name,

--- a/functions/dialect_test.go
+++ b/functions/dialect_test.go
@@ -365,14 +365,14 @@ scalar_functions:
 			assert.Equal(t, tt.expectedNotation, fv[0].Notation())
 			assert.Equal(t, tt.isOverflowError, fv[0].IsOptionSupported("overflow", "ERROR"))
 			assert.False(t, fv[0].IsOptionSupported("overflow", "SILENT"))
-			checkCompoundNames(t, getScalarCompoundNames(fv), tt.expectedNames)
+			checkSignatures(t, getScalarSignatures(fv), tt.expectedNames)
 
 			fv = localRegistry.GetScalarFunctions(SubstraitFunctionName(tt.substraitName), tt.numArgs)
 			assert.Greater(t, len(fv), 0)
 			assert.Equal(t, tt.expectedUrn, fv[0].URN())
 			assert.Equal(t, tt.localName, fv[0].LocalName())
 			assert.Equal(t, tt.substraitName, fv[0].Name())
-			checkCompoundNames(t, getScalarCompoundNames(fv), tt.expectedNames)
+			checkSignatures(t, getScalarSignatures(fv), tt.expectedNames)
 
 			scalarFunctions := gFunctionRegistry.GetScalarFunctions(tt.substraitName, tt.numArgs)
 			assert.Greater(t, len(scalarFunctions), 0)
@@ -448,13 +448,13 @@ aggregate_functions:
 			assert.Equal(t, tt.localName, av[0].LocalName())
 			assert.Equal(t, tt.expectedNotation, av[0].Notation())
 			assert.False(t, av[0].IsOptionSupported("overflow", "ERROR"))
-			checkCompoundNames(t, getAggregateCompoundNames(av), tt.expectedNames)
+			checkSignatures(t, getAggregateSignatures(av), tt.expectedNames)
 
 			av = localRegistry.GetAggregateFunctions(SubstraitFunctionName(tt.substraitName), 1)
 			assert.Greater(t, len(av), 0)
 			assert.Equal(t, tt.expectedUrn, av[0].URN())
 			assert.Equal(t, tt.substraitName, av[0].LocalName())
-			checkCompoundNames(t, getAggregateCompoundNames(av), tt.expectedNames)
+			checkSignatures(t, getAggregateSignatures(av), tt.expectedNames)
 
 			winFunctions := gFunctionRegistry.GetAggregateFunctions(tt.substraitName, tt.numArgs)
 			assert.Greater(t, len(winFunctions), 0)
@@ -515,13 +515,13 @@ window_functions:
 			assert.Equal(t, tt.localName, wf[0].LocalName())
 			assert.Equal(t, tt.expectedNotation, wf[0].Notation())
 			assert.False(t, wf[0].IsOptionSupported("overflow", "ERROR"))
-			checkCompoundNames(t, getWindowCompoundNames(wf), tt.expectedNames)
+			checkSignatures(t, getWindowSignatures(wf), tt.expectedNames)
 
 			wf = localRegistry.GetWindowFunctions(SubstraitFunctionName(tt.substraitName), tt.numArgs)
 			assert.Greater(t, len(wf), 0)
 			assert.Equal(t, tt.expectedUrn, wf[0].URN())
 			assert.Equal(t, tt.substraitName, wf[0].LocalName())
-			checkCompoundNames(t, getWindowCompoundNames(wf), tt.expectedNames)
+			checkSignatures(t, getWindowSignatures(wf), tt.expectedNames)
 
 			winFunctions := gFunctionRegistry.GetWindowFunctions(tt.substraitName, tt.numArgs)
 			assert.Greater(t, len(winFunctions), 0)
@@ -537,33 +537,33 @@ window_functions:
 	}
 }
 
-func getScalarCompoundNames(fv []*LocalScalarFunctionVariant) []string {
-	var compoundNames []string
+func getScalarSignatures(fv []*LocalScalarFunctionVariant) []string {
+	var signatures []string
 	for _, f := range fv {
-		compoundNames = append(compoundNames, f.CompoundName())
+		signatures = append(signatures, f.Signature())
 	}
-	return compoundNames
+	return signatures
 }
 
-func getAggregateCompoundNames(av []*LocalAggregateFunctionVariant) []string {
-	var compoundNames []string
+func getAggregateSignatures(av []*LocalAggregateFunctionVariant) []string {
+	var signatures []string
 	for _, f := range av {
-		compoundNames = append(compoundNames, f.CompoundName())
+		signatures = append(signatures, f.Signature())
 	}
-	return compoundNames
+	return signatures
 }
 
-func getWindowCompoundNames(wv []*LocalWindowFunctionVariant) []string {
-	var compoundNames []string
+func getWindowSignatures(wv []*LocalWindowFunctionVariant) []string {
+	var signatures []string
 	for _, f := range wv {
-		compoundNames = append(compoundNames, f.CompoundName())
+		signatures = append(signatures, f.Signature())
 	}
-	return compoundNames
+	return signatures
 }
 
-func checkCompoundNames(t *testing.T, compoundNames []string, expectedNames []string) {
+func checkSignatures(t *testing.T, signatures []string, expectedNames []string) {
 	for _, name := range expectedNames {
-		assert.Contains(t, compoundNames, name)
+		assert.Contains(t, signatures, name)
 	}
 }
 
@@ -1441,7 +1441,7 @@ scalar_functions:
 			assert.Equal(t, tt.expectedNotation, fv[0].Notation())
 			assert.Equal(t, tt.isOverflowError, fv[0].IsOptionSupported("overflow", "ERROR"))
 			assert.False(t, fv[0].IsOptionSupported("overflow", "SILENT"))
-			checkCompoundNames(t, getScalarCompoundNames(fv), tt.expectedNames)
+			checkSignatures(t, getScalarSignatures(fv), tt.expectedNames)
 			retType, err := fv[0].ResolveType(tt.args, extensions.NewSet())
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedReturnType, retType)
@@ -1450,7 +1450,7 @@ scalar_functions:
 			assert.Equal(t, tt.expectedUrn, fv[0].URN())
 			assert.Equal(t, tt.localName, fv[0].LocalName())
 			assert.Equal(t, tt.substraitName, fv[0].Name())
-			checkCompoundNames(t, getScalarCompoundNames(fv), tt.expectedNames)
+			checkSignatures(t, getScalarSignatures(fv), tt.expectedNames)
 
 			scalarFunctions := gFunctionRegistry.GetScalarFunctions(tt.substraitName, tt.numArgs)
 			assert.Greater(t, len(scalarFunctions), 0)
@@ -1523,7 +1523,7 @@ scalar_functions:
 			assert.Equal(t, tt.expectedUrn, fv[0].URN())
 			assert.Equal(t, tt.localName, fv[0].LocalName())
 			assert.False(t, fv[0].IsOptionSupported("overflow", "SILENT"))
-			checkCompoundNames(t, getScalarCompoundNames(fv), tt.expectedNames)
+			checkSignatures(t, getScalarSignatures(fv), tt.expectedNames)
 			retType, err := fv[0].ResolveType(tt.args, extensions.NewSet())
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedReturnType, retType)
@@ -1532,7 +1532,7 @@ scalar_functions:
 			assert.Equal(t, tt.expectedUrn, fv[0].URN())
 			assert.Equal(t, tt.localName, fv[0].LocalName())
 			assert.Equal(t, tt.substraitName, fv[0].Name())
-			checkCompoundNames(t, getScalarCompoundNames(fv), tt.expectedNames)
+			checkSignatures(t, getScalarSignatures(fv), tt.expectedNames)
 
 			scalarFunctions := gFunctionRegistry.GetScalarFunctions(tt.substraitName, tt.numArgs)
 			assert.Greater(t, len(scalarFunctions), 0)
@@ -1651,7 +1651,7 @@ scalar_functions:
 		assert.Contains(t, expectedUrns, f.URN())
 		urnsFound[f.URN()] = true
 	}
-	checkCompoundNames(t, getScalarCompoundNames(fv), expectedNames)
+	checkSignatures(t, getScalarSignatures(fv), expectedNames)
 	assert.Len(t, urnsFound, len(expectedUrns))
 	for k := range urnsFound {
 		assert.Contains(t, expectedUrns, k)
@@ -1667,7 +1667,7 @@ scalar_functions:
 		urnsFound[f.URN()] = true
 	}
 	assert.Len(t, urnsFound, len(expectedUrns))
-	checkCompoundNames(t, getScalarCompoundNames(fv), []string{})
+	checkSignatures(t, getScalarSignatures(fv), []string{})
 
 	scalarFunctions := funcRegistry.GetScalarFunctions("sqrt", 1)
 	assert.Greater(t, len(scalarFunctions), 0)
@@ -1795,14 +1795,14 @@ aggregate_functions:
 			assert.Equal(t, decimalUrn, fv[0].URN())
 			assert.Equal(t, tt.localName, fv[0].LocalName())
 			assert.Equal(t, tt.substraitName, fv[0].Name())
-			checkCompoundNames(t, getAggregateCompoundNames(fv), []string{tt.signature})
+			checkSignatures(t, getAggregateSignatures(fv), []string{tt.signature})
 
 			fv = localRegistry.GetAggregateFunctions(SubstraitFunctionName(tt.substraitName), tt.numArgs)
 			require.Greater(t, len(fv), 0)
 			assert.Equal(t, decimalUrn, fv[0].URN())
 			assert.Equal(t, tt.localName, fv[0].LocalName())
 			assert.Equal(t, tt.substraitName, fv[0].Name())
-			checkCompoundNames(t, getAggregateCompoundNames(fv), []string{tt.signature})
+			checkSignatures(t, getAggregateSignatures(fv), []string{tt.signature})
 
 			aggregateFunctions := funcRegistry.GetAggregateFunctions(tt.substraitName, tt.numArgs)
 			assert.Equal(t, tt.numSubstraitFunctions, len(aggregateFunctions))

--- a/functions/dialect_test.go
+++ b/functions/dialect_test.go
@@ -365,14 +365,14 @@ scalar_functions:
 			assert.Equal(t, tt.expectedNotation, fv[0].Notation())
 			assert.Equal(t, tt.isOverflowError, fv[0].IsOptionSupported("overflow", "ERROR"))
 			assert.False(t, fv[0].IsOptionSupported("overflow", "SILENT"))
-			checkSignatures(t, getScalarSignatures(fv), tt.expectedNames)
+			checkCompoundNames(t, getScalarCompoundNames(fv), tt.expectedNames)
 
 			fv = localRegistry.GetScalarFunctions(SubstraitFunctionName(tt.substraitName), tt.numArgs)
 			assert.Greater(t, len(fv), 0)
 			assert.Equal(t, tt.expectedUrn, fv[0].URN())
 			assert.Equal(t, tt.localName, fv[0].LocalName())
 			assert.Equal(t, tt.substraitName, fv[0].Name())
-			checkSignatures(t, getScalarSignatures(fv), tt.expectedNames)
+			checkCompoundNames(t, getScalarCompoundNames(fv), tt.expectedNames)
 
 			scalarFunctions := gFunctionRegistry.GetScalarFunctions(tt.substraitName, tt.numArgs)
 			assert.Greater(t, len(scalarFunctions), 0)
@@ -448,13 +448,13 @@ aggregate_functions:
 			assert.Equal(t, tt.localName, av[0].LocalName())
 			assert.Equal(t, tt.expectedNotation, av[0].Notation())
 			assert.False(t, av[0].IsOptionSupported("overflow", "ERROR"))
-			checkSignatures(t, getAggregateSignatures(av), tt.expectedNames)
+			checkCompoundNames(t, getAggregateCompoundNames(av), tt.expectedNames)
 
 			av = localRegistry.GetAggregateFunctions(SubstraitFunctionName(tt.substraitName), 1)
 			assert.Greater(t, len(av), 0)
 			assert.Equal(t, tt.expectedUrn, av[0].URN())
 			assert.Equal(t, tt.substraitName, av[0].LocalName())
-			checkSignatures(t, getAggregateSignatures(av), tt.expectedNames)
+			checkCompoundNames(t, getAggregateCompoundNames(av), tt.expectedNames)
 
 			winFunctions := gFunctionRegistry.GetAggregateFunctions(tt.substraitName, tt.numArgs)
 			assert.Greater(t, len(winFunctions), 0)
@@ -515,13 +515,13 @@ window_functions:
 			assert.Equal(t, tt.localName, wf[0].LocalName())
 			assert.Equal(t, tt.expectedNotation, wf[0].Notation())
 			assert.False(t, wf[0].IsOptionSupported("overflow", "ERROR"))
-			checkSignatures(t, getWindowSignatures(wf), tt.expectedNames)
+			checkCompoundNames(t, getWindowCompoundNames(wf), tt.expectedNames)
 
 			wf = localRegistry.GetWindowFunctions(SubstraitFunctionName(tt.substraitName), tt.numArgs)
 			assert.Greater(t, len(wf), 0)
 			assert.Equal(t, tt.expectedUrn, wf[0].URN())
 			assert.Equal(t, tt.substraitName, wf[0].LocalName())
-			checkSignatures(t, getWindowSignatures(wf), tt.expectedNames)
+			checkCompoundNames(t, getWindowCompoundNames(wf), tt.expectedNames)
 
 			winFunctions := gFunctionRegistry.GetWindowFunctions(tt.substraitName, tt.numArgs)
 			assert.Greater(t, len(winFunctions), 0)
@@ -537,33 +537,33 @@ window_functions:
 	}
 }
 
-func getScalarSignatures(fv []*LocalScalarFunctionVariant) []string {
-	var signatures []string
+func getScalarCompoundNames(fv []*LocalScalarFunctionVariant) []string {
+	var compoundNames []string
 	for _, f := range fv {
-		signatures = append(signatures, f.Signature())
+		compoundNames = append(compoundNames, f.CompoundName())
 	}
-	return signatures
+	return compoundNames
 }
 
-func getAggregateSignatures(av []*LocalAggregateFunctionVariant) []string {
-	var signatures []string
+func getAggregateCompoundNames(av []*LocalAggregateFunctionVariant) []string {
+	var compoundNames []string
 	for _, f := range av {
-		signatures = append(signatures, f.Signature())
+		compoundNames = append(compoundNames, f.CompoundName())
 	}
-	return signatures
+	return compoundNames
 }
 
-func getWindowSignatures(wv []*LocalWindowFunctionVariant) []string {
-	var signatures []string
+func getWindowCompoundNames(wv []*LocalWindowFunctionVariant) []string {
+	var compoundNames []string
 	for _, f := range wv {
-		signatures = append(signatures, f.Signature())
+		compoundNames = append(compoundNames, f.CompoundName())
 	}
-	return signatures
+	return compoundNames
 }
 
-func checkSignatures(t *testing.T, signatures []string, expectedNames []string) {
+func checkCompoundNames(t *testing.T, compoundNames []string, expectedNames []string) {
 	for _, name := range expectedNames {
-		assert.Contains(t, signatures, name)
+		assert.Contains(t, compoundNames, name)
 	}
 }
 
@@ -1441,7 +1441,7 @@ scalar_functions:
 			assert.Equal(t, tt.expectedNotation, fv[0].Notation())
 			assert.Equal(t, tt.isOverflowError, fv[0].IsOptionSupported("overflow", "ERROR"))
 			assert.False(t, fv[0].IsOptionSupported("overflow", "SILENT"))
-			checkSignatures(t, getScalarSignatures(fv), tt.expectedNames)
+			checkCompoundNames(t, getScalarCompoundNames(fv), tt.expectedNames)
 			retType, err := fv[0].ResolveType(tt.args, extensions.NewSet())
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedReturnType, retType)
@@ -1450,7 +1450,7 @@ scalar_functions:
 			assert.Equal(t, tt.expectedUrn, fv[0].URN())
 			assert.Equal(t, tt.localName, fv[0].LocalName())
 			assert.Equal(t, tt.substraitName, fv[0].Name())
-			checkSignatures(t, getScalarSignatures(fv), tt.expectedNames)
+			checkCompoundNames(t, getScalarCompoundNames(fv), tt.expectedNames)
 
 			scalarFunctions := gFunctionRegistry.GetScalarFunctions(tt.substraitName, tt.numArgs)
 			assert.Greater(t, len(scalarFunctions), 0)
@@ -1523,7 +1523,7 @@ scalar_functions:
 			assert.Equal(t, tt.expectedUrn, fv[0].URN())
 			assert.Equal(t, tt.localName, fv[0].LocalName())
 			assert.False(t, fv[0].IsOptionSupported("overflow", "SILENT"))
-			checkSignatures(t, getScalarSignatures(fv), tt.expectedNames)
+			checkCompoundNames(t, getScalarCompoundNames(fv), tt.expectedNames)
 			retType, err := fv[0].ResolveType(tt.args, extensions.NewSet())
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedReturnType, retType)
@@ -1532,7 +1532,7 @@ scalar_functions:
 			assert.Equal(t, tt.expectedUrn, fv[0].URN())
 			assert.Equal(t, tt.localName, fv[0].LocalName())
 			assert.Equal(t, tt.substraitName, fv[0].Name())
-			checkSignatures(t, getScalarSignatures(fv), tt.expectedNames)
+			checkCompoundNames(t, getScalarCompoundNames(fv), tt.expectedNames)
 
 			scalarFunctions := gFunctionRegistry.GetScalarFunctions(tt.substraitName, tt.numArgs)
 			assert.Greater(t, len(scalarFunctions), 0)
@@ -1651,7 +1651,7 @@ scalar_functions:
 		assert.Contains(t, expectedUrns, f.URN())
 		urnsFound[f.URN()] = true
 	}
-	checkSignatures(t, getScalarSignatures(fv), expectedNames)
+	checkCompoundNames(t, getScalarCompoundNames(fv), expectedNames)
 	assert.Len(t, urnsFound, len(expectedUrns))
 	for k := range urnsFound {
 		assert.Contains(t, expectedUrns, k)
@@ -1667,7 +1667,7 @@ scalar_functions:
 		urnsFound[f.URN()] = true
 	}
 	assert.Len(t, urnsFound, len(expectedUrns))
-	checkSignatures(t, getScalarSignatures(fv), []string{})
+	checkCompoundNames(t, getScalarCompoundNames(fv), []string{})
 
 	scalarFunctions := funcRegistry.GetScalarFunctions("sqrt", 1)
 	assert.Greater(t, len(scalarFunctions), 0)
@@ -1795,14 +1795,14 @@ aggregate_functions:
 			assert.Equal(t, decimalUrn, fv[0].URN())
 			assert.Equal(t, tt.localName, fv[0].LocalName())
 			assert.Equal(t, tt.substraitName, fv[0].Name())
-			checkSignatures(t, getAggregateSignatures(fv), []string{tt.signature})
+			checkCompoundNames(t, getAggregateCompoundNames(fv), []string{tt.signature})
 
 			fv = localRegistry.GetAggregateFunctions(SubstraitFunctionName(tt.substraitName), tt.numArgs)
 			require.Greater(t, len(fv), 0)
 			assert.Equal(t, decimalUrn, fv[0].URN())
 			assert.Equal(t, tt.localName, fv[0].LocalName())
 			assert.Equal(t, tt.substraitName, fv[0].Name())
-			checkSignatures(t, getAggregateSignatures(fv), []string{tt.signature})
+			checkCompoundNames(t, getAggregateCompoundNames(fv), []string{tt.signature})
 
 			aggregateFunctions := funcRegistry.GetAggregateFunctions(tt.substraitName, tt.numArgs)
 			assert.Equal(t, tt.numSubstraitFunctions, len(aggregateFunctions))

--- a/functions/local_functions.go
+++ b/functions/local_functions.go
@@ -83,13 +83,13 @@ func getFunctionVariantByInvocation[V localFunctionVariant](invocation expr.Func
 	for i, argType := range argTypes {
 		_, err := registry.localTypeRegistry.GetLocalTypeFromSubstraitType(argType)
 		if err != nil {
-			return zeroV, fmt.Errorf("unsupported substrait type: %v as argument %d in %s", argType, i, invocation.Signature())
+			return zeroV, fmt.Errorf("unsupported substrait type: %v as argument %d in %s", argType, i, invocation.CompoundName())
 		}
 	}
 	for _, option := range invocation.GetOptions() {
 		for _, value := range option.Preference {
 			if !f.IsOptionSupported(option.Name, value) {
-				return zeroV, fmt.Errorf("unsupported option [%s:%s] in function %s", option.Name, value, invocation.Signature())
+				return zeroV, fmt.Errorf("unsupported option [%s:%s] in function %s", option.Name, value, invocation.CompoundName())
 			}
 		}
 	}

--- a/functions/local_functions.go
+++ b/functions/local_functions.go
@@ -83,13 +83,13 @@ func getFunctionVariantByInvocation[V localFunctionVariant](invocation expr.Func
 	for i, argType := range argTypes {
 		_, err := registry.localTypeRegistry.GetLocalTypeFromSubstraitType(argType)
 		if err != nil {
-			return zeroV, fmt.Errorf("unsupported substrait type: %v as argument %d in %s", argType, i, invocation.CompoundName())
+			return zeroV, fmt.Errorf("unsupported substrait type: %v as argument %d in %s", argType, i, invocation.Signature())
 		}
 	}
 	for _, option := range invocation.GetOptions() {
 		for _, value := range option.Preference {
 			if !f.IsOptionSupported(option.Name, value) {
-				return zeroV, fmt.Errorf("unsupported option [%s:%s] in function %s", option.Name, value, invocation.CompoundName())
+				return zeroV, fmt.Errorf("unsupported option [%s:%s] in function %s", option.Name, value, invocation.Signature())
 			}
 		}
 	}

--- a/plan/builders.go
+++ b/plan/builders.go
@@ -264,12 +264,12 @@ func (b *builder) RootFieldRef(input Rel, index int32) (*expr.FieldReference, er
 }
 
 func (b *builder) ScalarFn(nameSpace, key string, opts []*types.FunctionOption, args ...types.FuncArg) (*expr.ScalarFunction, error) {
-	id := extensions.FunctionID{URN: nameSpace, Name: key}
+	id := extensions.FunctionID{URN: nameSpace, Signature: key}
 	return expr.NewScalarFunc(b.reg, id, opts, args...)
 }
 
 func (b *builder) AggregateFn(nameSpace, key string, opts []*types.FunctionOption, args ...types.FuncArg) (*expr.AggregateFunction, error) {
-	id := extensions.FunctionID{URN: nameSpace, Name: key}
+	id := extensions.FunctionID{URN: nameSpace, Signature: key}
 	return expr.NewAggregateFunc(b.reg, id, opts,
 		types.AggInvocationAll, types.AggPhaseInitialToResult, nil, args...)
 }

--- a/plan/builders.go
+++ b/plan/builders.go
@@ -23,11 +23,10 @@ import (
 // This will maintain consistency across the plan for the user without them
 // having to manually do so.
 type Builder interface {
-	// GetFunctionRef retrieves the function anchor reference for a given
-	// function identified by its namespace and function name. This also
-	// ensures that any plans built from this builder will contain this
-	// function anchor in its extensions section.
-	GetFunctionRef(nameSpace, key string) types.FunctionRef
+	// GetFunctionRef retrieves the function anchor reference for a function
+	// variant. This also ensures that any plans built from this builder will
+	// contain this function anchor in its extensions section.
+	GetFunctionRef(id extensions.ID) (types.FunctionRef, error)
 
 	// Construct a user-defined type from the extension namespace and typename,
 	// along with optional type parameters. It will add the type to the internal
@@ -227,8 +226,12 @@ func (b *builder) GetExprBuilder() *expr.ExprBuilder {
 	}
 }
 
-func (b *builder) GetFunctionRef(nameSpace, key string) types.FunctionRef {
-	return types.FunctionRef(b.extSet.GetFuncAnchor(extensions.ID{URN: nameSpace, Name: key}))
+func (b *builder) GetFunctionRef(id extensions.ID) (types.FunctionRef, error) {
+	if !b.ext.IsRegisteredFunction(id) {
+		return 0, fmt.Errorf("%w: could not find matching function for id: %v", substraitgo.ErrNotFound, id)
+	}
+
+	return types.FunctionRef(b.extSet.GetFuncAnchor(id)), nil
 }
 
 func (b *builder) UserDefinedType(nameSpace, typeName string, params ...types.TypeParam) types.UserDefinedType {

--- a/plan/builders.go
+++ b/plan/builders.go
@@ -43,14 +43,14 @@ type Builder interface {
 	// the condition or post join filter for a join relation.
 	JoinedRecordFieldRef(left, right Rel, index int32) (*expr.FieldReference, error)
 	// ScalarFn constructs a ScalarFunction from the passed in namespace and
-	// function name key. This is equivalent to calling expr.NewScalarFunc using
+	// registered function variant name. This is equivalent to calling expr.NewScalarFunc using
 	// the builder's extension registry. An error will be returned if the indicated
 	// function was not already in the extension collection the builder was created
 	// with or if the arguments of the function don't match the provided argument
 	// types.
 	ScalarFn(nameSpace, key string, opts []*types.FunctionOption, args ...types.FuncArg) (*expr.ScalarFunction, error)
 	// AggregateFn constructs an AggregateFunction from the passed in namespace and
-	// function name key. This is equivalent to calling expr.NewAggregateFunc using
+	// registered function variant name. This is equivalent to calling expr.NewAggregateFunc using
 	// the builder's extension registry. An error will be returned if the indicated
 	// function was not already in the extension collection the builder was created
 	// with or if the arguments of the function don't match the provided argument

--- a/plan/ctas_plan_test.go
+++ b/plan/ctas_plan_test.go
@@ -83,14 +83,14 @@ func makeNamedTableReadRel(b plan.Builder, tableNames []string, tableSchema type
 // makeConditionExprForLike constructs a LIKE condition expression for the specified column and value.
 func makeConditionExprForLike(t *testing.T, b plan.Builder, scan plan.Rel, colId int, valueLiteral expr.Literal) expr.Expression {
 	id := extensions.FunctionID{
-		URN:  "extension:io.substrait:functions_string",
-		Name: "contains:str_str",
+		URN:       "extension:io.substrait:functions_string",
+		Signature: "contains:str_str",
 	}
 	_, err := b.GetFunctionRef(id)
 	require.NoError(t, err)
 	colIdRef, err := b.RootFieldRef(scan, int32(colId))
 	require.NoError(t, err)
-	scalarExpr, err := b.ScalarFn(id.URN, id.Name, nil, colIdRef, valueLiteral)
+	scalarExpr, err := b.ScalarFn(id.URN, id.Signature, nil, colIdRef, valueLiteral)
 	require.NoError(t, err)
 	return scalarExpr
 }

--- a/plan/ctas_plan_test.go
+++ b/plan/ctas_plan_test.go
@@ -86,7 +86,8 @@ func makeConditionExprForLike(t *testing.T, b plan.Builder, scan plan.Rel, colId
 		URN:  "extension:io.substrait:functions_string",
 		Name: "contains:str_str",
 	}
-	b.GetFunctionRef(id.URN, id.Name)
+	_, err := b.GetFunctionRef(id)
+	require.NoError(t, err)
 	colIdRef, err := b.RootFieldRef(scan, int32(colId))
 	require.NoError(t, err)
 	scalarExpr, err := b.ScalarFn(id.URN, id.Name, nil, colIdRef, valueLiteral)

--- a/plan/dynamic_parameter_test.go
+++ b/plan/dynamic_parameter_test.go
@@ -177,7 +177,7 @@ func TestDynamicParameterBindingInFilter(t *testing.T) {
 	ref, err := b.RootFieldRef(scan, 0)
 	require.NoError(t, err)
 
-	gt, err := b.ScalarFn(extensions.SubstraitDefaultURNPrefix+"functions_comparison", "gt", nil, ref, dp)
+	gt, err := b.ScalarFn(extensions.SubstraitDefaultURNPrefix+"functions_comparison", "gt:any_any", nil, ref, dp)
 	require.NoError(t, err)
 
 	filter, err := b.Filter(scan, gt)

--- a/plan/plan_builder_test.go
+++ b/plan/plan_builder_test.go
@@ -264,7 +264,7 @@ func TestAggregateRelPlan(t *testing.T) {
 
 	b := plan.NewBuilderDefault()
 	aggCount, err := b.AggregateFn(extensions.SubstraitDefaultURNPrefix+"functions_aggregate_generic",
-		"count", nil)
+		"count:", nil)
 	require.NoError(t, err)
 	scan := b.NamedScan([]string{"test"}, baseSchema)
 	root, err := b.AggregateColumns(scan, []plan.AggRelMeasure{b.Measure(aggCount, nil)}, 0)
@@ -294,7 +294,7 @@ func TestAggregateRelPlan(t *testing.T) {
 func TestAggregateNoGrouping(t *testing.T) {
 	b := plan.NewBuilderDefault()
 	aggCount, err := b.AggregateFn(extensions.SubstraitDefaultURNPrefix+"functions_aggregate_generic",
-		"count", nil)
+		"count:", nil)
 	require.NoError(t, err)
 	scan := b.NamedScan([]string{"test"}, baseSchema)
 
@@ -1336,11 +1336,11 @@ func TestProjectExpressions(t *testing.T) {
 	ref, err := b.RootFieldRef(scan, 1)
 	require.NoError(t, err)
 
-	abs, err := b.ScalarFn(arithmeticURN, "abs", nil, ref)
+	abs, err := b.ScalarFn(arithmeticURN, "abs:fp32", nil, ref)
 	require.NoError(t, err)
 
 	add, err := b.GetExprBuilder().ScalarFunc(
-		extensions.ID{URN: arithmeticURN, Name: "add"}, nil).Args(
+		extensions.ID{URN: arithmeticURN, Name: "add:fp32_fp32"}, nil).Args(
 		b.GetExprBuilder().Expression(abs),
 		b.GetExprBuilder().Expression(ref)).Build()
 	require.NoError(t, err)
@@ -1771,7 +1771,7 @@ func TestSetRelErrors(t *testing.T) {
 func TestAggregateRelBuilder(t *testing.T) {
 	addID := extensions.ID{
 		URN:  extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
-		Name: "add"}
+		Name: "add:i32_i32"}
 
 	t.Run("AddExpression adds unique expressions", func(t *testing.T) {
 		b := plan.NewBuilderDefault()
@@ -1785,7 +1785,7 @@ func TestAggregateRelBuilder(t *testing.T) {
 			e.Wrap(expr.NewLiteral(int32(4), false))).BuildExpr()
 
 		aggCount, err := b.AggregateFn(extensions.SubstraitDefaultURNPrefix+"functions_aggregate_generic",
-			"count", nil)
+			"count:", nil)
 		require.NoError(t, err)
 		arb := b.GetRelBuilder().AggregateRel(b.NamedScan([]string{"test"}, baseSchema), []plan.AggRelMeasure{b.Measure(aggCount, nil)})
 
@@ -1816,7 +1816,7 @@ func TestAggregateRelBuilder(t *testing.T) {
 			e.Wrap(expr.NewLiteral(int32(4), false))).BuildExpr()
 
 		aggCount, err := b.AggregateFn(extensions.SubstraitDefaultURNPrefix+"functions_aggregate_generic",
-			"count", nil)
+			"count:", nil)
 		require.NoError(t, err)
 		arb := b.GetRelBuilder().AggregateRel(b.NamedScan([]string{"test"}, baseSchema), []plan.AggRelMeasure{b.Measure(aggCount, nil)})
 
@@ -1856,7 +1856,7 @@ func TestAggregateRelBuilder(t *testing.T) {
 			e.Wrap(expr.NewLiteral(int32(5), false))).BuildExpr()
 
 		aggCount, err := b.AggregateFn(extensions.SubstraitDefaultURNPrefix+"functions_aggregate_generic",
-			"count", nil)
+			"count:", nil)
 		require.NoError(t, err)
 
 		arb := b.GetRelBuilder().AggregateRel(b.NamedScan([]string{"test"}, baseSchema), []plan.AggRelMeasure{b.Measure(aggCount, nil)})
@@ -1895,7 +1895,7 @@ func TestAggregateRelBuilder(t *testing.T) {
 			e.Wrap(expr.NewLiteral(int32(5), false))).BuildExpr()
 
 		aggCount, err := b.AggregateFn(extensions.SubstraitDefaultURNPrefix+"functions_aggregate_generic",
-			"count", nil)
+			"count:", nil)
 		require.NoError(t, err)
 
 		arb := b.GetRelBuilder().AggregateRel(b.NamedScan([]string{"test"}, baseSchema), []plan.AggRelMeasure{b.Measure(aggCount, nil)})
@@ -1923,7 +1923,7 @@ func TestAggregateRelBuilder(t *testing.T) {
 			e.Wrap(expr.NewLiteral(int32(3), false)),
 			e.Wrap(expr.NewLiteral(int32(3), false))).BuildExpr()
 		aggCount, err := b.AggregateFn(extensions.SubstraitDefaultURNPrefix+"functions_aggregate_generic",
-			"count", nil)
+			"count:", nil)
 		require.NoError(t, err)
 
 		arb := b.GetRelBuilder().AggregateRel(nil, []plan.AggRelMeasure{b.Measure(aggCount, nil)})
@@ -1954,7 +1954,7 @@ func TestAggregateRelBuilder(t *testing.T) {
 			e.Wrap(expr.NewLiteral(int32(3), false))).BuildExpr()
 
 		aggCount, err := b.AggregateFn(extensions.SubstraitDefaultURNPrefix+"functions_aggregate_generic",
-			"count", nil)
+			"count:", nil)
 		require.NoError(t, err)
 		arb := b.GetRelBuilder().AggregateRel(b.NamedScan([]string{"test"}, baseSchema), []plan.AggRelMeasure{b.Measure(aggCount, nil)})
 		ref1 := arb.AddExpression(expr1)
@@ -1973,7 +1973,7 @@ func TestAggregateRelBuilder(t *testing.T) {
 			e.Wrap(expr.NewLiteral(int32(3), false))).BuildExpr()
 
 		aggCount, err := b.AggregateFn(extensions.SubstraitDefaultURNPrefix+"functions_aggregate_generic",
-			"count", nil)
+			"count:", nil)
 		require.NoError(t, err)
 		arb := b.GetRelBuilder().AggregateRel(b.NamedScan([]string{"test"}, baseSchema), []plan.AggRelMeasure{b.Measure(aggCount, nil)})
 
@@ -1998,7 +1998,7 @@ func TestAggregateRelBuilder(t *testing.T) {
 			e.Wrap(expr.NewLiteral(int32(3), false))).BuildExpr()
 
 		aggCount, err := b.AggregateFn(extensions.SubstraitDefaultURNPrefix+"functions_aggregate_generic",
-			"count", nil)
+			"count:", nil)
 		require.NoError(t, err)
 		arb := b.GetRelBuilder().AggregateRel(b.NamedScan([]string{"test"}, baseSchema), []plan.AggRelMeasure{b.Measure(aggCount, nil)})
 
@@ -2023,7 +2023,7 @@ func TestAggregateRelBuilder(t *testing.T) {
 			e.Wrap(expr.NewLiteral(int32(3), false))).BuildExpr()
 
 		aggCount, err := b.AggregateFn(extensions.SubstraitDefaultURNPrefix+"functions_aggregate_generic",
-			"count", nil)
+			"count:", nil)
 		require.NoError(t, err)
 		arb := b.GetRelBuilder().AggregateRel(b.NamedScan([]string{"test"}, baseSchema), []plan.AggRelMeasure{b.Measure(aggCount, nil)})
 

--- a/plan/plan_builder_test.go
+++ b/plan/plan_builder_test.go
@@ -1078,7 +1078,7 @@ func TestSortRelationKeyEqual(t *testing.T) {
 	ref, err := b.RootFieldRef(scan, 0)
 	require.NoError(t, err)
 
-	equalRef, err := b.GetFunctionRef(extensions.FunctionID{URN: extensions.SubstraitDefaultURNPrefix + "functions_comparison", Name: "equal:any_any"})
+	equalRef, err := b.GetFunctionRef(extensions.FunctionID{URN: extensions.SubstraitDefaultURNPrefix + "functions_comparison", Signature: "equal:any_any"})
 	require.NoError(t, err)
 
 	sort, err := b.Sort(scan, expr.SortField{Expr: ref, Kind: equalRef})
@@ -1092,10 +1092,10 @@ func TestSortRelationKeyEqual(t *testing.T) {
 
 func TestGetFunctionRefRequiresRegisteredFunction(t *testing.T) {
 	b := plan.NewBuilderDefault()
-	_, err := b.GetFunctionRef(extensions.FunctionID{URN: extensions.SubstraitDefaultURNPrefix + "functions_comparison", Name: "equal"})
+	_, err := b.GetFunctionRef(extensions.FunctionID{URN: extensions.SubstraitDefaultURNPrefix + "functions_comparison", Signature: "equal"})
 	require.ErrorIs(t, err, substraitgo.ErrNotFound)
 
-	ref, err := b.GetFunctionRef(extensions.FunctionID{URN: extensions.SubstraitDefaultURNPrefix + "functions_comparison", Name: "equal:any_any"})
+	ref, err := b.GetFunctionRef(extensions.FunctionID{URN: extensions.SubstraitDefaultURNPrefix + "functions_comparison", Signature: "equal:any_any"})
 	require.NoError(t, err)
 	assert.NotZero(t, ref)
 }
@@ -1353,7 +1353,7 @@ func TestProjectExpressions(t *testing.T) {
 	require.NoError(t, err)
 
 	add, err := b.GetExprBuilder().ScalarFunc(
-		extensions.FunctionID{URN: arithmeticURN, Name: "add:fp32_fp32"}, nil).Args(
+		extensions.FunctionID{URN: arithmeticURN, Signature: "add:fp32_fp32"}, nil).Args(
 		b.GetExprBuilder().Expression(abs),
 		b.GetExprBuilder().Expression(ref)).Build()
 	require.NoError(t, err)
@@ -1783,8 +1783,8 @@ func TestSetRelErrors(t *testing.T) {
 
 func TestAggregateRelBuilder(t *testing.T) {
 	addID := extensions.FunctionID{
-		URN:  extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
-		Name: "add:i32_i32"}
+		URN:       extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
+		Signature: "add:i32_i32"}
 
 	t.Run("AddExpression adds unique expressions", func(t *testing.T) {
 		b := plan.NewBuilderDefault()

--- a/plan/plan_builder_test.go
+++ b/plan/plan_builder_test.go
@@ -1027,7 +1027,7 @@ func TestSortRelationKeyEqual(t *testing.T) {
 				"extensionFunction": {
 					"extensionUrnReference": 1,
 					"functionAnchor": 1,
-					"name": "equal"
+					"name": "equal:any_any"
 				}
 			}
 		],
@@ -1078,13 +1078,26 @@ func TestSortRelationKeyEqual(t *testing.T) {
 	ref, err := b.RootFieldRef(scan, 0)
 	require.NoError(t, err)
 
-	sort, err := b.Sort(scan, expr.SortField{Expr: ref, Kind: b.GetFunctionRef(extensions.SubstraitDefaultURNPrefix+"functions_comparison", "equal")})
+	equalRef, err := b.GetFunctionRef(extensions.ID{URN: extensions.SubstraitDefaultURNPrefix + "functions_comparison", Name: "equal:any_any"})
+	require.NoError(t, err)
+
+	sort, err := b.Sort(scan, expr.SortField{Expr: ref, Kind: equalRef})
 	require.NoError(t, err)
 
 	p, err := b.Plan(sort, []string{"a", "b"})
 	require.NoError(t, err)
 
 	checkRoundTrip(t, expectedJSON, p)
+}
+
+func TestGetFunctionRefRequiresRegisteredFunction(t *testing.T) {
+	b := plan.NewBuilderDefault()
+	_, err := b.GetFunctionRef(extensions.ID{URN: extensions.SubstraitDefaultURNPrefix + "functions_comparison", Name: "equal"})
+	require.ErrorIs(t, err, substraitgo.ErrNotFound)
+
+	ref, err := b.GetFunctionRef(extensions.ID{URN: extensions.SubstraitDefaultURNPrefix + "functions_comparison", Name: "equal:any_any"})
+	require.NoError(t, err)
+	assert.NotZero(t, ref)
 }
 
 func TestSortRelationMultiple(t *testing.T) {

--- a/plan/relations_test.go
+++ b/plan/relations_test.go
@@ -56,8 +56,8 @@ func createPrimitiveBool(value bool) expr.Expression {
 func TestRelations_Copy(t *testing.T) {
 	extReg := expr.NewExtensionRegistry(extensions.NewSet(), extensions.GetDefaultCollectionWithNoError())
 	aggregateFnID := extensions.FunctionID{
-		URN:  extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
-		Name: "avg:fp64",
+		URN:       extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
+		Signature: "avg:fp64",
 	}
 	aggregateFn, err := expr.NewAggregateFunc(extReg,
 		aggregateFnID, nil, types.AggInvocationAll,
@@ -442,8 +442,8 @@ func TestRelations_Copy(t *testing.T) {
 func TestRelations_AdvancedExtensions(t *testing.T) {
 	extReg := expr.NewExtensionRegistry(extensions.NewSet(), extensions.GetDefaultCollectionWithNoError())
 	aggregateFnID := extensions.FunctionID{
-		URN:  extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
-		Name: "avg:fp64",
+		URN:       extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
+		Signature: "avg:fp64",
 	}
 	aggregateFn, err := expr.NewAggregateFunc(extReg,
 		aggregateFnID, nil, types.AggInvocationAll,
@@ -535,8 +535,8 @@ func TestRelations_AdvancedExtensions(t *testing.T) {
 func TestAggregateRelToBuilder(t *testing.T) {
 	extReg := expr.NewExtensionRegistry(extensions.NewSet(), extensions.GetDefaultCollectionWithNoError())
 	aggregateFnID := extensions.FunctionID{
-		URN:  extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
-		Name: "avg:fp64",
+		URN:       extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
+		Signature: "avg:fp64",
 	}
 	aggregateFn, err := expr.NewAggregateFunc(extReg,
 		aggregateFnID, nil, types.AggInvocationAll,

--- a/plan/relations_test.go
+++ b/plan/relations_test.go
@@ -57,7 +57,7 @@ func TestRelations_Copy(t *testing.T) {
 	extReg := expr.NewExtensionRegistry(extensions.NewSet(), extensions.GetDefaultCollectionWithNoError())
 	aggregateFnID := extensions.ID{
 		URN:  extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
-		Name: "avg",
+		Name: "avg:fp64",
 	}
 	aggregateFn, err := expr.NewAggregateFunc(extReg,
 		aggregateFnID, nil, types.AggInvocationAll,
@@ -443,7 +443,7 @@ func TestRelations_AdvancedExtensions(t *testing.T) {
 	extReg := expr.NewExtensionRegistry(extensions.NewSet(), extensions.GetDefaultCollectionWithNoError())
 	aggregateFnID := extensions.ID{
 		URN:  extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
-		Name: "avg",
+		Name: "avg:fp64",
 	}
 	aggregateFn, err := expr.NewAggregateFunc(extReg,
 		aggregateFnID, nil, types.AggInvocationAll,
@@ -536,7 +536,7 @@ func TestAggregateRelToBuilder(t *testing.T) {
 	extReg := expr.NewExtensionRegistry(extensions.NewSet(), extensions.GetDefaultCollectionWithNoError())
 	aggregateFnID := extensions.ID{
 		URN:  extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
-		Name: "avg",
+		Name: "avg:fp64",
 	}
 	aggregateFn, err := expr.NewAggregateFunc(extReg,
 		aggregateFnID, nil, types.AggInvocationAll,

--- a/plan/virtual_table_from_expr_test.go
+++ b/plan/virtual_table_from_expr_test.go
@@ -22,7 +22,8 @@ func makeAddExpr(t *testing.T, b plan.Builder, val1, val2 expr.Literal) expr.Exp
 		URN:  "extension:io.substrait:functions_arithmetic",
 		Name: "add:i32_i32",
 	}
-	b.GetFunctionRef(id.URN, id.Name)
+	_, err := b.GetFunctionRef(id)
+	require.NoError(t, err)
 	scalarExpr, err := b.ScalarFn(id.URN, id.Name, nil, val1, val2)
 	require.NoError(t, err)
 	return scalarExpr

--- a/plan/virtual_table_from_expr_test.go
+++ b/plan/virtual_table_from_expr_test.go
@@ -19,12 +19,12 @@ var (
 // makeAddExpr constructs expression val1 + val2.
 func makeAddExpr(t *testing.T, b plan.Builder, val1, val2 expr.Literal) expr.Expression {
 	id := extensions.FunctionID{
-		URN:  "extension:io.substrait:functions_arithmetic",
-		Name: "add:i32_i32",
+		URN:       "extension:io.substrait:functions_arithmetic",
+		Signature: "add:i32_i32",
 	}
 	_, err := b.GetFunctionRef(id)
 	require.NoError(t, err)
-	scalarExpr, err := b.ScalarFn(id.URN, id.Name, nil, val1, val2)
+	scalarExpr, err := b.ScalarFn(id.URN, id.Signature, nil, val1, val2)
 	require.NoError(t, err)
 	return scalarExpr
 }

--- a/testcases/parser/nodes.go
+++ b/testcases/parser/nodes.go
@@ -341,8 +341,8 @@ func (tc *TestCase) ID() extensions.FunctionID {
 		baseURN = extensions.SubstraitDefaultURNPrefix + path
 	}
 	return extensions.FunctionID{
-		URN:  baseURN,
-		Name: tc.CompoundFunctionName(),
+		URN:       baseURN,
+		Signature: tc.CompoundFunctionName(),
 	}
 }
 

--- a/testcases/parser/parse_test.go
+++ b/testcases/parser/parse_test.go
@@ -98,7 +98,7 @@ add(120::i8, 10::i8) [overflow:ERROR] = <!ERROR>
 	overflowGroupDesc := "Overflow examples demonstrating overflow behavior"
 	groupDescs := []string{basicGroupDesc, basicGroupDesc, basicGroupDesc, overflowGroupDesc}
 	for i, tc := range testFile.TestCases {
-		assert.Equal(t, extensions.FunctionID{URN: arithURN, Name: ids[i]}, tc.ID())
+		assert.Equal(t, extensions.FunctionID{URN: arithURN, Signature: ids[i]}, tc.ID())
 		scalarFunc, err1 := tc.GetScalarFunctionInvocation(&reg, funcRegistry)
 		require.NoError(t, err1)
 		assert.Equal(t, tc.FuncName, scalarFunc.Name())
@@ -484,7 +484,7 @@ sum((9223372036854775806, 1, 1, 1, 1, 10000000000)::i64) [overflow:ERROR] = <!ER
 	assert.Equal(t, AggregateFuncType, tc.FuncType)
 	_, err = tc.GetScalarFunctionInvocation(nil, nil)
 	require.Error(t, err)
-	assert.Equal(t, extensions.FunctionID{URN: arithUrn, Name: "avg:fp32"}, tc.ID())
+	assert.Equal(t, extensions.FunctionID{URN: arithUrn, Signature: "avg:fp32"}, tc.ID())
 	assert.Equal(t, "avg:fp32", tc.CompoundFunctionName())
 	aggregateFunc, err1 := tc.GetAggregateFunctionInvocation(&reg, funcRegistry)
 	require.NoError(t, err1)
@@ -526,7 +526,7 @@ sum((9223372036854775806, 1, 1, 1, 1, 10000000000)::i64) [overflow:ERROR] = <!ER
 
 	_, err = tc.GetScalarFunctionInvocation(nil, nil)
 	require.Error(t, err)
-	assert.Equal(t, extensions.FunctionID{URN: arithUrn, Name: "sum:i64"}, tc.ID())
+	assert.Equal(t, extensions.FunctionID{URN: arithUrn, Signature: "sum:i64"}, tc.ID())
 	assert.Equal(t, "sum:i64", tc.CompoundFunctionName())
 	aggregateFunc, err1 = tc.GetAggregateFunctionInvocation(&reg, funcRegistry)
 	require.NoError(t, err1)
@@ -794,7 +794,7 @@ LIST_AGG(t1.col0, ','::string) = 1::fp64
 	for i, tc := range testFile.TestCases {
 		assert.Equal(t, AggregateFuncType, tc.FuncType)
 		assert.Equal(t, expectedArgTypes, tc.GetArgTypes(), "unexpected arg types in test case %d", i)
-		assert.Equal(t, "LIST_AGG:fp32_str", tc.ID().Name)
+		assert.Equal(t, "LIST_AGG:fp32_str", tc.ID().Signature)
 		assert.Equal(t, testString, tc.String(), "unexpected string in test case %d", i)
 	}
 


### PR DESCRIPTION
`NewScalarFunc`, `NewAggregateFunc`, `NewWindowFunc`, collection lookups, and plan builder function refs now require function IDs to name a registered function variant.

Previously, these APIs accepted an `extensions.FunctionID` whose `Name` could be only the simple function name. The constructor then tried to infer the registered variant from the argument types.

```go
reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())

// Previously accepted because NewScalarFunc resolved "add" to a concrete
// variant such as "add:i32_i32" from the argument types.
id := extensions.FunctionID{
    URN:  extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
    Name: "add",
}

_, err := expr.NewScalarFunc(reg, id, nil,
    expr.NewPrimitiveLiteral(int32(1), false),
    expr.NewPrimitiveLiteral(int32(2), false),
)
```

That behavior made ID-based APIs do two jobs. They accepted an ID, but they also performed simple-name overload resolution. This made a convenience behavior permeate the core function structs and lookup paths, even though an ID should identify an already-resolved extension object.

With this PR, `FunctionID` uses `Signature` instead of `Name`, and callers must provide the full registered variant signature.

```go
reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())

// Required now. The ID names the exact registered function variant.
id := extensions.FunctionID{
    URN:       extensions.SubstraitDefaultURNPrefix + "functions_arithmetic",
    Signature: "add:i32_i32",
}

_, err := expr.NewScalarFunc(reg, id, nil,
    expr.NewPrimitiveLiteral(int32(1), false),
    expr.NewPrimitiveLiteral(int32(2), false),
)
```

The same rule applies to aggregate and window functions, collection lookups, and plan builder function refs. This PR also adds `Collection.IsRegisteredFunction` so callers can check whether an ID names a registered scalar, aggregate, or window function variant before asking a plan builder for a function ref.

```go
builder := plan.NewBuilderDefault()

// Rejected now because "equal" is only the simple function name.
_, err := builder.GetFunctionRef(extensions.FunctionID{
    URN:       extensions.SubstraitDefaultURNPrefix + "functions_comparison",
    Signature: "equal",
})

// Accepted because "equal:any_any" is the registered variant signature.
ref, err := builder.GetFunctionRef(extensions.FunctionID{
    URN:       extensions.SubstraitDefaultURNPrefix + "functions_comparison",
    Signature: "equal:any_any",
})
```

This is a breaking change for callers that relied on the previous implicit resolution behavior.

A simple-name convenience API is still useful, but it should be explicit and opt in. This PR adds resolver helpers for that path:

```go
// ResolveScalarFunctionVariant resolves a simple scalar function name and arguments
// to the ID of a registered function variant.
func ResolveScalarFunctionVariant(
    reg expr.ExtensionRegistry,
    urn string,
    name string,
    args ...types.FuncArg,
) (extensions.FunctionID, error)

// ResolveAggregateFunctionVariant resolves a simple aggregate function name and arguments
// to the ID of a registered function variant.
func ResolveAggregateFunctionVariant(
    reg expr.ExtensionRegistry,
    urn string,
    name string,
    args ...types.FuncArg,
) (extensions.FunctionID, error)

// ResolveWindowFunctionVariant resolves a simple window function name and arguments
// to the ID of a registered function variant.
func ResolveWindowFunctionVariant(
    reg expr.ExtensionRegistry,
    urn string,
    name string,
    args ...types.FuncArg,
) (extensions.FunctionID, error)
```

Callers that want convenience resolution can opt into it first, then pass the resolved ID to `NewScalarFunc`, `NewAggregateFunc`, or `NewWindowFunc`.

```go
id, err := expr.ResolveScalarFunctionVariant(reg,
    extensions.SubstraitDefaultURNPrefix+"functions_arithmetic",
    "add",
    expr.NewPrimitiveLiteral(int32(1), false),
    expr.NewPrimitiveLiteral(int32(2), false),
)
if err != nil {
    return err
}

_, err = expr.NewScalarFunc(reg, id, nil,
    expr.NewPrimitiveLiteral(int32(1), false),
    expr.NewPrimitiveLiteral(int32(2), false),
)
```

This keeps exact ID construction separate from convenience resolution and avoids maintaining simple-name aliases in `Collection`. It also gives the resolver room to be smarter than the previous constructor fallback. For example, if a function had multiple variants and the best match for `i32, i32` was a generic variant like `add:any_any`, the old constructor fallback would still synthesize `add:i32_i32` and fail unless that exact variant existed.

---
Note: This PR was developed with AI assistance. All changes have been reviewed, and I take full responsibility for this contribution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Function identifiers now include complete signatures, improving support for overloaded scalar, aggregate, and window functions.
  - Added clearer function resolution for typed and generic arguments.
  - Function lookup now provides explicit handling for unregistered functions.

- **Bug Fixes**
  - Improved resolution of function variants across expressions, query planning, window functions, and lambda expressions.
  - Updated function references to consistently use signature-qualified names, reducing ambiguity between variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->