### PR TITLE
fix(plan): derive right join record types

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -304,16 +304,11 @@ func validateRootNamesForSchema(recordType types.RecordType, names []string) err
 // have incomplete implementations that panic or guess.
 // TODO(#210): remove this once RecordType() is fixed for all relation types.
 func isRecordTypeSupported(rel Rel) bool {
-	switch r := rel.(type) {
+	switch rel.(type) {
 	case *ExtensionSingleRel, *ExtensionLeafRel, *ExtensionMultiRel:
 		return false // TODO(#210): UndecodedExtension.Schema() guesses or returns empty
 	case *NamedTableWriteRel:
 		return false // TODO(#210): panics when outputMode is unspecified
-	case *JoinRel:
-		switch r.joinType {
-		case JoinTypeRightSemi, JoinTypeRightAnti, JoinTypeRightSingle:
-			return false // TODO(#210) panics: not yet implemented
-		}
 	}
 	return true
 }

--- a/plan/relations.go
+++ b/plan/relations.go
@@ -840,7 +840,7 @@ func (j *JoinRel) directOutputSchema() types.RecordType {
 		for _, r := range right.Types() {
 			typeList = append(typeList, r.WithNullability(types.NullabilityNullable))
 		}
-	case JoinTypeRight:
+	case JoinTypeRight, JoinTypeRightSingle:
 		left := j.left.RecordType()
 		right := j.right.RecordType()
 		typeList = make([]types.Type, 0, left.FieldCount()+right.FieldCount())
@@ -850,8 +850,8 @@ func (j *JoinRel) directOutputSchema() types.RecordType {
 		typeList = append(typeList, right.Types()...)
 	case JoinTypeLeftAnti:
 		typeList = j.left.RecordType().Types()
-	case JoinTypeRightSemi, JoinTypeRightAnti, JoinTypeRightSingle:
-		panic(fmt.Sprintf("join type: %v not supported", j.joinType))
+	case JoinTypeRightSemi, JoinTypeRightAnti:
+		return j.right.RecordType()
 	}
 
 	return *types.NewRecordTypeFromTypes(typeList)

--- a/plan/relations_test.go
+++ b/plan/relations_test.go
@@ -655,6 +655,34 @@ func TestProjectRecordType(t *testing.T) {
 	assert.Equal(t, expected, result)
 }
 
+func TestRightJoinRecordType(t *testing.T) {
+	left := &fakeRel{outputType: *types.NewRecordTypeFromTypes(
+		[]types.Type{&types.Int64Type{Nullability: types.NullabilityRequired}})}
+	right := &fakeRel{outputType: *types.NewRecordTypeFromTypes(
+		[]types.Type{&types.StringType{Nullability: types.NullabilityRequired}})}
+
+	tests := []struct {
+		name     string
+		joinType JoinType
+		expected types.RecordType
+	}{
+		{"right semi", JoinTypeRightSemi, right.RecordType()},
+		{"right anti", JoinTypeRightAnti, right.RecordType()},
+		{"right single", JoinTypeRightSingle, *types.NewRecordTypeFromTypes([]types.Type{
+			&types.Int64Type{Nullability: types.NullabilityNullable},
+			&types.StringType{Nullability: types.NullabilityRequired},
+		})},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rel := &JoinRel{left: left, right: right, joinType: tt.joinType}
+			assert.Equal(t, tt.expected, rel.RecordType())
+			assert.True(t, isRecordTypeSupported(rel))
+		})
+	}
+}
+
 func TestExtensionSingleRecordType(t *testing.T) {
 	var rel ExtensionSingleRel
 	rel.input = &fakeRel{outputType: *types.NewRecordTypeFromTypes(


### PR DESCRIPTION
## Summary

Implement `RecordType()` semantics for right semi, right anti, and right single joins. This addresses the right-join portion of #210 without expanding into extension or write relations.

## Changes

- Return only right input schema for `RIGHT_SEMI` and `RIGHT_ANTI`.
- Return nullable left fields followed by unchanged right fields for `RIGHT_SINGLE`, matching right outer semantics.
- Enable schema validation for these now-supported join types.
- Add table-driven regression coverage.

## Repro

Calling `RecordType()` for these join types previously panicked. Right semi and anti now return right schema; right single returns combined schema with only left fields made nullable.

## Testing

- `go test ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run`

## Did this cause any problems?

No. Revert this commit to restore previous behavior.