### PR TITLE
fix: persist extension registry in SubqueryConverters for FromProto

### DIFF
--- a/plan/builders.go
+++ b/plan/builders.go
@@ -784,10 +784,12 @@ func (b *builder) PlanWithBindings(root Rel, rootNames []string, expectedTypeURL
 		relations[i].rel = o
 	}
 
+	reg := b.reg
+	reg.SetSubqueryConverter(&ExpressionConverter{ExtensionRegistry: reg})
 	return &Plan{
 		version:           &CurrentVersion,
 		extensions:        b.extSet,
-		reg:               b.reg,
+		reg:               reg,
 		expectedTypeURLs:  expectedTypeURLs,
 		relations:         relations,
 		parameterBindings: bindings,

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -239,6 +239,7 @@ func FromProto(plan *proto.Plan, c *extensions.Collection) (*Plan, error) {
 	}
 
 	ret.reg = expr.NewExtensionRegistry(ret.extensions, c)
+	ret.reg.SetSubqueryConverter(&ExpressionConverter{ExtensionRegistry: ret.reg})
 	for i, r := range plan.Relations {
 		if err := ret.relations[i].FromProto(r, ret.reg); err != nil {
 			return nil, err

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -132,6 +132,109 @@ func TestRejectsMismatchedRootNames(t *testing.T) {
 	assert.ErrorContains(t, err, "1 output name(s) but the output schema requires 2")
 }
 
+func TestFromProtoWithSubqueries(t *testing.T) {
+	c := extensions.GetDefaultCollectionWithNoError()
+
+	// Build a named-scan relation proto to embed as subquery input.
+	scanProto := &proto.Rel{
+		RelType: &proto.Rel_Read{
+			Read: &proto.ReadRel{
+				Common: &proto.RelCommon{EmitKind: &proto.RelCommon_Direct_{Direct: &proto.RelCommon_Direct{}}},
+				BaseSchema: &proto.NamedStruct{
+					Names: []string{"col1"},
+					Struct: &proto.Type_Struct{
+						Nullability: proto.Type_NULLABILITY_REQUIRED,
+						Types:       []*proto.Type{{Kind: &proto.Type_I32_{I32: &proto.Type_I32{Nullability: proto.Type_NULLABILITY_REQUIRED}}}},
+					},
+				},
+				ReadType: &proto.ReadRel_NamedTable_{NamedTable: &proto.ReadRel_NamedTable{Names: []string{"t"}}},
+			},
+		},
+	}
+
+	makePlan := func(subquery *proto.Expression_Subquery) *proto.Plan {
+		return &proto.Plan{
+			Relations: []*proto.PlanRel{
+				{
+					RelType: &proto.PlanRel_Root{
+						Root: &proto.RelRoot{
+							Names: []string{"out"},
+							Input: &proto.Rel{
+								RelType: &proto.Rel_Filter{
+									Filter: &proto.FilterRel{
+										Common: &proto.RelCommon{EmitKind: &proto.RelCommon_Direct_{Direct: &proto.RelCommon_Direct{}}},
+										Input:  scanProto,
+										Condition: &proto.Expression{
+											RexType: &proto.Expression_Subquery_{Subquery: subquery},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("ScalarSubquery", func(t *testing.T) {
+		p := makePlan(&proto.Expression_Subquery{
+			SubqueryType: &proto.Expression_Subquery_Scalar_{
+				Scalar: &proto.Expression_Subquery_Scalar{Input: scanProto},
+			},
+		})
+		result, err := FromProto(p, c)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+	})
+
+	t.Run("InPredicateSubquery", func(t *testing.T) {
+		needle := expr.NewPrimitiveLiteral(int32(1), false).ToProto()
+		p := makePlan(&proto.Expression_Subquery{
+			SubqueryType: &proto.Expression_Subquery_InPredicate_{
+				InPredicate: &proto.Expression_Subquery_InPredicate{
+					Needles:  []*proto.Expression{needle},
+					Haystack: scanProto,
+				},
+			},
+		})
+		result, err := FromProto(p, c)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+	})
+
+	t.Run("SetPredicateSubquery", func(t *testing.T) {
+		p := makePlan(&proto.Expression_Subquery{
+			SubqueryType: &proto.Expression_Subquery_SetPredicate_{
+				SetPredicate: &proto.Expression_Subquery_SetPredicate{
+					PredicateOp: proto.Expression_Subquery_SetPredicate_PREDICATE_OP_EXISTS,
+					Tuples:      scanProto,
+				},
+			},
+		})
+		result, err := FromProto(p, c)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+	})
+
+	t.Run("SetComparisonSubquery", func(t *testing.T) {
+		left := expr.NewPrimitiveLiteral(int32(1), false).ToProto()
+		p := makePlan(&proto.Expression_Subquery{
+			SubqueryType: &proto.Expression_Subquery_SetComparison_{
+				SetComparison: &proto.Expression_Subquery_SetComparison{
+					ReductionOp:  proto.Expression_Subquery_SetComparison_REDUCTION_OP_ANY,
+					ComparisonOp: proto.Expression_Subquery_SetComparison_COMPARISON_OP_EQ,
+					Left:         left,
+					Right:        scanProto,
+				},
+			},
+		})
+		result, err := FromProto(p, c)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+	})
+}
+
 func TestFromProtoRightSemiJoinRootNames(t *testing.T) {
 	// Regression: validateRootNamesFromProto must not panic on JoinRel
 	// with RIGHT_SEMI (directOutputSchema panics for unsupported join types).

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -329,7 +329,7 @@ func TestFromProtoWithSubqueries(t *testing.T) {
 func TestBuilderPlanRegistryWithSubqueries(t *testing.T) {
 	b := NewBuilderDefault()
 	scan := b.NamedScan([]string{"t"}, types.NamedStruct{
-		Names: []string{"col1"},
+		Names:  []string{"col1"},
 		Struct: types.StructType{Types: []types.Type{&types.Int32Type{}}},
 	})
 	p, err := b.Plan(scan, []string{"col1"})

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -118,6 +118,106 @@ func TestPlanRoundTripWithExtensions(t *testing.T) {
 		protojson.Format(original), protojson.Format(roundTripped))
 }
 
+func TestPlanRoundTripWithSubqueries(t *testing.T) {
+	c := extensions.GetDefaultCollectionWithNoError()
+	scanProto := &proto.Rel{
+		RelType: &proto.Rel_Read{
+			Read: &proto.ReadRel{
+				Common: &proto.RelCommon{EmitKind: &proto.RelCommon_Direct_{Direct: &proto.RelCommon_Direct{}}},
+				BaseSchema: &proto.NamedStruct{
+					Names: []string{"col1"},
+					Struct: &proto.Type_Struct{
+						Nullability: proto.Type_NULLABILITY_REQUIRED,
+						Types:       []*proto.Type{{Kind: &proto.Type_I32_{I32: &proto.Type_I32{Nullability: proto.Type_NULLABILITY_REQUIRED}}}},
+					},
+				},
+				ReadType: &proto.ReadRel_NamedTable_{NamedTable: &proto.ReadRel_NamedTable{Names: []string{"t"}}},
+			},
+		},
+	}
+	needle := expr.NewPrimitiveLiteral(int32(1), false).ToProto()
+
+	tests := []struct {
+		name     string
+		subquery *proto.Expression_Subquery
+	}{
+		{
+			name: "ScalarSubquery",
+			subquery: &proto.Expression_Subquery{
+				SubqueryType: &proto.Expression_Subquery_Scalar_{
+					Scalar: &proto.Expression_Subquery_Scalar{Input: scanProto},
+				},
+			},
+		},
+		{
+			name: "InPredicateSubquery",
+			subquery: &proto.Expression_Subquery{
+				SubqueryType: &proto.Expression_Subquery_InPredicate_{
+					InPredicate: &proto.Expression_Subquery_InPredicate{
+						Needles:  []*proto.Expression{needle},
+						Haystack: scanProto,
+					},
+				},
+			},
+		},
+		{
+			name: "SetPredicateSubquery",
+			subquery: &proto.Expression_Subquery{
+				SubqueryType: &proto.Expression_Subquery_SetPredicate_{
+					SetPredicate: &proto.Expression_Subquery_SetPredicate{
+						PredicateOp: proto.Expression_Subquery_SetPredicate_PREDICATE_OP_EXISTS,
+						Tuples:      scanProto,
+					},
+				},
+			},
+		},
+		{
+			name: "SetComparisonSubquery",
+			subquery: &proto.Expression_Subquery{
+				SubqueryType: &proto.Expression_Subquery_SetComparison_{
+					SetComparison: &proto.Expression_Subquery_SetComparison{
+						ReductionOp:  proto.Expression_Subquery_SetComparison_REDUCTION_OP_ANY,
+						ComparisonOp: proto.Expression_Subquery_SetComparison_COMPARISON_OP_EQ,
+						Left:         needle,
+						Right:        scanProto,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			original := &proto.Plan{
+				Relations: []*proto.PlanRel{{
+					RelType: &proto.PlanRel_Root{
+						Root: &proto.RelRoot{
+							Names: []string{"out"},
+							Input: &proto.Rel{
+								RelType: &proto.Rel_Filter{
+									Filter: &proto.FilterRel{
+										Common:    &proto.RelCommon{EmitKind: &proto.RelCommon_Direct_{Direct: &proto.RelCommon_Direct{}}},
+										Input:     scanProto,
+										Condition: &proto.Expression{RexType: &proto.Expression_Subquery_{Subquery: tc.subquery}},
+									},
+								},
+							},
+						},
+					},
+				}},
+			}
+			p, err := FromProto(original, c)
+			require.NoError(t, err)
+			roundTripped, err := p.ToProto()
+			require.NoError(t, err)
+			// Use cmp.Diff instead of protojson for comparison: protojson output is non-deterministic.
+			if diff := cmp.Diff(original, roundTripped, protocmp.Transform()); diff != "" {
+				t.Errorf("plan round-trip mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestRejectsMismatchedRootNames(t *testing.T) {
 	b := NewBuilderDefault()
 	scan := b.NamedScan([]string{"test"}, types.NamedStruct{
@@ -134,8 +234,6 @@ func TestRejectsMismatchedRootNames(t *testing.T) {
 
 func TestFromProtoWithSubqueries(t *testing.T) {
 	c := extensions.GetDefaultCollectionWithNoError()
-
-	// Build a named-scan relation proto to embed as subquery input.
 	scanProto := &proto.Rel{
 		RelType: &proto.Rel_Read{
 			Read: &proto.ReadRel{
@@ -151,88 +249,120 @@ func TestFromProtoWithSubqueries(t *testing.T) {
 			},
 		},
 	}
+	needle := expr.NewPrimitiveLiteral(int32(1), false).ToProto()
+	tests := []struct {
+		name     string
+		subquery *proto.Expression_Subquery
+	}{
+		{
+			name: "ScalarSubquery",
+			subquery: &proto.Expression_Subquery{
+				SubqueryType: &proto.Expression_Subquery_Scalar_{
+					Scalar: &proto.Expression_Subquery_Scalar{Input: scanProto},
+				},
+			},
+		},
+		{
+			name: "InPredicateSubquery",
+			subquery: &proto.Expression_Subquery{
+				SubqueryType: &proto.Expression_Subquery_InPredicate_{
+					InPredicate: &proto.Expression_Subquery_InPredicate{
+						Needles:  []*proto.Expression{needle},
+						Haystack: scanProto,
+					},
+				},
+			},
+		},
+		{
+			name: "SetPredicateSubquery",
+			subquery: &proto.Expression_Subquery{
+				SubqueryType: &proto.Expression_Subquery_SetPredicate_{
+					SetPredicate: &proto.Expression_Subquery_SetPredicate{
+						PredicateOp: proto.Expression_Subquery_SetPredicate_PREDICATE_OP_EXISTS,
+						Tuples:      scanProto,
+					},
+				},
+			},
+		},
+		{
+			name: "SetComparisonSubquery",
+			subquery: &proto.Expression_Subquery{
+				SubqueryType: &proto.Expression_Subquery_SetComparison_{
+					SetComparison: &proto.Expression_Subquery_SetComparison{
+						ReductionOp:  proto.Expression_Subquery_SetComparison_REDUCTION_OP_ANY,
+						ComparisonOp: proto.Expression_Subquery_SetComparison_COMPARISON_OP_EQ,
+						Left:         needle,
+						Right:        scanProto,
+					},
+				},
+			},
+		},
+	}
 
-	makePlan := func(subquery *proto.Expression_Subquery) *proto.Plan {
-		return &proto.Plan{
-			Relations: []*proto.PlanRel{
-				{
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &proto.Plan{
+				Relations: []*proto.PlanRel{{
 					RelType: &proto.PlanRel_Root{
 						Root: &proto.RelRoot{
 							Names: []string{"out"},
 							Input: &proto.Rel{
 								RelType: &proto.Rel_Filter{
 									Filter: &proto.FilterRel{
-										Common: &proto.RelCommon{EmitKind: &proto.RelCommon_Direct_{Direct: &proto.RelCommon_Direct{}}},
-										Input:  scanProto,
-										Condition: &proto.Expression{
-											RexType: &proto.Expression_Subquery_{Subquery: subquery},
-										},
+										Common:    &proto.RelCommon{EmitKind: &proto.RelCommon_Direct_{Direct: &proto.RelCommon_Direct{}}},
+										Input:     scanProto,
+										Condition: &proto.Expression{RexType: &proto.Expression_Subquery_{Subquery: tc.subquery}},
 									},
 								},
 							},
 						},
 					},
+				}},
+			}
+			result, err := FromProto(p, c)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+		})
+	}
+}
+
+func TestBuilderPlanRegistryWithSubqueries(t *testing.T) {
+	b := NewBuilderDefault()
+	scan := b.NamedScan([]string{"t"}, types.NamedStruct{
+		Names: []string{"col1"},
+		Struct: types.StructType{Types: []types.Type{&types.Int32Type{}}},
+	})
+	p, err := b.Plan(scan, []string{"col1"})
+	require.NoError(t, err)
+
+	scanProto := &proto.Rel{
+		RelType: &proto.Rel_Read{
+			Read: &proto.ReadRel{
+				Common: &proto.RelCommon{EmitKind: &proto.RelCommon_Direct_{Direct: &proto.RelCommon_Direct{}}},
+				BaseSchema: &proto.NamedStruct{
+					Names: []string{"col1"},
+					Struct: &proto.Type_Struct{
+						Nullability: proto.Type_NULLABILITY_REQUIRED,
+						Types:       []*proto.Type{{Kind: &proto.Type_I32_{I32: &proto.Type_I32{Nullability: proto.Type_NULLABILITY_REQUIRED}}}},
+					},
+				},
+				ReadType: &proto.ReadRel_NamedTable_{NamedTable: &proto.ReadRel_NamedTable{Names: []string{"t"}}},
+			},
+		},
+	}
+	subqueryExprProto := &proto.Expression{
+		RexType: &proto.Expression_Subquery_{
+			Subquery: &proto.Expression_Subquery{
+				SubqueryType: &proto.Expression_Subquery_Scalar_{
+					Scalar: &proto.Expression_Subquery_Scalar{Input: scanProto},
 				},
 			},
-		}
+		},
 	}
 
-	t.Run("ScalarSubquery", func(t *testing.T) {
-		p := makePlan(&proto.Expression_Subquery{
-			SubqueryType: &proto.Expression_Subquery_Scalar_{
-				Scalar: &proto.Expression_Subquery_Scalar{Input: scanProto},
-			},
-		})
-		result, err := FromProto(p, c)
-		require.NoError(t, err)
-		require.NotNil(t, result)
-	})
-
-	t.Run("InPredicateSubquery", func(t *testing.T) {
-		needle := expr.NewPrimitiveLiteral(int32(1), false).ToProto()
-		p := makePlan(&proto.Expression_Subquery{
-			SubqueryType: &proto.Expression_Subquery_InPredicate_{
-				InPredicate: &proto.Expression_Subquery_InPredicate{
-					Needles:  []*proto.Expression{needle},
-					Haystack: scanProto,
-				},
-			},
-		})
-		result, err := FromProto(p, c)
-		require.NoError(t, err)
-		require.NotNil(t, result)
-	})
-
-	t.Run("SetPredicateSubquery", func(t *testing.T) {
-		p := makePlan(&proto.Expression_Subquery{
-			SubqueryType: &proto.Expression_Subquery_SetPredicate_{
-				SetPredicate: &proto.Expression_Subquery_SetPredicate{
-					PredicateOp: proto.Expression_Subquery_SetPredicate_PREDICATE_OP_EXISTS,
-					Tuples:      scanProto,
-				},
-			},
-		})
-		result, err := FromProto(p, c)
-		require.NoError(t, err)
-		require.NotNil(t, result)
-	})
-
-	t.Run("SetComparisonSubquery", func(t *testing.T) {
-		left := expr.NewPrimitiveLiteral(int32(1), false).ToProto()
-		p := makePlan(&proto.Expression_Subquery{
-			SubqueryType: &proto.Expression_Subquery_SetComparison_{
-				SetComparison: &proto.Expression_Subquery_SetComparison{
-					ReductionOp:  proto.Expression_Subquery_SetComparison_REDUCTION_OP_ANY,
-					ComparisonOp: proto.Expression_Subquery_SetComparison_COMPARISON_OP_EQ,
-					Left:         left,
-					Right:        scanProto,
-				},
-			},
-		})
-		result, err := FromProto(p, c)
-		require.NoError(t, err)
-		require.NotNil(t, result)
-	})
+	result, err := expr.ExprFromProto(subqueryExprProto, &types.RecordType{}, p.ExtensionRegistry())
+	require.NoError(t, err)
+	require.NotNil(t, result)
 }
 
 func TestFromProtoRightSemiJoinRootNames(t *testing.T) {


### PR DESCRIPTION
When deserializing a plan from protobuf via FromProto, or when building a plan via PlanWithBindings, subquery expressions could not be resolved because the SubqueryConverter was never registered on the extension registry. This caused subquery expression conversion to silently fail or panic. This PR fixes this so that protobuf plans with Subquery Expressions can also be deserialized correctly.
