### PR TITLE
feat(literal): add NewEmptyMap and NewEmptyList constructors

### DIFF
--- a/literal/utils.go
+++ b/literal/utils.go
@@ -423,6 +423,18 @@ func NewList(elements []expr.Literal, nullable bool) (expr.Literal, error) {
 	return expr.NewLiteral[expr.ListLiteralValue](elements, nullable)
 }
 
+// NewEmptyMap creates an empty map literal of the given key and value types,
+// marked nullable or not.
+func NewEmptyMap(keyType, valueType types.Type, nullable bool) expr.Literal {
+	return expr.NewEmptyMapLiteral(keyType, valueType, nullable)
+}
+
+// NewEmptyList creates an empty list literal of the given element type, marked
+// nullable or not.
+func NewEmptyList(elementType types.Type, nullable bool) expr.Literal {
+	return expr.NewEmptyListLiteral(elementType, nullable)
+}
+
 // NewUserDefinedLiteral creates a user-defined literal using the struct representation.
 // The typeRef should be obtained from an extension registry's GetTypeAnchor method.
 // The structValue contains the field values for the user-defined type.

--- a/literal/utils_test.go
+++ b/literal/utils_test.go
@@ -959,6 +959,55 @@ func TestNewList(t *testing.T) {
 	}
 }
 
+func TestNewEmptyMap(t *testing.T) {
+	tests := []struct {
+		name      string
+		keyType   types.Type
+		valueType types.Type
+		nullable  bool
+	}{
+		{"i8ToString", &types.Int8Type{Nullability: types.NullabilityRequired}, &types.StringType{Nullability: types.NullabilityRequired}, false},
+		{"i8ToStringNullable", &types.Int8Type{Nullability: types.NullabilityRequired}, &types.StringType{Nullability: types.NullabilityRequired}, true},
+		{"stringToI32", &types.StringType{Nullability: types.NullabilityRequired}, &types.Int32Type{Nullability: types.NullabilityRequired}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewEmptyMap(tt.keyType, tt.valueType, tt.nullable)
+			wantNullability := types.NullabilityRequired
+			if tt.nullable {
+				wantNullability = types.NullabilityNullable
+			}
+			wantType := &types.MapType{Nullability: wantNullability, Key: tt.keyType, Value: tt.valueType}
+			assert.Equalf(t, wantType, got.GetType(), "NewEmptyMap(%v, %v)", tt.keyType, tt.valueType)
+			assert.Equalf(t, expr.NewEmptyMapLiteral(tt.keyType, tt.valueType, tt.nullable), got, "NewEmptyMap(%v, %v)", tt.keyType, tt.valueType)
+		})
+	}
+}
+
+func TestNewEmptyList(t *testing.T) {
+	tests := []struct {
+		name        string
+		elementType types.Type
+		nullable    bool
+	}{
+		{"i32", &types.Int32Type{Nullability: types.NullabilityRequired}, false},
+		{"i32Nullable", &types.Int32Type{Nullability: types.NullabilityRequired}, true},
+		{"string", &types.StringType{Nullability: types.NullabilityRequired}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewEmptyList(tt.elementType, tt.nullable)
+			wantNullability := types.NullabilityRequired
+			if tt.nullable {
+				wantNullability = types.NullabilityNullable
+			}
+			wantType := &types.ListType{Nullability: wantNullability, Type: tt.elementType}
+			assert.Equalf(t, wantType, got.GetType(), "NewEmptyList(%v)", tt.elementType)
+			assert.Equalf(t, expr.NewEmptyListLiteral(tt.elementType, tt.nullable), got, "NewEmptyList(%v)", tt.elementType)
+		})
+	}
+}
+
 func TestNewDateFromString(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/literal/utils_test.go
+++ b/literal/utils_test.go
@@ -969,6 +969,7 @@ func TestNewEmptyMap(t *testing.T) {
 		{"i8ToString", &types.Int8Type{Nullability: types.NullabilityRequired}, &types.StringType{Nullability: types.NullabilityRequired}, false},
 		{"i8ToStringNullable", &types.Int8Type{Nullability: types.NullabilityRequired}, &types.StringType{Nullability: types.NullabilityRequired}, true},
 		{"stringToI32", &types.StringType{Nullability: types.NullabilityRequired}, &types.Int32Type{Nullability: types.NullabilityRequired}, false},
+		{"i8ToListOfI32", &types.Int8Type{Nullability: types.NullabilityRequired}, &types.ListType{Type: &types.Int32Type{Nullability: types.NullabilityRequired}, Nullability: types.NullabilityRequired}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -993,6 +994,7 @@ func TestNewEmptyList(t *testing.T) {
 		{"i32", &types.Int32Type{Nullability: types.NullabilityRequired}, false},
 		{"i32Nullable", &types.Int32Type{Nullability: types.NullabilityRequired}, true},
 		{"string", &types.StringType{Nullability: types.NullabilityRequired}, false},
+		{"listOfI32", &types.ListType{Type: &types.Int32Type{Nullability: types.NullabilityRequired}, Nullability: types.NullabilityRequired}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
follow-up to #236. adds NewEmptyMap and NewEmptyList to literal so all four collection constructors sit together, where callers already look. they wrap the existing expr.NewEmptyMapLiteral / NewEmptyListLiteral, which stay put (literal already wraps expr this way for the primitive constructors).

didn't move the expr versions: the dependency only runs literal -> expr, so relocating the bodies means literal reaching into expr's types. happy to remove them under a breaking change later if you'd rather they only live in one place.
