### PR TITLE
fix: decode schemas in extension relations

### DIFF
--- a/expr/expressions_test.go
+++ b/expr/expressions_test.go
@@ -729,4 +729,3 @@ type stubRelDecoder struct{}
 func (s *stubRelDecoder) DecodeExtensionRel(_ *anypb.Any) (any, error) {
 	return nil, errors.New("stub")
 }
-

--- a/expr/expressions_test.go
+++ b/expr/expressions_test.go
@@ -699,27 +699,26 @@ func TestSubqueryExpressionRoundtrip(t *testing.T) {
 }
 
 func TestExtensionRegistrySetAndGetDecoder(t *testing.T) {
+	const typeURL = "type.googleapis.com/test.Ext"
 	c := ext.GetDefaultCollectionWithNoError()
 
 	t.Run("nil before set", func(t *testing.T) {
 		reg := expr.NewEmptyExtensionRegistry(c)
-		require.Nil(t, reg.ExtensionRelDecoderFor())
+		require.Nil(t, reg.ExtensionRelDecoderFor(typeURL))
 	})
 
 	t.Run("returns decoder after set", func(t *testing.T) {
 		reg := expr.NewEmptyExtensionRegistry(c)
 		dec := &stubRelDecoder{}
-		reg.SetExtensionRelDecoder(dec)
-		require.Equal(t, dec, reg.ExtensionRelDecoderFor())
+		require.NoError(t, reg.SetExtensionRelDecoder(typeURL, dec))
+		require.Equal(t, dec, reg.ExtensionRelDecoderFor(typeURL))
 	})
 
-	t.Run("overwrite replaces decoder", func(t *testing.T) {
+	t.Run("duplicate typeURL returns error", func(t *testing.T) {
 		reg := expr.NewEmptyExtensionRegistry(c)
-		first := &stubRelDecoder{}
-		second := &stubRelDecoder{}
-		reg.SetExtensionRelDecoder(first)
-		reg.SetExtensionRelDecoder(second)
-		require.Equal(t, second, reg.ExtensionRelDecoderFor())
+		require.NoError(t, reg.SetExtensionRelDecoder(typeURL, &stubRelDecoder{}))
+		err := reg.SetExtensionRelDecoder(typeURL, &stubRelDecoder{})
+		require.ErrorContains(t, err, typeURL)
 	})
 }
 

--- a/expr/expressions_test.go
+++ b/expr/expressions_test.go
@@ -5,6 +5,7 @@ package expr_test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -14,6 +15,7 @@ import (
 	"github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	substraitgo "github.com/substrait-io/substrait-go/v8"
 	"github.com/substrait-io/substrait-go/v8/expr"
 	ext "github.com/substrait-io/substrait-go/v8/extensions"
 	"github.com/substrait-io/substrait-go/v8/plan"
@@ -22,6 +24,7 @@ import (
 	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
 	"google.golang.org/protobuf/encoding/protojson"
 	pb "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 const sampleYAML = `---
@@ -694,4 +697,70 @@ func TestSubqueryExpressionRoundtrip(t *testing.T) {
 			// comment in plan/subquery.go
 		})
 	}
+}
+
+func TestExtensionRegistrySetAndGetDecoder(t *testing.T) {
+	c := ext.GetDefaultCollectionWithNoError()
+
+	t.Run("nil before set", func(t *testing.T) {
+		reg := expr.NewEmptyExtensionRegistry(c)
+		require.Nil(t, reg.ExtensionRelDecoderFor())
+	})
+
+	t.Run("returns decoder after set", func(t *testing.T) {
+		reg := expr.NewEmptyExtensionRegistry(c)
+		dec := &stubRelDecoder{}
+		reg.SetExtensionRelDecoder(dec)
+		require.Equal(t, dec, reg.ExtensionRelDecoderFor())
+	})
+
+	t.Run("overwrite replaces decoder", func(t *testing.T) {
+		reg := expr.NewEmptyExtensionRegistry(c)
+		first := &stubRelDecoder{}
+		second := &stubRelDecoder{}
+		reg.SetExtensionRelDecoder(first)
+		reg.SetExtensionRelDecoder(second)
+		require.Equal(t, second, reg.ExtensionRelDecoderFor())
+	})
+}
+
+// stubRelDecoder is a minimal ExtensionRelDecoder that always returns an error.
+type stubRelDecoder struct{}
+
+func (s *stubRelDecoder) DecodeExtensionRel(_ *anypb.Any) (any, error) {
+	return nil, errors.New("stub")
+}
+
+func TestStructFieldRefGetTypeBounds(t *testing.T) {
+	st := &types.StructType{
+		Types: []types.Type{
+			&types.Int64Type{Nullability: types.NullabilityRequired},
+			&types.Int32Type{Nullability: types.NullabilityRequired},
+		},
+	}
+
+	t.Run("valid index returns type", func(t *testing.T) {
+		ref := &expr.StructFieldRef{Field: 0}
+		got, err := ref.GetType(st)
+		require.NoError(t, err)
+		assert.IsType(t, &types.Int64Type{}, got)
+	})
+
+	t.Run("negative index returns error", func(t *testing.T) {
+		ref := &expr.StructFieldRef{Field: -1}
+		_, err := ref.GetType(st)
+		require.ErrorIs(t, err, substraitgo.ErrInvalidType)
+	})
+
+	t.Run("index equal to len returns error", func(t *testing.T) {
+		ref := &expr.StructFieldRef{Field: int32(len(st.Types))}
+		_, err := ref.GetType(st)
+		require.ErrorIs(t, err, substraitgo.ErrInvalidType)
+	})
+
+	t.Run("index beyond len returns error", func(t *testing.T) {
+		ref := &expr.StructFieldRef{Field: int32(len(st.Types) + 1)}
+		_, err := ref.GetType(st)
+		require.ErrorIs(t, err, substraitgo.ErrInvalidType)
+	})
 }

--- a/expr/expressions_test.go
+++ b/expr/expressions_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	substraitgo "github.com/substrait-io/substrait-go/v8"
 	"github.com/substrait-io/substrait-go/v8/expr"
 	ext "github.com/substrait-io/substrait-go/v8/extensions"
 	"github.com/substrait-io/substrait-go/v8/plan"
@@ -731,36 +730,3 @@ func (s *stubRelDecoder) DecodeExtensionRel(_ *anypb.Any) (any, error) {
 	return nil, errors.New("stub")
 }
 
-func TestStructFieldRefGetTypeBounds(t *testing.T) {
-	st := &types.StructType{
-		Types: []types.Type{
-			&types.Int64Type{Nullability: types.NullabilityRequired},
-			&types.Int32Type{Nullability: types.NullabilityRequired},
-		},
-	}
-
-	t.Run("valid index returns type", func(t *testing.T) {
-		ref := &expr.StructFieldRef{Field: 0}
-		got, err := ref.GetType(st)
-		require.NoError(t, err)
-		assert.IsType(t, &types.Int64Type{}, got)
-	})
-
-	t.Run("negative index returns error", func(t *testing.T) {
-		ref := &expr.StructFieldRef{Field: -1}
-		_, err := ref.GetType(st)
-		require.ErrorIs(t, err, substraitgo.ErrInvalidType)
-	})
-
-	t.Run("index equal to len returns error", func(t *testing.T) {
-		ref := &expr.StructFieldRef{Field: int32(len(st.Types))}
-		_, err := ref.GetType(st)
-		require.ErrorIs(t, err, substraitgo.ErrInvalidType)
-	})
-
-	t.Run("index beyond len returns error", func(t *testing.T) {
-		ref := &expr.StructFieldRef{Field: int32(len(st.Types) + 1)}
-		_, err := ref.GetType(st)
-		require.ErrorIs(t, err, substraitgo.ErrInvalidType)
-	})
-}

--- a/expr/field_reference.go
+++ b/expr/field_reference.go
@@ -192,7 +192,7 @@ func (r *StructFieldRef) GetType(parentType types.Type) (types.Type, error) {
 		return nil, substraitgo.ErrInvalidType
 	}
 
-	if r.Field < 0 || int(r.Field) >= len(st.Types) {
+	if len(st.Types) < int(r.Field) {
 		return nil, substraitgo.ErrInvalidType
 	}
 

--- a/expr/field_reference.go
+++ b/expr/field_reference.go
@@ -192,7 +192,7 @@ func (r *StructFieldRef) GetType(parentType types.Type) (types.Type, error) {
 		return nil, substraitgo.ErrInvalidType
 	}
 
-	if len(st.Types) < int(r.Field) {
+	if r.Field < 0 || int(r.Field) >= len(st.Types) {
 		return nil, substraitgo.ErrInvalidType
 	}
 

--- a/expr/utils.go
+++ b/expr/utils.go
@@ -15,11 +15,12 @@ import (
 // It is called by RelFromProto instead of falling back to UndecodedExtension
 // when a decoder is registered for the detail's type URL.
 //
-// The Rel type is intentionally left as an interface{} here to avoid an import
-// cycle between the expr and plan packages; the plan package casts it to plan.Rel
-// via the ExtensionRelDecoderFunc type alias defined there.
+// The return type is intentionally left as any to avoid an import cycle between
+// the expr and plan packages; callers cast it to the appropriate concrete type.
 type ExtensionRelDecoder interface {
-	// DecodeExtensionRel attempts to decode detail into an ExtensionRelDefinition.
+	// DecodeExtensionRel attempts to decode detail into a plan.ExtensionRelDefinition.
+	// The return type is any because ExtensionRelDefinition is defined in the plan
+	// package, and importing it here would create a cycle with the expr package.
 	// Returns (nil, nil) to signal that this decoder does not handle the given detail,
 	// allowing fallback to UndecodedExtension.
 	DecodeExtensionRel(detail *anypb.Any) (any, error)

--- a/expr/utils.go
+++ b/expr/utils.go
@@ -3,6 +3,8 @@
 package expr
 
 import (
+	"fmt"
+
 	"github.com/substrait-io/substrait-go/v8/extensions"
 	"github.com/substrait-io/substrait-go/v8/types"
 	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
@@ -12,17 +14,15 @@ import (
 
 // ExtensionRelDecoder decodes an extension relation's Any detail into an
 // ExtensionRelDefinition that knows its output schema and expressions.
-// It is called by RelFromProto instead of falling back to UndecodedExtension
-// when a decoder is registered for the detail's type URL.
+// It is called by RelFromProto for extension rels whose type URL has a
+// registered decoder; unregistered type URLs fall back to UndecodedExtension.
 //
 // The return type is intentionally left as any to avoid an import cycle between
 // the expr and plan packages; callers cast it to the appropriate concrete type.
 type ExtensionRelDecoder interface {
-	// DecodeExtensionRel attempts to decode detail into a plan.ExtensionRelDefinition.
+	// DecodeExtensionRel decodes detail into a plan.ExtensionRelDefinition.
 	// The return type is any because ExtensionRelDefinition is defined in the plan
 	// package, and importing it here would create a cycle with the expr package.
-	// Returns (nil, nil) to signal that this decoder does not handle the given detail,
-	// allowing fallback to UndecodedExtension.
 	DecodeExtensionRel(detail *anypb.Any) (any, error)
 }
 
@@ -36,9 +36,8 @@ type ExtensionRegistry struct {
 	// TODO: We may want to consider refactoring to make a cleaner interface here
 	subqueryConverter
 
-	// extensionRelDecoder is optionally set to decode extension relation details
-	// into typed ExtensionRelDefinitions during RelFromProto.
-	extensionRelDecoder ExtensionRelDecoder
+	// extensionRelDecoders maps type URLs to decoders for extension relation details.
+	extensionRelDecoders map[string]ExtensionRelDecoder
 }
 
 // subqueryConverter converts subqueries and the Relations within from the native
@@ -61,17 +60,24 @@ func (e *ExtensionRegistry) SetSubqueryConverter(converter subqueryConverter) {
 	e.subqueryConverter = converter
 }
 
-// SetExtensionRelDecoder registers a decoder that RelFromProto will call for
-// each ExtensionSingle/ExtensionMulti/ExtensionLeaf relation. If the decoder
-// returns a non-nil value it is used as the ExtensionRelDefinition; if it
-// returns (nil, nil) RelFromProto falls back to UndecodedExtension.
-func (e *ExtensionRegistry) SetExtensionRelDecoder(decoder ExtensionRelDecoder) {
-	e.extensionRelDecoder = decoder
+// SetExtensionRelDecoder registers a decoder for the given type URL.
+// RelFromProto dispatches to it when it encounters an extension rel whose
+// detail matches typeURL; unregistered type URLs fall back to UndecodedExtension.
+// Returns an error if a decoder is already registered for typeURL.
+func (e *ExtensionRegistry) SetExtensionRelDecoder(typeURL string, decoder ExtensionRelDecoder) error {
+	if e.extensionRelDecoders == nil {
+		e.extensionRelDecoders = make(map[string]ExtensionRelDecoder)
+	}
+	if _, exists := e.extensionRelDecoders[typeURL]; exists {
+		return fmt.Errorf("decoder already registered for type URL %q", typeURL)
+	}
+	e.extensionRelDecoders[typeURL] = decoder
+	return nil
 }
 
-// ExtensionRelDecoderFor returns the registered decoder, or nil if none was set.
-func (e *ExtensionRegistry) ExtensionRelDecoderFor() ExtensionRelDecoder {
-	return e.extensionRelDecoder
+// ExtensionRelDecoderFor returns the decoder registered for typeURL, or nil if none was set.
+func (e *ExtensionRegistry) ExtensionRelDecoderFor(typeURL string) ExtensionRelDecoder {
+	return e.extensionRelDecoders[typeURL]
 }
 
 // NewExtensionRegistry creates a new registry.  If you have an existing plan you can use GetExtensionSet() to

--- a/expr/utils.go
+++ b/expr/utils.go
@@ -7,7 +7,23 @@ import (
 	"github.com/substrait-io/substrait-go/v8/types"
 	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
 	extensionspb "github.com/substrait-io/substrait-protobuf/go/substraitpb/extensions"
+	"google.golang.org/protobuf/types/known/anypb"
 )
+
+// ExtensionRelDecoder decodes an extension relation's Any detail into an
+// ExtensionRelDefinition that knows its output schema and expressions.
+// It is called by RelFromProto instead of falling back to UndecodedExtension
+// when a decoder is registered for the detail's type URL.
+//
+// The Rel type is intentionally left as an interface{} here to avoid an import
+// cycle between the expr and plan packages; the plan package casts it to plan.Rel
+// via the ExtensionRelDecoderFunc type alias defined there.
+type ExtensionRelDecoder interface {
+	// DecodeExtensionRel attempts to decode detail into an ExtensionRelDefinition.
+	// Returns (nil, nil) to signal that this decoder does not handle the given detail,
+	// allowing fallback to UndecodedExtension.
+	DecodeExtensionRel(detail *anypb.Any) (any, error)
+}
 
 // ExtensionRegistry provides functionality to resolve extension references and handle subquery expressions.
 // It combines an extensions.Set for looking up extension definitions with a Collection for extension metadata.
@@ -18,6 +34,10 @@ type ExtensionRegistry struct {
 	// subqueryConverter is injected by the plan package to handle subquery expressions
 	// TODO: We may want to consider refactoring to make a cleaner interface here
 	subqueryConverter
+
+	// extensionRelDecoder is optionally set to decode extension relation details
+	// into typed ExtensionRelDefinitions during RelFromProto.
+	extensionRelDecoder ExtensionRelDecoder
 }
 
 // subqueryConverter converts subqueries and the Relations within from the native
@@ -38,6 +58,19 @@ type subqueryConverter interface {
 // This is an internal function used to break the dependency cycle between expr and plan packages.
 func (e *ExtensionRegistry) SetSubqueryConverter(converter subqueryConverter) {
 	e.subqueryConverter = converter
+}
+
+// SetExtensionRelDecoder registers a decoder that RelFromProto will call for
+// each ExtensionSingle/ExtensionMulti/ExtensionLeaf relation. If the decoder
+// returns a non-nil value it is used as the ExtensionRelDefinition; if it
+// returns (nil, nil) RelFromProto falls back to UndecodedExtension.
+func (e *ExtensionRegistry) SetExtensionRelDecoder(decoder ExtensionRelDecoder) {
+	e.extensionRelDecoder = decoder
+}
+
+// ExtensionRelDecoderFor returns the registered decoder, or nil if none was set.
+func (e *ExtensionRegistry) ExtensionRelDecoderFor() ExtensionRelDecoder {
+	return e.extensionRelDecoder
 }
 
 // NewExtensionRegistry creates a new registry.  If you have an existing plan you can use GetExtensionSet() to

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -226,6 +226,13 @@ func (p *Plan) ParameterBindings() []DynamicParameterBinding {
 }
 
 func FromProto(plan *proto.Plan, c *extensions.Collection) (*Plan, error) {
+	return FromProtoWithDecoder(plan, c, nil)
+}
+
+// FromProtoWithDecoder is like FromProto but registers per-typeURL ExtensionRelDecoders
+// on the registry before parsing relations, allowing extension rels to be
+// decoded into typed ExtensionRelDefinitions rather than UndecodedExtension.
+func FromProtoWithDecoder(plan *proto.Plan, c *extensions.Collection, decoders map[string]expr.ExtensionRelDecoder) (*Plan, error) {
 	extSet, err := extensions.GetExtensionSet(plan, c)
 	if err != nil {
 		return nil, err
@@ -240,6 +247,11 @@ func FromProto(plan *proto.Plan, c *extensions.Collection) (*Plan, error) {
 
 	ret.reg = expr.NewExtensionRegistry(ret.extensions, c)
 	ret.reg.SetSubqueryConverter(&ExpressionConverter{ExtensionRegistry: ret.reg})
+	for typeURL, dec := range decoders {
+		if err := ret.reg.SetExtensionRelDecoder(typeURL, dec); err != nil {
+			return nil, err
+		}
+	}
 	for i, r := range plan.Relations {
 		if err := ret.relations[i].FromProto(r, ret.reg); err != nil {
 			return nil, err
@@ -415,22 +427,19 @@ type Rel interface {
 	CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInputs ...Rel) (Rel, error)
 }
 
-// decodeExtensionDef uses the registry's ExtensionRelDecoder (if any) to
-// produce a typed ExtensionRelDefinition for the given detail. Falls back to
-// UndecodedExtension when no decoder is registered or the decoder declines.
+// decodeExtensionDef dispatches to the decoder registered for detail's type URL (if any).
+// Falls back to UndecodedExtension for unregistered type URLs.
 func decodeExtensionDef(reg expr.ExtensionRegistry, detail *anypb.Any) (ExtensionRelDefinition, error) {
-	if dec := reg.ExtensionRelDecoderFor(); dec != nil {
+	if dec := reg.ExtensionRelDecoderFor(detail.GetTypeUrl()); dec != nil {
 		raw, err := dec.DecodeExtensionRel(detail)
 		if err != nil {
 			return nil, err
 		}
-		if raw != nil {
-			def, ok := raw.(ExtensionRelDefinition)
-			if !ok {
-				return nil, fmt.Errorf("ExtensionRelDecoder returned %T which does not implement ExtensionRelDefinition", raw)
-			}
-			return def, nil
+		def, ok := raw.(ExtensionRelDefinition)
+		if !ok {
+			return nil, fmt.Errorf("ExtensionRelDecoder returned %T which does not implement ExtensionRelDefinition", raw)
 		}
+		return def, nil
 	}
 	return &UndecodedExtension{detail: detail}, nil
 }

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -415,6 +415,26 @@ type Rel interface {
 	CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInputs ...Rel) (Rel, error)
 }
 
+// decodeExtensionDef uses the registry's ExtensionRelDecoder (if any) to
+// produce a typed ExtensionRelDefinition for the given detail. Falls back to
+// UndecodedExtension when no decoder is registered or the decoder declines.
+func decodeExtensionDef(reg expr.ExtensionRegistry, detail *anypb.Any) (ExtensionRelDefinition, error) {
+	if dec := reg.ExtensionRelDecoderFor(); dec != nil {
+		raw, err := dec.DecodeExtensionRel(detail)
+		if err != nil {
+			return nil, err
+		}
+		if raw != nil {
+			def, ok := raw.(ExtensionRelDefinition)
+			if !ok {
+				return nil, fmt.Errorf("ExtensionRelDecoder returned %T which does not implement ExtensionRelDefinition", raw)
+			}
+			return def, nil
+		}
+	}
+	return &UndecodedExtension{detail: detail}, nil
+}
+
 func RelFromProto(rel *proto.Rel, reg expr.ExtensionRegistry) (Rel, error) {
 	switch rel := rel.RelType.(type) {
 	case *proto.Rel_Read:
@@ -731,11 +751,13 @@ func RelFromProto(rel *proto.Rel, reg expr.ExtensionRegistry) (Rel, error) {
 			return nil, fmt.Errorf("error getting input to ExtensionSingle: %w", err)
 		}
 
-		// TODO: we should probably be adding Extension relations to the ExtensionRegistry,
-		// look up extensions from there, and have a way to decode *anypb.Any to ExtensionRelDefinitions
+		definition, err := decodeExtensionDef(reg, rel.ExtensionSingle.Detail)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding ExtensionSingle detail: %w", err)
+		}
 		out := &ExtensionSingleRel{
 			input:      input,
-			definition: &UndecodedExtension{detail: rel.ExtensionSingle.Detail},
+			definition: definition,
 		}
 		out.fromProtoCommon(rel.ExtensionSingle.Common)
 
@@ -750,21 +772,24 @@ func RelFromProto(rel *proto.Rel, reg expr.ExtensionRegistry) (Rel, error) {
 			}
 		}
 
-		// TODO: we should probably be adding Extension relations to the ExtensionRegistry,
-		// look up extensions from there, and have a way to decode *anypb.Any to ExtensionRelDefinitions
+		definition, err := decodeExtensionDef(reg, rel.ExtensionMulti.Detail)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding ExtensionMulti detail: %w", err)
+		}
 		out := &ExtensionMultiRel{
 			inputs:     inputs,
-			definition: &UndecodedExtension{detail: rel.ExtensionMulti.Detail},
+			definition: definition,
 		}
 		out.fromProtoCommon(rel.ExtensionMulti.Common)
 
 		return out, nil
 	case *proto.Rel_ExtensionLeaf:
-
-		// TODO: we should probably be adding Extension relations to the ExtensionRegistry,
-		// look up extensions from there, and have a way to decode *anypb.Any to ExtensionRelDefinitions
+		definition, err := decodeExtensionDef(reg, rel.ExtensionLeaf.Detail)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding ExtensionLeaf detail: %w", err)
+		}
 		out := &ExtensionLeafRel{
-			definition: &UndecodedExtension{detail: rel.ExtensionLeaf.Detail},
+			definition: definition,
 		}
 		out.fromProtoCommon(rel.ExtensionLeaf.Common)
 

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -318,8 +318,15 @@ func validateRootNamesForSchema(recordType types.RecordType, names []string) err
 // TODO(#210): remove this once RecordType() is fixed for all relation types.
 func isRecordTypeSupported(rel Rel) bool {
 	switch r := rel.(type) {
-	case *ExtensionSingleRel, *ExtensionLeafRel, *ExtensionMultiRel:
-		return false // TODO(#210): UndecodedExtension.Schema() guesses or returns empty
+	case *ExtensionSingleRel:
+		_, undecoded := r.Definition().(*UndecodedExtension)
+		return !undecoded
+	case *ExtensionLeafRel:
+		_, undecoded := r.Definition().(*UndecodedExtension)
+		return !undecoded
+	case *ExtensionMultiRel:
+		_, undecoded := r.Definition().(*UndecodedExtension)
+		return !undecoded
 	case *NamedTableWriteRel:
 		return false // TODO(#210): panics when outputMode is unspecified
 	case *JoinRel:

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	protobuf "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 func TestRelFromProto(t *testing.T) {
@@ -120,15 +121,21 @@ func TestPlanRoundTripWithExtensions(t *testing.T) {
 
 func TestPlanRoundTripWithSubqueries(t *testing.T) {
 	c := extensions.GetDefaultCollectionWithNoError()
+
+	i32Type := &proto.Type{Kind: &proto.Type_I32_{I32: &proto.Type_I32{Nullability: proto.Type_NULLABILITY_REQUIRED}}}
+	i64Type := &proto.Type{Kind: &proto.Type_I64_{I64: &proto.Type_I64{Nullability: proto.Type_NULLABILITY_REQUIRED}}}
+	strType := &proto.Type{Kind: &proto.Type_String_{String_: &proto.Type_String{Nullability: proto.Type_NULLABILITY_REQUIRED}}}
+
+	// 3-column scan: col1 i32, col2 i64, col3 string
 	scanProto := &proto.Rel{
 		RelType: &proto.Rel_Read{
 			Read: &proto.ReadRel{
 				Common: &proto.RelCommon{EmitKind: &proto.RelCommon_Direct_{Direct: &proto.RelCommon_Direct{}}},
 				BaseSchema: &proto.NamedStruct{
-					Names: []string{"col1"},
+					Names: []string{"col1", "col2", "col3"},
 					Struct: &proto.Type_Struct{
 						Nullability: proto.Type_NULLABILITY_REQUIRED,
-						Types:       []*proto.Type{{Kind: &proto.Type_I32_{I32: &proto.Type_I32{Nullability: proto.Type_NULLABILITY_REQUIRED}}}},
+						Types:       []*proto.Type{i32Type, i64Type, strType},
 					},
 				},
 				ReadType: &proto.ReadRel_NamedTable_{NamedTable: &proto.ReadRel_NamedTable{Names: []string{"t"}}},
@@ -137,7 +144,7 @@ func TestPlanRoundTripWithSubqueries(t *testing.T) {
 	}
 	needle := expr.NewPrimitiveLiteral(int32(1), false).ToProto()
 
-	tests := []struct {
+	subqueries := []struct {
 		name     string
 		subquery *proto.Expression_Subquery
 	}{
@@ -186,35 +193,58 @@ func TestPlanRoundTripWithSubqueries(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			original := &proto.Plan{
-				Relations: []*proto.PlanRel{{
-					RelType: &proto.PlanRel_Root{
-						Root: &proto.RelRoot{
-							Names: []string{"out"},
-							Input: &proto.Rel{
-								RelType: &proto.Rel_Filter{
-									Filter: &proto.FilterRel{
-										Common:    &proto.RelCommon{EmitKind: &proto.RelCommon_Direct_{Direct: &proto.RelCommon_Direct{}}},
-										Input:     scanProto,
-										Condition: &proto.Expression{RexType: &proto.Expression_Subquery_{Subquery: tc.subquery}},
+	commons := []struct {
+		name   string
+		common *proto.RelCommon
+		// rootNames must match the number of output columns after the emit mapping
+		rootNames []string
+	}{
+		{
+			name:      "Direct",
+			common:    &proto.RelCommon{EmitKind: &proto.RelCommon_Direct_{Direct: &proto.RelCommon_Direct{}}},
+			rootNames: []string{"col1", "col2", "col3"},
+		},
+		{
+			// out-of-order emit: col3, col1, col2 → output mapping [2, 0, 1]
+			name: "Emit",
+			common: &proto.RelCommon{EmitKind: &proto.RelCommon_Emit_{
+				Emit: &proto.RelCommon_Emit{OutputMapping: []int32{2, 0, 1}},
+			}},
+			rootNames: []string{"col3", "col1", "col2"},
+		},
+	}
+
+	for _, sq := range subqueries {
+		for _, cm := range commons {
+			t.Run(sq.name+"/"+cm.name, func(t *testing.T) {
+				original := &proto.Plan{
+					Relations: []*proto.PlanRel{{
+						RelType: &proto.PlanRel_Root{
+							Root: &proto.RelRoot{
+								Names: cm.rootNames,
+								Input: &proto.Rel{
+									RelType: &proto.Rel_Filter{
+										Filter: &proto.FilterRel{
+											Common:    cm.common,
+											Input:     scanProto,
+											Condition: &proto.Expression{RexType: &proto.Expression_Subquery_{Subquery: sq.subquery}},
+										},
 									},
 								},
 							},
 						},
-					},
-				}},
-			}
-			p, err := FromProto(original, c)
-			require.NoError(t, err)
-			roundTripped, err := p.ToProto()
-			require.NoError(t, err)
-			// Use cmp.Diff instead of protojson for comparison: protojson output is non-deterministic.
-			if diff := cmp.Diff(original, roundTripped, protocmp.Transform()); diff != "" {
-				t.Errorf("plan round-trip mismatch (-want +got):\n%s", diff)
-			}
-		})
+					}},
+				}
+				p, err := FromProto(original, c)
+				require.NoError(t, err)
+				roundTripped, err := p.ToProto()
+				require.NoError(t, err)
+				// Use cmp.Diff instead of protojson for comparison: protojson output is non-deterministic.
+				if diff := cmp.Diff(original, roundTripped, protocmp.Transform()); diff != "" {
+					t.Errorf("plan round-trip mismatch (-want +got):\n%s", diff)
+				}
+			})
+		}
 	}
 }
 
@@ -418,4 +448,397 @@ func TestFromProtoRightSemiJoinRootNames(t *testing.T) {
 	c := extensions.GetDefaultCollectionWithNoError()
 	_, err := FromProto(&p, c)
 	require.NoError(t, err)
+}
+
+// TestProjectSetStyleDecoder models an extension that implements a
+// set-returning function (SRF / unnest-style) relation:
+//
+//   - The extension detail is an anypb.Any whose Value encodes a list of SRF
+//     expressions (one per output column beyond the passthrough input columns).
+//   - The extension's output schema = input schema + one col per SRF expression,
+//     typed from the expression's output type.
+//   - A registered ExtensionRelDecoder (psStyleDecoder) unpacks the detail,
+//     resolves each expression via ExprFromProto, and returns an
+//     ExtensionRelDefinition with the full output schema.
+//
+// Without the decoder, UndecodedExtension returns only the input schema, so an
+// emit mapping that references the SRF output column panics on RecordType().
+// The test also verifies round-trip fidelity: ToProto() reproduces the original proto.
+func TestProjectSetStyleDecoder(t *testing.T) {
+	const projectSetTypeURL = "type.googleapis.com/test.ProjectSetRel"
+
+	// inputSchema: one i64 column ("a") — the passthrough column.
+	inputSchema := *types.NewRecordTypeFromTypes([]types.Type{
+		&types.Int64Type{Nullability: types.NullabilityRequired},
+	})
+
+	// SRF expression: literal i32 (models an unnest() returning i32 rows).
+	// The decoder will call ExprFromProto on this to learn the SRF output type.
+	srfExprProto := &proto.Expression{
+		RexType: &proto.Expression_Literal_{
+			Literal: &proto.Expression_Literal{
+				LiteralType: &proto.Expression_Literal_I32{I32: 42},
+			},
+		},
+	}
+
+	// Build the detail: Any{typeURL, value=marshal(Expression_Nested_Struct{srfExpr})}.
+	// psStyleDecoder unmarshals this to recover the SRF expressions.
+	// A real implementation would similarly marshal each SRF expression
+	// into an Any-wrapped proto inside the extension's own message type.
+	nestedStruct := &proto.Expression_Nested_Struct{
+		Fields: []*proto.Expression{srfExprProto},
+	}
+	nestedBytes, err := protobuf.Marshal(nestedStruct)
+	require.NoError(t, err)
+	projectSetDetail := &anypb.Any{TypeUrl: projectSetTypeURL, Value: nestedBytes}
+
+	// Build the input rel proto. directCommon is set so ToProto() round-trips exactly.
+	inputRelProto := &proto.Rel{
+		RelType: &proto.Rel_Read{
+			Read: &proto.ReadRel{
+				Common: directCommon,
+				BaseSchema: &proto.NamedStruct{
+					Names: []string{"a"},
+					Struct: &proto.Type_Struct{
+						Types: []*proto.Type{
+							{Kind: &proto.Type_I64_{I64: &proto.Type_I64{Nullability: proto.Type_NULLABILITY_REQUIRED}}},
+						},
+					},
+				},
+				ReadType: &proto.ReadRel_VirtualTable_{VirtualTable: &proto.ReadRel_VirtualTable{}},
+			},
+		},
+	}
+
+	// ExtensionSingleRel with emit [0, 1]:
+	//   col 0 = passthrough input col "a" (i64)
+	//   col 1 = SRF output col (i32, from the literal expression)
+	extSingleProto := &proto.ExtensionSingleRel{
+		Common: emit01,
+		Input:  inputRelProto,
+		Detail: projectSetDetail,
+	}
+	rel := &proto.Rel{RelType: &proto.Rel_ExtensionSingle{ExtensionSingle: extSingleProto}}
+
+	makeDecoder := func(reg expr.ExtensionRegistry) expr.ExtensionRelDecoder {
+		return projectSetDecoderFor(projectSetTypeURL, inputSchema, reg)
+	}
+
+	t.Run("without decoder panics on emit OOB", func(t *testing.T) {
+		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+		require.Panics(t, func() {
+			out, err := RelFromProto(rel, reg)
+			require.NoError(t, err)
+			_ = out.RecordType()
+		})
+	})
+
+	t.Run("with decoder schema is input+srf", func(t *testing.T) {
+		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+		reg.SetExtensionRelDecoder(makeDecoder(reg))
+
+		out, err := RelFromProto(rel, reg)
+		require.NoError(t, err)
+
+		got := out.RecordType()
+		// emit [0,1] selects both cols from the 2-col schema — result is 2 cols.
+		require.Equal(t, int32(2), got.FieldCount())
+		// col 0 = i64 (passthrough), col 1 = i32 (SRF output)
+		assert.IsType(t, &types.Int64Type{}, got.GetFieldRef(0))
+		assert.IsType(t, &types.Int32Type{}, got.GetFieldRef(1))
+	})
+
+	t.Run("round-trip ToProto matches original", func(t *testing.T) {
+		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+		reg.SetExtensionRelDecoder(makeDecoder(reg))
+
+		out, err := RelFromProto(rel, reg)
+		require.NoError(t, err)
+
+		got := out.ToProto()
+		if diff := cmp.Diff(rel, got, protocmp.Transform()); diff != "" {
+			t.Errorf("round-trip mismatch (-want +got):\n%s", diff)
+		}
+	})
+}
+
+// projectSetDecoderFor returns an ExtensionRelDecoder that handles the
+// ProjectSet-style extension: it unpacks a nested struct of SRF expressions
+// from the detail, resolves each expression's output type via ExprFromProto
+// against the provided inputSchema, and returns an ExtensionRelDefinition
+// whose Schema() = inputSchema + SRF output types.
+//
+// This mirrors the pattern used by SRF-style extension relations.
+func projectSetDecoderFor(typeURL string, inputSchema types.RecordType, reg expr.ExtensionRegistry) expr.ExtensionRelDecoder {
+	return &psStyleDecoder{typeURL: typeURL, inputSchema: inputSchema, reg: reg}
+}
+
+type psStyleDecoder struct {
+	typeURL     string
+	inputSchema types.RecordType
+	reg         expr.ExtensionRegistry
+}
+
+func (d *psStyleDecoder) DecodeExtensionRel(detail *anypb.Any) (any, error) {
+	if detail == nil || detail.TypeUrl != d.typeURL {
+		return nil, nil
+	}
+	var ns proto.Expression_Nested_Struct
+	if err := protobuf.Unmarshal(detail.Value, &ns); err != nil {
+		return nil, err
+	}
+	srfFields := ns.GetFields()
+	srfTypes := make([]types.Type, 0, len(srfFields))
+	for _, f := range srfFields {
+		stExpr, err := expr.ExprFromProto(f, &d.inputSchema, d.reg)
+		if err != nil {
+			return nil, err
+		}
+		srfTypes = append(srfTypes, stExpr.GetType())
+	}
+	fullSchema := d.inputSchema.Concat(*types.NewRecordTypeFromTypes(srfTypes))
+	return &customExtDef{schema: fullSchema, detail: detail}, nil
+}
+
+// customExtDef is a test ExtensionRelDefinition that claims a fixed output schema.
+type customExtDef struct {
+	detail  *anypb.Any
+	schema  types.RecordType
+	typeURL string
+}
+
+func (d *customExtDef) Schema(inputs []Rel) types.RecordType { return d.schema }
+func (d *customExtDef) Build(_ []Rel) *anypb.Any            { return d.detail }
+func (d *customExtDef) Expressions(_ []Rel) []expr.Expression { return nil }
+
+// customDecoder returns a customExtDef for a specific typeURL and nil for everything else.
+type customDecoder struct {
+	typeURL string
+	schema  types.RecordType
+}
+
+func (cd *customDecoder) DecodeExtensionRel(detail *anypb.Any) (any, error) {
+	if detail == nil || detail.TypeUrl != cd.typeURL {
+		return nil, nil // not ours — fall back to UndecodedExtension
+	}
+	return &customExtDef{detail: detail, schema: cd.schema, typeURL: cd.typeURL}, nil
+}
+
+// extSchema2col is a 2-column RecordType used across extension decoder tests.
+var extSchema2col = *types.NewRecordTypeFromTypes([]types.Type{
+	&types.Int64Type{Nullability: types.NullabilityRequired},
+	&types.Int32Type{Nullability: types.NullabilityRequired},
+})
+
+// emit01 is a RelCommon with output mapping [0, 1], sufficient to trigger remap OOB.
+var emit01 = &proto.RelCommon{
+	EmitKind: &proto.RelCommon_Emit_{
+		Emit: &proto.RelCommon_Emit{OutputMapping: []int32{0, 1}},
+	},
+}
+
+// directCommon is a RelCommon with no emit (direct pass-through), which is what
+// substrait-go serialises back out on ToProto() when no mapping is set.
+var directCommon = &proto.RelCommon{EmitKind: &proto.RelCommon_Direct_{Direct: &proto.RelCommon_Direct{}}}
+
+// oneColInputRel is a VirtualTable ReadRel with a single i64 column.
+var oneColInputRel = &proto.Rel{
+	RelType: &proto.Rel_Read{
+		Read: &proto.ReadRel{
+			Common: directCommon,
+			BaseSchema: &proto.NamedStruct{
+				Names: []string{"a"},
+				Struct: &proto.Type_Struct{
+					Types: []*proto.Type{
+						{Kind: &proto.Type_I64_{I64: &proto.Type_I64{Nullability: proto.Type_NULLABILITY_REQUIRED}}},
+					},
+				},
+			},
+			ReadType: &proto.ReadRel_VirtualTable_{VirtualTable: &proto.ReadRel_VirtualTable{}},
+		},
+	},
+}
+
+// TestExtensionRelDecoder_Single verifies the decoder hook for ExtensionSingleRel.
+//
+// ExtensionSingleRel wraps one input; UndecodedExtension.Schema returns the
+// input schema unchanged, so an emit mapping that references an extra column
+// added by the extension will panic on RecordType(). A registered decoder
+// provides the correct wider schema, preventing the panic.
+func TestExtensionRelDecoder_Single(t *testing.T) {
+	const typeURL = "type.googleapis.com/test.MyExtension"
+	detail := &anypb.Any{TypeUrl: typeURL, Value: []byte("irrelevant")}
+
+	// ExtensionSingleRel: emit [0,1] — index 1 is the extension's extra column.
+	rel := &proto.Rel{RelType: &proto.Rel_ExtensionSingle{ExtensionSingle: &proto.ExtensionSingleRel{
+		Common: emit01,
+		Input:  oneColInputRel,
+		Detail: detail,
+	}}}
+
+	t.Run("without decoder panics on emit OOB", func(t *testing.T) {
+		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+		require.Panics(t, func() {
+			out, err := RelFromProto(rel, reg)
+			require.NoError(t, err)
+			_ = out.RecordType()
+		})
+	})
+
+	t.Run("with decoder uses custom schema", func(t *testing.T) {
+		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+		reg.SetExtensionRelDecoder(&customDecoder{typeURL: typeURL, schema: extSchema2col})
+
+		out, err := RelFromProto(rel, reg)
+		require.NoError(t, err)
+		require.Equal(t, int32(2), out.RecordType().FieldCount())
+	})
+
+	t.Run("round-trip ToProto matches original", func(t *testing.T) {
+		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+		reg.SetExtensionRelDecoder(&customDecoder{typeURL: typeURL, schema: extSchema2col})
+
+		out, err := RelFromProto(rel, reg)
+		require.NoError(t, err)
+
+		if diff := cmp.Diff(rel, out.ToProto(), protocmp.Transform()); diff != "" {
+			t.Errorf("round-trip mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("decoder returning nil falls back to UndecodedExtension", func(t *testing.T) {
+		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+		reg.SetExtensionRelDecoder(&customDecoder{typeURL: "type.googleapis.com/other.Type"})
+		require.Panics(t, func() {
+			out, err := RelFromProto(rel, reg)
+			require.NoError(t, err)
+			_ = out.RecordType()
+		})
+	})
+}
+
+// TestExtensionRelDecoder_Leaf verifies the decoder hook for ExtensionLeafRel.
+//
+// ExtensionLeafRel has no inputs; UndecodedExtension.Schema always returns an
+// empty RecordType, so any non-empty emit mapping panics on RecordType().
+func TestExtensionRelDecoder_Leaf(t *testing.T) {
+	const typeURL = "type.googleapis.com/test.MyLeafExtension"
+	detail := &anypb.Any{TypeUrl: typeURL, Value: []byte("irrelevant")}
+
+	// ExtensionLeafRel: emit [0,1] — both columns come from the extension schema.
+	rel := &proto.Rel{RelType: &proto.Rel_ExtensionLeaf{ExtensionLeaf: &proto.ExtensionLeafRel{
+		Common: emit01,
+		Detail: detail,
+	}}}
+
+	t.Run("without decoder panics on emit OOB", func(t *testing.T) {
+		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+		require.Panics(t, func() {
+			out, err := RelFromProto(rel, reg)
+			require.NoError(t, err)
+			_ = out.RecordType()
+		})
+	})
+
+	t.Run("with decoder uses custom schema", func(t *testing.T) {
+		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+		reg.SetExtensionRelDecoder(&customDecoder{typeURL: typeURL, schema: extSchema2col})
+
+		out, err := RelFromProto(rel, reg)
+		require.NoError(t, err)
+		require.Equal(t, int32(2), out.RecordType().FieldCount())
+	})
+
+	t.Run("round-trip ToProto matches original", func(t *testing.T) {
+		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+		reg.SetExtensionRelDecoder(&customDecoder{typeURL: typeURL, schema: extSchema2col})
+
+		out, err := RelFromProto(rel, reg)
+		require.NoError(t, err)
+
+		if diff := cmp.Diff(rel, out.ToProto(), protocmp.Transform()); diff != "" {
+			t.Errorf("round-trip mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("decoder returning nil falls back to UndecodedExtension", func(t *testing.T) {
+		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+		reg.SetExtensionRelDecoder(&customDecoder{typeURL: "type.googleapis.com/other.Type"})
+		require.Panics(t, func() {
+			out, err := RelFromProto(rel, reg)
+			require.NoError(t, err)
+			_ = out.RecordType()
+		})
+	})
+}
+
+// TestExtensionRelDecoder_Multi verifies the decoder hook for ExtensionMultiRel.
+//
+// ExtensionMultiRel has multiple inputs; UndecodedExtension.Schema returns an
+// empty RecordType (len(inputs) != 1), so any non-empty emit mapping panics.
+func TestExtensionRelDecoder_Multi(t *testing.T) {
+	const typeURL = "type.googleapis.com/test.MyMultiExtension"
+	detail := &anypb.Any{TypeUrl: typeURL, Value: []byte("irrelevant")}
+
+	// Two identical one-column inputs; the extension combines them into 2 cols.
+	rel := &proto.Rel{RelType: &proto.Rel_ExtensionMulti{ExtensionMulti: &proto.ExtensionMultiRel{
+		Common:  emit01,
+		Inputs:  []*proto.Rel{oneColInputRel, oneColInputRel},
+		Detail:  detail,
+	}}}
+
+	t.Run("without decoder panics on emit OOB", func(t *testing.T) {
+		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+		require.Panics(t, func() {
+			out, err := RelFromProto(rel, reg)
+			require.NoError(t, err)
+			_ = out.RecordType()
+		})
+	})
+
+	t.Run("with decoder uses custom schema", func(t *testing.T) {
+		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+		reg.SetExtensionRelDecoder(&customDecoder{typeURL: typeURL, schema: extSchema2col})
+
+		out, err := RelFromProto(rel, reg)
+		require.NoError(t, err)
+		require.Equal(t, int32(2), out.RecordType().FieldCount())
+	})
+
+	t.Run("round-trip ToProto matches original", func(t *testing.T) {
+		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+		reg.SetExtensionRelDecoder(&customDecoder{typeURL: typeURL, schema: extSchema2col})
+
+		out, err := RelFromProto(rel, reg)
+		require.NoError(t, err)
+
+		if diff := cmp.Diff(rel, out.ToProto(), protocmp.Transform()); diff != "" {
+			t.Errorf("round-trip mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("decoder returning nil falls back to UndecodedExtension", func(t *testing.T) {
+		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+		reg.SetExtensionRelDecoder(&customDecoder{typeURL: "type.googleapis.com/other.Type"})
+		require.Panics(t, func() {
+			out, err := RelFromProto(rel, reg)
+			require.NoError(t, err)
+			_ = out.RecordType()
+		})
+	})
+}
+
+// TestStructFieldRefGetTypeBoundsCheck verifies that StructFieldRef.GetType returns
+// an error (not a panic) when the field index equals the length of the struct types.
+func TestStructFieldRefGetTypeBoundsCheck(t *testing.T) {
+	st := &types.StructType{
+		Types: []types.Type{
+			&types.Int64Type{Nullability: types.NullabilityRequired},
+		},
+	}
+	// Field == len(Types) must return ErrInvalidType, not panic with an OOB access.
+	ref := &expr.StructFieldRef{Field: 1}
+	_, err := ref.GetType(st)
+	require.ErrorIs(t, err, substraitgo.ErrInvalidType)
 }

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -422,120 +422,155 @@ func TestFromProtoRightSemiJoinRootNames(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestProjectSetStyleDecoder models an extension that implements a
-// set-returning function (SRF / unnest-style) relation:
-//
-//   - The extension detail is an anypb.Any whose Value encodes a list of SRF
-//     expressions (one per output column beyond the passthrough input columns).
-//   - The extension's output schema = input schema + one col per SRF expression,
-//     typed from the expression's output type.
-//   - A registered ExtensionRelDecoder (psStyleDecoder) unpacks the detail,
-//     resolves each expression via ExprFromProto, and returns an
-//     ExtensionRelDefinition with the full output schema.
-//
-// Without the decoder, UndecodedExtension returns only the input schema, so an
-// emit mapping that references the SRF output column panics on RecordType().
-// The test also verifies round-trip fidelity: ToProto() reproduces the original proto.
+// TestProjectSetStyleDecoder verifies that psStyleDecoder correctly resolves SRF
+// expression types from the detail payload and appends them to the input schema.
+// The input has one i64 column; the SRF adds one i32 column, producing a 2-column output.
 func TestProjectSetStyleDecoder(t *testing.T) {
 	const projectSetTypeURL = "type.googleapis.com/test.ProjectSetRel"
 
-	// inputSchema: one i64 column ("a") — the passthrough column.
 	inputSchema := *types.NewRecordTypeFromTypes([]types.Type{
 		&types.Int64Type{Nullability: types.NullabilityRequired},
 	})
 
-	// SRF expression: literal i32 (models an unnest() returning i32 rows).
-	// The decoder will call ExprFromProto on this to learn the SRF output type.
-	srfExprProto := &proto.Expression{
-		RexType: &proto.Expression_Literal_{
-			Literal: &proto.Expression_Literal{
-				LiteralType: &proto.Expression_Literal_I32{I32: 42},
-			},
-		},
-	}
-
-	// Build the detail: Any{typeURL, value=marshal(Expression_Nested_Struct{srfExpr})}.
-	// psStyleDecoder unmarshals this to recover the SRF expressions.
-	// A real implementation would similarly marshal each SRF expression
-	// into an Any-wrapped proto inside the extension's own message type.
-	nestedStruct := &proto.Expression_Nested_Struct{
-		Fields: []*proto.Expression{srfExprProto},
-	}
-	nestedBytes, err := protobuf.Marshal(nestedStruct)
+	srfExprProto := &proto.Expression{RexType: &proto.Expression_Literal_{
+		Literal: &proto.Expression_Literal{LiteralType: &proto.Expression_Literal_I32{I32: 42}},
+	}}
+	nestedBytes, err := protobuf.Marshal(&proto.Expression_Nested_Struct{Fields: []*proto.Expression{srfExprProto}})
 	require.NoError(t, err)
 	projectSetDetail := &anypb.Any{TypeUrl: projectSetTypeURL, Value: nestedBytes}
 
-	// Build the input rel proto. direct common is set so ToProto() round-trips exactly.
-	inputRelProto := &proto.Rel{
-		RelType: &proto.Rel_Read{
-			Read: &proto.ReadRel{
-				Common: &proto.RelCommon{EmitKind: &proto.RelCommon_Direct_{Direct: &proto.RelCommon_Direct{}}},
-				BaseSchema: &proto.NamedStruct{
-					Names: []string{"a"},
-					Struct: &proto.Type_Struct{
-						Types: []*proto.Type{
-							{Kind: &proto.Type_I64_{I64: &proto.Type_I64{Nullability: proto.Type_NULLABILITY_REQUIRED}}},
-						},
-					},
-				},
-				ReadType: &proto.ReadRel_VirtualTable_{VirtualTable: &proto.ReadRel_VirtualTable{}},
+	inputRelProto := &proto.Rel{RelType: &proto.Rel_Read{Read: &proto.ReadRel{
+		Common: &proto.RelCommon{EmitKind: &proto.RelCommon_Direct_{Direct: &proto.RelCommon_Direct{}}},
+		BaseSchema: &proto.NamedStruct{
+			Names: []string{"a"},
+			Struct: &proto.Type_Struct{
+				Types: []*proto.Type{{Kind: &proto.Type_I64_{I64: &proto.Type_I64{Nullability: proto.Type_NULLABILITY_REQUIRED}}}},
 			},
+		},
+		ReadType: &proto.ReadRel_VirtualTable_{VirtualTable: &proto.ReadRel_VirtualTable{}},
+	}}}
+
+	rel := &proto.Rel{RelType: &proto.Rel_ExtensionSingle{ExtensionSingle: &proto.ExtensionSingleRel{
+		Common: &proto.RelCommon{EmitKind: &proto.RelCommon_Emit_{Emit: &proto.RelCommon_Emit{OutputMapping: []int32{0, 1}}}},
+		Input:  inputRelProto,
+		Detail: projectSetDetail,
+	}}}
+
+	reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+	require.NoError(t, reg.SetExtensionRelDecoder(projectSetTypeURL, projectSetDecoderFor(inputSchema, reg)))
+
+	out, err := RelFromProto(rel, reg)
+	require.NoError(t, err)
+
+	// psStyleDecoder resolves types from the SRF expressions: i64 passthrough + i32 SRF output.
+	got := out.RecordType()
+	require.Equal(t, int32(2), got.FieldCount())
+	assert.IsType(t, &types.Int64Type{}, got.GetFieldRef(0))
+	assert.IsType(t, &types.Int32Type{}, got.GetFieldRef(1))
+}
+
+// TestFromProtoWithDecoder is an integration test for FromProtoWithDecoder.
+// It verifies decoder wiring, schema resolution, and round-trip fidelity across
+// all three extension rel types and both direct and emit mappings.
+func TestFromProtoWithDecoder(t *testing.T) {
+	const typeURL = "type.googleapis.com/test.MyExtension"
+	c := extensions.GetDefaultCollectionWithNoError()
+
+	direct := &proto.RelCommon{EmitKind: &proto.RelCommon_Direct_{Direct: &proto.RelCommon_Direct{}}}
+	emit201 := &proto.RelCommon{EmitKind: &proto.RelCommon_Emit_{Emit: &proto.RelCommon_Emit{OutputMapping: []int32{2, 0, 1}}}}
+	detail := &anypb.Any{TypeUrl: typeURL, Value: []byte("irrelevant")}
+
+	extSchema := *types.NewRecordTypeFromTypes([]types.Type{
+		&types.Int64Type{Nullability: types.NullabilityRequired},
+		&types.Int32Type{Nullability: types.NullabilityRequired},
+		&types.StringType{Nullability: types.NullabilityRequired},
+	})
+
+	oneColInput := &proto.Rel{RelType: &proto.Rel_Read{Read: &proto.ReadRel{
+		Common: direct,
+		BaseSchema: &proto.NamedStruct{
+			Names: []string{"a"},
+			Struct: &proto.Type_Struct{
+				Types: []*proto.Type{{Kind: &proto.Type_I64_{I64: &proto.Type_I64{Nullability: proto.Type_NULLABILITY_REQUIRED}}}},
+			},
+		},
+		ReadType: &proto.ReadRel_VirtualTable_{VirtualTable: &proto.ReadRel_VirtualTable{}},
+	}}}
+
+	makePlan := func(extRel *proto.Rel, names []string) *proto.Plan {
+		return &proto.Plan{Relations: []*proto.PlanRel{{
+			RelType: &proto.PlanRel_Root{Root: &proto.RelRoot{Names: names, Input: extRel}},
+		}}}
+	}
+
+	cases := []struct {
+		name                 string
+		plan                 *proto.Plan
+		panicsWithoutDecoder bool
+	}{
+		{
+			name: "Single/Direct",
+			plan: makePlan(&proto.Rel{RelType: &proto.Rel_ExtensionSingle{ExtensionSingle: &proto.ExtensionSingleRel{
+				Common: direct, Input: oneColInput, Detail: detail,
+			}}}, []string{"a", "b", "c"}),
+		},
+		{
+			name:                 "Single/Emit",
+			panicsWithoutDecoder: true,
+			plan: makePlan(&proto.Rel{RelType: &proto.Rel_ExtensionSingle{ExtensionSingle: &proto.ExtensionSingleRel{
+				Common: emit201, Input: oneColInput, Detail: detail,
+			}}}, []string{"c", "a", "b"}),
+		},
+		{
+			name: "Leaf/Direct",
+			plan: makePlan(&proto.Rel{RelType: &proto.Rel_ExtensionLeaf{ExtensionLeaf: &proto.ExtensionLeafRel{
+				Common: direct, Detail: detail,
+			}}}, []string{"a", "b", "c"}),
+		},
+		{
+			name:                 "Leaf/Emit",
+			panicsWithoutDecoder: true,
+			plan: makePlan(&proto.Rel{RelType: &proto.Rel_ExtensionLeaf{ExtensionLeaf: &proto.ExtensionLeafRel{
+				Common: emit201, Detail: detail,
+			}}}, []string{"c", "a", "b"}),
+		},
+		{
+			name: "Multi/Direct",
+			plan: makePlan(&proto.Rel{RelType: &proto.Rel_ExtensionMulti{ExtensionMulti: &proto.ExtensionMultiRel{
+				Common: direct, Inputs: []*proto.Rel{oneColInput, oneColInput}, Detail: detail,
+			}}}, []string{"a", "b", "c"}),
+		},
+		{
+			name:                 "Multi/Emit",
+			panicsWithoutDecoder: true,
+			plan: makePlan(&proto.Rel{RelType: &proto.Rel_ExtensionMulti{ExtensionMulti: &proto.ExtensionMultiRel{
+				Common: emit201, Inputs: []*proto.Rel{oneColInput, oneColInput}, Detail: detail,
+			}}}, []string{"c", "a", "b"}),
 		},
 	}
 
-	// ExtensionSingleRel with emit [0, 1]:
-	//   col 0 = passthrough input col "a" (i64)
-	//   col 1 = SRF output col (i32, from the literal expression)
-	emitDirect01 := &proto.RelCommon{EmitKind: &proto.RelCommon_Emit_{
-		Emit: &proto.RelCommon_Emit{OutputMapping: []int32{0, 1}},
-	}}
-	extSingleProto := &proto.ExtensionSingleRel{
-		Common: emitDirect01,
-		Input:  inputRelProto,
-		Detail: projectSetDetail,
-	}
-	rel := &proto.Rel{RelType: &proto.Rel_ExtensionSingle{ExtensionSingle: extSingleProto}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.panicsWithoutDecoder {
+				require.Panics(t, func() {
+					p, err := FromProto(tc.plan, c)
+					require.NoError(t, err)
+					_ = p.Relations()[0].Root().RecordType()
+				})
+			}
 
-	makeDecoder := func(reg expr.ExtensionRegistry) expr.ExtensionRelDecoder {
-		return projectSetDecoderFor(projectSetTypeURL, inputSchema, reg)
-	}
-
-	t.Run("without decoder panics on emit OOB", func(t *testing.T) {
-		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-		require.Panics(t, func() {
-			out, err := RelFromProto(rel, reg)
+			p, err := FromProtoWithDecoder(tc.plan, c, map[string]expr.ExtensionRelDecoder{typeURL: &customDecoder{schema: extSchema}})
 			require.NoError(t, err)
-			_ = out.RecordType()
+
+			require.Len(t, p.Relations()[0].Root().RecordType().Struct.Types, 3)
+
+			roundTripped, err := p.ToProto()
+			require.NoError(t, err)
+			if diff := cmp.Diff(tc.plan, roundTripped, protocmp.Transform()); diff != "" {
+				t.Errorf("round-trip mismatch (-want +got):\n%s", diff)
+			}
 		})
-	})
-
-	t.Run("with decoder schema is input+srf", func(t *testing.T) {
-		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-		reg.SetExtensionRelDecoder(makeDecoder(reg))
-
-		out, err := RelFromProto(rel, reg)
-		require.NoError(t, err)
-
-		got := out.RecordType()
-		// emit [0,1] selects both cols from the 2-col schema — result is 2 cols.
-		require.Equal(t, int32(2), got.FieldCount())
-		// col 0 = i64 (passthrough), col 1 = i32 (SRF output)
-		assert.IsType(t, &types.Int64Type{}, got.GetFieldRef(0))
-		assert.IsType(t, &types.Int32Type{}, got.GetFieldRef(1))
-	})
-
-	t.Run("round-trip ToProto matches original", func(t *testing.T) {
-		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-		reg.SetExtensionRelDecoder(makeDecoder(reg))
-
-		out, err := RelFromProto(rel, reg)
-		require.NoError(t, err)
-
-		got := out.ToProto()
-		if diff := cmp.Diff(rel, got, protocmp.Transform()); diff != "" {
-			t.Errorf("round-trip mismatch (-want +got):\n%s", diff)
-		}
-	})
+	}
 }
 
 // projectSetDecoderFor returns an ExtensionRelDecoder that handles the
@@ -545,18 +580,17 @@ func TestProjectSetStyleDecoder(t *testing.T) {
 // whose Schema() = inputSchema + SRF output types.
 //
 // This mirrors the pattern used by SRF-style extension relations.
-func projectSetDecoderFor(typeURL string, inputSchema types.RecordType, reg expr.ExtensionRegistry) expr.ExtensionRelDecoder {
-	return &psStyleDecoder{typeURL: typeURL, inputSchema: inputSchema, reg: reg}
+func projectSetDecoderFor(inputSchema types.RecordType, reg expr.ExtensionRegistry) expr.ExtensionRelDecoder {
+	return &psStyleDecoder{inputSchema: inputSchema, reg: reg}
 }
 
 type psStyleDecoder struct {
-	typeURL     string
 	inputSchema types.RecordType
 	reg         expr.ExtensionRegistry
 }
 
 func (d *psStyleDecoder) DecodeExtensionRel(detail *anypb.Any) (any, error) {
-	if detail == nil || detail.TypeUrl != d.typeURL {
+	if detail == nil {
 		return nil, nil
 	}
 	var ns proto.Expression_Nested_Struct
@@ -578,26 +612,22 @@ func (d *psStyleDecoder) DecodeExtensionRel(detail *anypb.Any) (any, error) {
 
 // customExtDef is a test ExtensionRelDefinition that claims a fixed output schema.
 type customExtDef struct {
-	detail  *anypb.Any
-	schema  types.RecordType
-	typeURL string
+	detail *anypb.Any
+	schema types.RecordType
 }
 
 func (d *customExtDef) Schema(inputs []Rel) types.RecordType  { return d.schema }
 func (d *customExtDef) Build(_ []Rel) *anypb.Any              { return d.detail }
 func (d *customExtDef) Expressions(_ []Rel) []expr.Expression { return nil }
 
-// customDecoder returns a customExtDef for a specific typeURL and nil for everything else.
+// customDecoder returns a customExtDef with a fixed schema. The registry dispatches
+// to it only for the type URL it was registered under.
 type customDecoder struct {
-	typeURL string
-	schema  types.RecordType
+	schema types.RecordType
 }
 
 func (cd *customDecoder) DecodeExtensionRel(detail *anypb.Any) (any, error) {
-	if detail == nil || detail.TypeUrl != cd.typeURL {
-		return nil, nil // not ours — fall back to UndecodedExtension
-	}
-	return &customExtDef{detail: detail, schema: cd.schema, typeURL: cd.typeURL}, nil
+	return &customExtDef{detail: detail, schema: cd.schema}, nil
 }
 
 // errorDecoder always returns a non-nil error from DecodeExtensionRel.
@@ -706,11 +736,11 @@ func TestExtensionRelDecoder(t *testing.T) {
 					})
 				})
 
-				// A decoder returning (nil, nil) signals it doesn't handle this detail,
-				// so RelFromProto falls back to UndecodedExtension and panics on OOB.
-				t.Run("decoder returning nil falls back to UndecodedExtension", func(t *testing.T) {
+				// Registering a decoder under a different type URL leaves this detail
+				// unmatched, so RelFromProto falls back to UndecodedExtension and panics on OOB.
+				t.Run("decoder registered under different typeURL falls back to UndecodedExtension", func(t *testing.T) {
 					reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-					reg.SetExtensionRelDecoder(&customDecoder{typeURL: "type.googleapis.com/other.Type"})
+					require.NoError(t, reg.SetExtensionRelDecoder("type.googleapis.com/other.Type", &customDecoder{schema: extSchema}))
 					require.Panics(t, func() {
 						out, err := RelFromProto(tc.rel, reg)
 						require.NoError(t, err)
@@ -722,27 +752,16 @@ func TestExtensionRelDecoder(t *testing.T) {
 			// With a decoder, the custom schema is used and RecordType() returns all 3 cols.
 			t.Run("with decoder uses custom schema", func(t *testing.T) {
 				reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-				reg.SetExtensionRelDecoder(&customDecoder{typeURL: typeURL, schema: extSchema})
+				require.NoError(t, reg.SetExtensionRelDecoder(typeURL, &customDecoder{schema: extSchema}))
 				out, err := RelFromProto(tc.rel, reg)
 				require.NoError(t, err)
 				require.Equal(t, int32(3), out.RecordType().FieldCount())
 			})
 
-			// ToProto must reproduce the original proto exactly for downstream consumers.
-			t.Run("round-trip ToProto matches original", func(t *testing.T) {
-				reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-				reg.SetExtensionRelDecoder(&customDecoder{typeURL: typeURL, schema: extSchema})
-				out, err := RelFromProto(tc.rel, reg)
-				require.NoError(t, err)
-				if diff := cmp.Diff(tc.rel, out.ToProto(), protocmp.Transform()); diff != "" {
-					t.Errorf("round-trip mismatch (-want +got):\n%s", diff)
-				}
-			})
-
 			// A decoder error is propagated directly to the RelFromProto caller.
 			t.Run("decoder returning error propagates to RelFromProto", func(t *testing.T) {
 				reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-				reg.SetExtensionRelDecoder(&errorDecoder{err: errors.New("decode failed")})
+				require.NoError(t, reg.SetExtensionRelDecoder(typeURL, &errorDecoder{err: errors.New("decode failed")}))
 				_, err := RelFromProto(tc.rel, reg)
 				require.ErrorContains(t, err, "decode failed")
 			})
@@ -751,7 +770,7 @@ func TestExtensionRelDecoder(t *testing.T) {
 			// value is caught at cast time and surfaced as an error.
 			t.Run("DecodeExtensionRel returns the wrong type errors", func(t *testing.T) {
 				reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-				reg.SetExtensionRelDecoder(&wrongTypeDecoder{})
+				require.NoError(t, reg.SetExtensionRelDecoder(typeURL, &wrongTypeDecoder{}))
 				_, err := RelFromProto(tc.rel, reg)
 				require.ErrorContains(t, err, "does not implement ExtensionRelDefinition")
 			})

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -882,17 +882,3 @@ func TestExtensionRelDecoder_Multi(t *testing.T) {
 		require.ErrorContains(t, err, "does not implement ExtensionRelDefinition")
 	})
 }
-
-// TestStructFieldRefGetTypeBoundsCheck verifies that StructFieldRef.GetType returns
-// an error (not a panic) when the field index equals the length of the struct types.
-func TestStructFieldRefGetTypeBoundsCheck(t *testing.T) {
-	st := &types.StructType{
-		Types: []types.Type{
-			&types.Int64Type{Nullability: types.NullabilityRequired},
-		},
-	}
-	// Field == len(Types) must return ErrInvalidType, not panic with an OOB access.
-	ref := &expr.StructFieldRef{Field: 1}
-	_, err := ref.GetType(st)
-	require.ErrorIs(t, err, substraitgo.ErrInvalidType)
-}

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -122,21 +122,15 @@ func TestPlanRoundTripWithExtensions(t *testing.T) {
 
 func TestPlanRoundTripWithSubqueries(t *testing.T) {
 	c := extensions.GetDefaultCollectionWithNoError()
-
-	i32Type := &proto.Type{Kind: &proto.Type_I32_{I32: &proto.Type_I32{Nullability: proto.Type_NULLABILITY_REQUIRED}}}
-	i64Type := &proto.Type{Kind: &proto.Type_I64_{I64: &proto.Type_I64{Nullability: proto.Type_NULLABILITY_REQUIRED}}}
-	strType := &proto.Type{Kind: &proto.Type_String_{String_: &proto.Type_String{Nullability: proto.Type_NULLABILITY_REQUIRED}}}
-
-	// 3-column scan: col1 i32, col2 i64, col3 string
 	scanProto := &proto.Rel{
 		RelType: &proto.Rel_Read{
 			Read: &proto.ReadRel{
 				Common: &proto.RelCommon{EmitKind: &proto.RelCommon_Direct_{Direct: &proto.RelCommon_Direct{}}},
 				BaseSchema: &proto.NamedStruct{
-					Names: []string{"col1", "col2", "col3"},
+					Names: []string{"col1"},
 					Struct: &proto.Type_Struct{
 						Nullability: proto.Type_NULLABILITY_REQUIRED,
-						Types:       []*proto.Type{i32Type, i64Type, strType},
+						Types:       []*proto.Type{{Kind: &proto.Type_I32_{I32: &proto.Type_I32{Nullability: proto.Type_NULLABILITY_REQUIRED}}}},
 					},
 				},
 				ReadType: &proto.ReadRel_NamedTable_{NamedTable: &proto.ReadRel_NamedTable{Names: []string{"t"}}},
@@ -145,7 +139,7 @@ func TestPlanRoundTripWithSubqueries(t *testing.T) {
 	}
 	needle := expr.NewPrimitiveLiteral(int32(1), false).ToProto()
 
-	subqueries := []struct {
+	tests := []struct {
 		name     string
 		subquery *proto.Expression_Subquery
 	}{
@@ -194,58 +188,35 @@ func TestPlanRoundTripWithSubqueries(t *testing.T) {
 		},
 	}
 
-	commons := []struct {
-		name   string
-		common *proto.RelCommon
-		// rootNames must match the number of output columns after the emit mapping
-		rootNames []string
-	}{
-		{
-			name:      "Direct",
-			common:    &proto.RelCommon{EmitKind: &proto.RelCommon_Direct_{Direct: &proto.RelCommon_Direct{}}},
-			rootNames: []string{"col1", "col2", "col3"},
-		},
-		{
-			// out-of-order emit: col3, col1, col2 → output mapping [2, 0, 1]
-			name: "Emit",
-			common: &proto.RelCommon{EmitKind: &proto.RelCommon_Emit_{
-				Emit: &proto.RelCommon_Emit{OutputMapping: []int32{2, 0, 1}},
-			}},
-			rootNames: []string{"col3", "col1", "col2"},
-		},
-	}
-
-	for _, sq := range subqueries {
-		for _, cm := range commons {
-			t.Run(sq.name+"/"+cm.name, func(t *testing.T) {
-				original := &proto.Plan{
-					Relations: []*proto.PlanRel{{
-						RelType: &proto.PlanRel_Root{
-							Root: &proto.RelRoot{
-								Names: cm.rootNames,
-								Input: &proto.Rel{
-									RelType: &proto.Rel_Filter{
-										Filter: &proto.FilterRel{
-											Common:    cm.common,
-											Input:     scanProto,
-											Condition: &proto.Expression{RexType: &proto.Expression_Subquery_{Subquery: sq.subquery}},
-										},
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			original := &proto.Plan{
+				Relations: []*proto.PlanRel{{
+					RelType: &proto.PlanRel_Root{
+						Root: &proto.RelRoot{
+							Names: []string{"out"},
+							Input: &proto.Rel{
+								RelType: &proto.Rel_Filter{
+									Filter: &proto.FilterRel{
+										Common:    &proto.RelCommon{EmitKind: &proto.RelCommon_Direct_{Direct: &proto.RelCommon_Direct{}}},
+										Input:     scanProto,
+										Condition: &proto.Expression{RexType: &proto.Expression_Subquery_{Subquery: tc.subquery}},
 									},
 								},
 							},
 						},
-					}},
-				}
-				p, err := FromProto(original, c)
-				require.NoError(t, err)
-				roundTripped, err := p.ToProto()
-				require.NoError(t, err)
-				// Use cmp.Diff instead of protojson for comparison: protojson output is non-deterministic.
-				if diff := cmp.Diff(original, roundTripped, protocmp.Transform()); diff != "" {
-					t.Errorf("plan round-trip mismatch (-want +got):\n%s", diff)
-				}
-			})
-		}
+					},
+				}},
+			}
+			p, err := FromProto(original, c)
+			require.NoError(t, err)
+			roundTripped, err := p.ToProto()
+			require.NoError(t, err)
+			// Use cmp.Diff instead of protojson for comparison: protojson output is non-deterministic.
+			if diff := cmp.Diff(original, roundTripped, protocmp.Transform()); diff != "" {
+				t.Errorf("plan round-trip mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 
@@ -494,11 +465,11 @@ func TestProjectSetStyleDecoder(t *testing.T) {
 	require.NoError(t, err)
 	projectSetDetail := &anypb.Any{TypeUrl: projectSetTypeURL, Value: nestedBytes}
 
-	// Build the input rel proto. directCommon is set so ToProto() round-trips exactly.
+	// Build the input rel proto. direct common is set so ToProto() round-trips exactly.
 	inputRelProto := &proto.Rel{
 		RelType: &proto.Rel_Read{
 			Read: &proto.ReadRel{
-				Common: directCommon,
+				Common: &proto.RelCommon{EmitKind: &proto.RelCommon_Direct_{Direct: &proto.RelCommon_Direct{}}},
 				BaseSchema: &proto.NamedStruct{
 					Names: []string{"a"},
 					Struct: &proto.Type_Struct{
@@ -515,8 +486,11 @@ func TestProjectSetStyleDecoder(t *testing.T) {
 	// ExtensionSingleRel with emit [0, 1]:
 	//   col 0 = passthrough input col "a" (i64)
 	//   col 1 = SRF output col (i32, from the literal expression)
+	emitDirect01 := &proto.RelCommon{EmitKind: &proto.RelCommon_Emit_{
+		Emit: &proto.RelCommon_Emit{OutputMapping: []int32{0, 1}},
+	}}
 	extSingleProto := &proto.ExtensionSingleRel{
-		Common: emit01,
+		Common: emitDirect01,
 		Input:  inputRelProto,
 		Detail: projectSetDetail,
 	}
@@ -636,249 +610,151 @@ type wrongTypeDecoder struct{}
 
 func (d *wrongTypeDecoder) DecodeExtensionRel(_ *anypb.Any) (any, error) { return "not-a-def", nil }
 
-// extSchema2col is a 2-column RecordType used across extension decoder tests.
-var extSchema2col = *types.NewRecordTypeFromTypes([]types.Type{
-	&types.Int64Type{Nullability: types.NullabilityRequired},
-	&types.Int32Type{Nullability: types.NullabilityRequired},
-})
-
-// emit01 is a RelCommon with output mapping [0, 1], sufficient to trigger remap OOB.
-var emit01 = &proto.RelCommon{
-	EmitKind: &proto.RelCommon_Emit_{
-		Emit: &proto.RelCommon_Emit{OutputMapping: []int32{0, 1}},
-	},
-}
-
-// directCommon is a RelCommon with no emit (direct pass-through), which is what
-// substrait-go serialises back out on ToProto() when no mapping is set.
-var directCommon = &proto.RelCommon{EmitKind: &proto.RelCommon_Direct_{Direct: &proto.RelCommon_Direct{}}}
-
-// oneColInputRel is a VirtualTable ReadRel with a single i64 column.
-var oneColInputRel = &proto.Rel{
-	RelType: &proto.Rel_Read{
-		Read: &proto.ReadRel{
-			Common: directCommon,
-			BaseSchema: &proto.NamedStruct{
-				Names: []string{"a"},
-				Struct: &proto.Type_Struct{
-					Types: []*proto.Type{
-						{Kind: &proto.Type_I64_{I64: &proto.Type_I64{Nullability: proto.Type_NULLABILITY_REQUIRED}}},
-					},
-				},
-			},
-			ReadType: &proto.ReadRel_VirtualTable_{VirtualTable: &proto.ReadRel_VirtualTable{}},
-		},
-	},
-}
-
-// TestExtensionRelDecoder_Single verifies the decoder hook for ExtensionSingleRel.
-//
-// ExtensionSingleRel wraps one input; UndecodedExtension.Schema returns the
-// input schema unchanged, so an emit mapping that references an extra column
-// added by the extension will panic on RecordType(). A registered decoder
-// provides the correct wider schema, preventing the panic.
-func TestExtensionRelDecoder_Single(t *testing.T) {
+// TestExtensionRelDecoder verifies the decoder hook for all three extension rel types.
+// Without a decoder, UndecodedExtension returns a schema too narrow for the emit
+// mapping, causing a panic on RecordType(). A registered decoder provides the correct
+// wider schema.
+func TestExtensionRelDecoder(t *testing.T) {
 	const typeURL = "type.googleapis.com/test.MyExtension"
 	detail := &anypb.Any{TypeUrl: typeURL, Value: []byte("irrelevant")}
 
-	// ExtensionSingleRel: emit [0,1] — index 1 is the extension's extra column.
-	rel := &proto.Rel{RelType: &proto.Rel_ExtensionSingle{ExtensionSingle: &proto.ExtensionSingleRel{
-		Common: emit01,
-		Input:  oneColInputRel,
-		Detail: detail,
+	// extSchema is the 3-column output schema the decoder claims for the extension.
+	// It is wider than oneColInput, so emit [2,0,1] would OOB without a decoder.
+	extSchema := *types.NewRecordTypeFromTypes([]types.Type{
+		&types.Int64Type{Nullability: types.NullabilityRequired},
+		&types.Int32Type{Nullability: types.NullabilityRequired},
+		&types.StringType{Nullability: types.NullabilityRequired},
+	})
+
+	// direct is a pass-through RelCommon; emit201 exercises out-of-order reordering.
+	// Both are tested to cover the two common real-world mapping shapes.
+	direct := &proto.RelCommon{EmitKind: &proto.RelCommon_Direct_{Direct: &proto.RelCommon_Direct{}}}
+	emit201 := &proto.RelCommon{EmitKind: &proto.RelCommon_Emit_{Emit: &proto.RelCommon_Emit{OutputMapping: []int32{2, 0, 1}}}}
+
+	// oneColInput is the single-column input fed into Single/Multi extension rels.
+	// The extension decoder claims a wider schema, so OOB only occurs without it.
+	oneColInput := &proto.Rel{RelType: &proto.Rel_Read{Read: &proto.ReadRel{
+		Common: direct,
+		BaseSchema: &proto.NamedStruct{
+			Names: []string{"a"},
+			Struct: &proto.Type_Struct{
+				Types: []*proto.Type{{Kind: &proto.Type_I64_{I64: &proto.Type_I64{Nullability: proto.Type_NULLABILITY_REQUIRED}}}},
+			},
+		},
+		ReadType: &proto.ReadRel_VirtualTable_{VirtualTable: &proto.ReadRel_VirtualTable{}},
 	}}}
 
-	t.Run("without decoder panics on emit OOB", func(t *testing.T) {
-		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-		require.Panics(t, func() {
-			out, err := RelFromProto(rel, reg)
-			require.NoError(t, err)
-			_ = out.RecordType()
+	// rels covers all three extension rel types × direct and out-of-order emit mappings.
+	// Direct tests the no-remap path; Emit tests the OOB-without-decoder path.
+	rels := []struct {
+		name                 string
+		rel                  *proto.Rel
+		panicsWithoutDecoder bool // true when emit mapping exceeds UndecodedExtension schema
+	}{
+		{
+			name: "Single/Direct",
+			rel: &proto.Rel{RelType: &proto.Rel_ExtensionSingle{ExtensionSingle: &proto.ExtensionSingleRel{
+				Common: direct, Input: oneColInput, Detail: detail,
+			}}},
+		},
+		{
+			name:                 "Single/Emit",
+			panicsWithoutDecoder: true,
+			rel: &proto.Rel{RelType: &proto.Rel_ExtensionSingle{ExtensionSingle: &proto.ExtensionSingleRel{
+				Common: emit201, Input: oneColInput, Detail: detail,
+			}}},
+		},
+		{
+			name: "Leaf/Direct",
+			rel: &proto.Rel{RelType: &proto.Rel_ExtensionLeaf{ExtensionLeaf: &proto.ExtensionLeafRel{
+				Common: direct, Detail: detail,
+			}}},
+		},
+		{
+			name:                 "Leaf/Emit",
+			panicsWithoutDecoder: true,
+			rel: &proto.Rel{RelType: &proto.Rel_ExtensionLeaf{ExtensionLeaf: &proto.ExtensionLeafRel{
+				Common: emit201, Detail: detail,
+			}}},
+		},
+		{
+			name: "Multi/Direct",
+			rel: &proto.Rel{RelType: &proto.Rel_ExtensionMulti{ExtensionMulti: &proto.ExtensionMultiRel{
+				Common: direct, Inputs: []*proto.Rel{oneColInput, oneColInput}, Detail: detail,
+			}}},
+		},
+		{
+			name:                 "Multi/Emit",
+			panicsWithoutDecoder: true,
+			rel: &proto.Rel{RelType: &proto.Rel_ExtensionMulti{ExtensionMulti: &proto.ExtensionMultiRel{
+				Common: emit201, Inputs: []*proto.Rel{oneColInput, oneColInput}, Detail: detail,
+			}}},
+		},
+	}
+
+	for _, tc := range rels {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.panicsWithoutDecoder {
+				// Without a decoder, UndecodedExtension returns a schema narrower than the
+				// emit mapping, so RecordType() panics on OOB access.
+				t.Run("without decoder panics on emit OOB", func(t *testing.T) {
+					reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+					require.Panics(t, func() {
+						out, err := RelFromProto(tc.rel, reg)
+						require.NoError(t, err)
+						_ = out.RecordType()
+					})
+				})
+
+				// A decoder returning (nil, nil) signals it doesn't handle this detail,
+				// so RelFromProto falls back to UndecodedExtension and panics on OOB.
+				t.Run("decoder returning nil falls back to UndecodedExtension", func(t *testing.T) {
+					reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+					reg.SetExtensionRelDecoder(&customDecoder{typeURL: "type.googleapis.com/other.Type"})
+					require.Panics(t, func() {
+						out, err := RelFromProto(tc.rel, reg)
+						require.NoError(t, err)
+						_ = out.RecordType()
+					})
+				})
+			}
+
+			// With a decoder, the custom schema is used and RecordType() returns all 3 cols.
+			t.Run("with decoder uses custom schema", func(t *testing.T) {
+				reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+				reg.SetExtensionRelDecoder(&customDecoder{typeURL: typeURL, schema: extSchema})
+				out, err := RelFromProto(tc.rel, reg)
+				require.NoError(t, err)
+				require.Equal(t, int32(3), out.RecordType().FieldCount())
+			})
+
+			// ToProto must reproduce the original proto exactly for downstream consumers.
+			t.Run("round-trip ToProto matches original", func(t *testing.T) {
+				reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+				reg.SetExtensionRelDecoder(&customDecoder{typeURL: typeURL, schema: extSchema})
+				out, err := RelFromProto(tc.rel, reg)
+				require.NoError(t, err)
+				if diff := cmp.Diff(tc.rel, out.ToProto(), protocmp.Transform()); diff != "" {
+					t.Errorf("round-trip mismatch (-want +got):\n%s", diff)
+				}
+			})
+
+			// A decoder error is propagated directly to the RelFromProto caller.
+			t.Run("decoder returning error propagates to RelFromProto", func(t *testing.T) {
+				reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+				reg.SetExtensionRelDecoder(&errorDecoder{err: errors.New("decode failed")})
+				_, err := RelFromProto(tc.rel, reg)
+				require.ErrorContains(t, err, "decode failed")
+			})
+
+			// DecodeExtensionRel returns any; returning a non-ExtensionRelDefinition
+			// value is caught at cast time and surfaced as an error.
+			t.Run("DecodeExtensionRel returns the wrong type errors", func(t *testing.T) {
+				reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+				reg.SetExtensionRelDecoder(&wrongTypeDecoder{})
+				_, err := RelFromProto(tc.rel, reg)
+				require.ErrorContains(t, err, "does not implement ExtensionRelDefinition")
+			})
 		})
-	})
-
-	t.Run("with decoder uses custom schema", func(t *testing.T) {
-		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-		reg.SetExtensionRelDecoder(&customDecoder{typeURL: typeURL, schema: extSchema2col})
-
-		out, err := RelFromProto(rel, reg)
-		require.NoError(t, err)
-		require.Equal(t, int32(2), out.RecordType().FieldCount())
-	})
-
-	t.Run("round-trip ToProto matches original", func(t *testing.T) {
-		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-		reg.SetExtensionRelDecoder(&customDecoder{typeURL: typeURL, schema: extSchema2col})
-
-		out, err := RelFromProto(rel, reg)
-		require.NoError(t, err)
-
-		if diff := cmp.Diff(rel, out.ToProto(), protocmp.Transform()); diff != "" {
-			t.Errorf("round-trip mismatch (-want +got):\n%s", diff)
-		}
-	})
-
-	t.Run("decoder returning nil falls back to UndecodedExtension", func(t *testing.T) {
-		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-		reg.SetExtensionRelDecoder(&customDecoder{typeURL: "type.googleapis.com/other.Type"})
-		require.Panics(t, func() {
-			out, err := RelFromProto(rel, reg)
-			require.NoError(t, err)
-			_ = out.RecordType()
-		})
-	})
-
-	t.Run("decoder returning error propagates to RelFromProto", func(t *testing.T) {
-		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-		sentinel := errors.New("decode failed")
-		reg.SetExtensionRelDecoder(&errorDecoder{err: sentinel})
-		_, err := RelFromProto(rel, reg)
-		require.ErrorContains(t, err, "decode failed")
-	})
-
-	t.Run("decoder returning wrong type errors", func(t *testing.T) {
-		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-		reg.SetExtensionRelDecoder(&wrongTypeDecoder{})
-		_, err := RelFromProto(rel, reg)
-		require.ErrorContains(t, err, "does not implement ExtensionRelDefinition")
-	})
-}
-
-// TestExtensionRelDecoder_Leaf verifies the decoder hook for ExtensionLeafRel.
-//
-// ExtensionLeafRel has no inputs; UndecodedExtension.Schema always returns an
-// empty RecordType, so any non-empty emit mapping panics on RecordType().
-func TestExtensionRelDecoder_Leaf(t *testing.T) {
-	const typeURL = "type.googleapis.com/test.MyLeafExtension"
-	detail := &anypb.Any{TypeUrl: typeURL, Value: []byte("irrelevant")}
-
-	// ExtensionLeafRel: emit [0,1] — both columns come from the extension schema.
-	rel := &proto.Rel{RelType: &proto.Rel_ExtensionLeaf{ExtensionLeaf: &proto.ExtensionLeafRel{
-		Common: emit01,
-		Detail: detail,
-	}}}
-
-	t.Run("without decoder panics on emit OOB", func(t *testing.T) {
-		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-		require.Panics(t, func() {
-			out, err := RelFromProto(rel, reg)
-			require.NoError(t, err)
-			_ = out.RecordType()
-		})
-	})
-
-	t.Run("with decoder uses custom schema", func(t *testing.T) {
-		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-		reg.SetExtensionRelDecoder(&customDecoder{typeURL: typeURL, schema: extSchema2col})
-
-		out, err := RelFromProto(rel, reg)
-		require.NoError(t, err)
-		require.Equal(t, int32(2), out.RecordType().FieldCount())
-	})
-
-	t.Run("round-trip ToProto matches original", func(t *testing.T) {
-		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-		reg.SetExtensionRelDecoder(&customDecoder{typeURL: typeURL, schema: extSchema2col})
-
-		out, err := RelFromProto(rel, reg)
-		require.NoError(t, err)
-
-		if diff := cmp.Diff(rel, out.ToProto(), protocmp.Transform()); diff != "" {
-			t.Errorf("round-trip mismatch (-want +got):\n%s", diff)
-		}
-	})
-
-	t.Run("decoder returning nil falls back to UndecodedExtension", func(t *testing.T) {
-		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-		reg.SetExtensionRelDecoder(&customDecoder{typeURL: "type.googleapis.com/other.Type"})
-		require.Panics(t, func() {
-			out, err := RelFromProto(rel, reg)
-			require.NoError(t, err)
-			_ = out.RecordType()
-		})
-	})
-
-	t.Run("decoder returning error propagates to RelFromProto", func(t *testing.T) {
-		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-		reg.SetExtensionRelDecoder(&errorDecoder{err: errors.New("decode failed")})
-		_, err := RelFromProto(rel, reg)
-		require.ErrorContains(t, err, "decode failed")
-	})
-
-	t.Run("decoder returning wrong type errors", func(t *testing.T) {
-		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-		reg.SetExtensionRelDecoder(&wrongTypeDecoder{})
-		_, err := RelFromProto(rel, reg)
-		require.ErrorContains(t, err, "does not implement ExtensionRelDefinition")
-	})
-}
-
-// TestExtensionRelDecoder_Multi verifies the decoder hook for ExtensionMultiRel.
-//
-// ExtensionMultiRel has multiple inputs; UndecodedExtension.Schema returns an
-// empty RecordType (len(inputs) != 1), so any non-empty emit mapping panics.
-func TestExtensionRelDecoder_Multi(t *testing.T) {
-	const typeURL = "type.googleapis.com/test.MyMultiExtension"
-	detail := &anypb.Any{TypeUrl: typeURL, Value: []byte("irrelevant")}
-
-	// Two identical one-column inputs; the extension combines them into 2 cols.
-	rel := &proto.Rel{RelType: &proto.Rel_ExtensionMulti{ExtensionMulti: &proto.ExtensionMultiRel{
-		Common: emit01,
-		Inputs: []*proto.Rel{oneColInputRel, oneColInputRel},
-		Detail: detail,
-	}}}
-
-	t.Run("without decoder panics on emit OOB", func(t *testing.T) {
-		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-		require.Panics(t, func() {
-			out, err := RelFromProto(rel, reg)
-			require.NoError(t, err)
-			_ = out.RecordType()
-		})
-	})
-
-	t.Run("with decoder uses custom schema", func(t *testing.T) {
-		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-		reg.SetExtensionRelDecoder(&customDecoder{typeURL: typeURL, schema: extSchema2col})
-
-		out, err := RelFromProto(rel, reg)
-		require.NoError(t, err)
-		require.Equal(t, int32(2), out.RecordType().FieldCount())
-	})
-
-	t.Run("round-trip ToProto matches original", func(t *testing.T) {
-		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-		reg.SetExtensionRelDecoder(&customDecoder{typeURL: typeURL, schema: extSchema2col})
-
-		out, err := RelFromProto(rel, reg)
-		require.NoError(t, err)
-
-		if diff := cmp.Diff(rel, out.ToProto(), protocmp.Transform()); diff != "" {
-			t.Errorf("round-trip mismatch (-want +got):\n%s", diff)
-		}
-	})
-
-	t.Run("decoder returning nil falls back to UndecodedExtension", func(t *testing.T) {
-		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-		reg.SetExtensionRelDecoder(&customDecoder{typeURL: "type.googleapis.com/other.Type"})
-		require.Panics(t, func() {
-			out, err := RelFromProto(rel, reg)
-			require.NoError(t, err)
-			_ = out.RecordType()
-		})
-	})
-
-	t.Run("decoder returning error propagates to RelFromProto", func(t *testing.T) {
-		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-		reg.SetExtensionRelDecoder(&errorDecoder{err: errors.New("decode failed")})
-		_, err := RelFromProto(rel, reg)
-		require.ErrorContains(t, err, "decode failed")
-	})
-
-	t.Run("decoder returning wrong type errors", func(t *testing.T) {
-		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-		reg.SetExtensionRelDecoder(&wrongTypeDecoder{})
-		_, err := RelFromProto(rel, reg)
-		require.ErrorContains(t, err, "does not implement ExtensionRelDefinition")
-	})
+	}
 }

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -609,8 +609,8 @@ type customExtDef struct {
 	typeURL string
 }
 
-func (d *customExtDef) Schema(inputs []Rel) types.RecordType { return d.schema }
-func (d *customExtDef) Build(_ []Rel) *anypb.Any            { return d.detail }
+func (d *customExtDef) Schema(inputs []Rel) types.RecordType  { return d.schema }
+func (d *customExtDef) Build(_ []Rel) *anypb.Any              { return d.detail }
 func (d *customExtDef) Expressions(_ []Rel) []expr.Expression { return nil }
 
 // customDecoder returns a customExtDef for a specific typeURL and nil for everything else.
@@ -823,9 +823,9 @@ func TestExtensionRelDecoder_Multi(t *testing.T) {
 
 	// Two identical one-column inputs; the extension combines them into 2 cols.
 	rel := &proto.Rel{RelType: &proto.Rel_ExtensionMulti{ExtensionMulti: &proto.ExtensionMultiRel{
-		Common:  emit01,
-		Inputs:  []*proto.Rel{oneColInputRel, oneColInputRel},
-		Detail:  detail,
+		Common: emit01,
+		Inputs: []*proto.Rel{oneColInputRel, oneColInputRel},
+		Detail: detail,
 	}}}
 
 	t.Run("without decoder panics on emit OOB", func(t *testing.T) {

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -422,62 +422,15 @@ func TestFromProtoRightSemiJoinRootNames(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestProjectSetStyleDecoder verifies that psStyleDecoder correctly resolves SRF
-// expression types from the detail payload and appends them to the input schema.
-// The input has one i64 column; the SRF adds one i32 column, producing a 2-column output.
-func TestProjectSetStyleDecoder(t *testing.T) {
-	const projectSetTypeURL = "type.googleapis.com/test.ProjectSetRel"
-
-	inputSchema := *types.NewRecordTypeFromTypes([]types.Type{
-		&types.Int64Type{Nullability: types.NullabilityRequired},
-	})
-
-	srfExprProto := &proto.Expression{RexType: &proto.Expression_Literal_{
-		Literal: &proto.Expression_Literal{LiteralType: &proto.Expression_Literal_I32{I32: 42}},
-	}}
-	nestedBytes, err := protobuf.Marshal(&proto.Expression_Nested_Struct{Fields: []*proto.Expression{srfExprProto}})
-	require.NoError(t, err)
-	projectSetDetail := &anypb.Any{TypeUrl: projectSetTypeURL, Value: nestedBytes}
-
-	inputRelProto := &proto.Rel{RelType: &proto.Rel_Read{Read: &proto.ReadRel{
-		Common: &proto.RelCommon{EmitKind: &proto.RelCommon_Direct_{Direct: &proto.RelCommon_Direct{}}},
-		BaseSchema: &proto.NamedStruct{
-			Names: []string{"a"},
-			Struct: &proto.Type_Struct{
-				Types: []*proto.Type{{Kind: &proto.Type_I64_{I64: &proto.Type_I64{Nullability: proto.Type_NULLABILITY_REQUIRED}}}},
-			},
-		},
-		ReadType: &proto.ReadRel_VirtualTable_{VirtualTable: &proto.ReadRel_VirtualTable{}},
-	}}}
-
-	rel := &proto.Rel{RelType: &proto.Rel_ExtensionSingle{ExtensionSingle: &proto.ExtensionSingleRel{
-		Common: &proto.RelCommon{EmitKind: &proto.RelCommon_Emit_{Emit: &proto.RelCommon_Emit{OutputMapping: []int32{0, 1}}}},
-		Input:  inputRelProto,
-		Detail: projectSetDetail,
-	}}}
-
-	reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
-	require.NoError(t, reg.SetExtensionRelDecoder(projectSetTypeURL, projectSetDecoderFor(inputSchema, reg)))
-
-	out, err := RelFromProto(rel, reg)
-	require.NoError(t, err)
-
-	// psStyleDecoder resolves types from the SRF expressions: i64 passthrough + i32 SRF output.
-	got := out.RecordType()
-	require.Equal(t, int32(2), got.FieldCount())
-	assert.IsType(t, &types.Int64Type{}, got.GetFieldRef(0))
-	assert.IsType(t, &types.Int32Type{}, got.GetFieldRef(1))
-}
-
-// TestFromProtoWithDecoder is an integration test for FromProtoWithDecoder.
-// It verifies decoder wiring, schema resolution, and round-trip fidelity across
-// all three extension rel types and both direct and emit mappings.
+// TestFromProtoWithDecoder is a full-plan integration test for FromProtoWithDecoder.
+// It verifies decoder wiring and round-trip fidelity for all three extension rel types.
+// Relation-level decoder error cases are covered by TestExtensionRelDecoder below.
 func TestFromProtoWithDecoder(t *testing.T) {
 	const typeURL = "type.googleapis.com/test.MyExtension"
 	c := extensions.GetDefaultCollectionWithNoError()
 
-	direct := &proto.RelCommon{EmitKind: &proto.RelCommon_Direct_{Direct: &proto.RelCommon_Direct{}}}
 	emit201 := &proto.RelCommon{EmitKind: &proto.RelCommon_Emit_{Emit: &proto.RelCommon_Emit{OutputMapping: []int32{2, 0, 1}}}}
+	direct := &proto.RelCommon{EmitKind: &proto.RelCommon_Direct_{Direct: &proto.RelCommon_Direct{}}}
 	detail := &anypb.Any{TypeUrl: typeURL, Value: []byte("irrelevant")}
 
 	extSchema := *types.NewRecordTypeFromTypes([]types.Type{
@@ -497,71 +450,40 @@ func TestFromProtoWithDecoder(t *testing.T) {
 		ReadType: &proto.ReadRel_VirtualTable_{VirtualTable: &proto.ReadRel_VirtualTable{}},
 	}}}
 
-	makePlan := func(extRel *proto.Rel, names []string) *proto.Plan {
+	makePlan := func(extRel *proto.Rel) *proto.Plan {
 		return &proto.Plan{Relations: []*proto.PlanRel{{
-			RelType: &proto.PlanRel_Root{Root: &proto.RelRoot{Names: names, Input: extRel}},
+			RelType: &proto.PlanRel_Root{Root: &proto.RelRoot{Names: []string{"c", "a", "b"}, Input: extRel}},
 		}}}
 	}
 
-	cases := []struct {
-		name                 string
-		plan                 *proto.Plan
-		panicsWithoutDecoder bool
+	successCases := []struct {
+		name string
+		plan *proto.Plan
 	}{
 		{
-			name: "Single/Direct",
-			plan: makePlan(&proto.Rel{RelType: &proto.Rel_ExtensionSingle{ExtensionSingle: &proto.ExtensionSingleRel{
-				Common: direct, Input: oneColInput, Detail: detail,
-			}}}, []string{"a", "b", "c"}),
-		},
-		{
-			name:                 "Single/Emit",
-			panicsWithoutDecoder: true,
+			name: "Single",
 			plan: makePlan(&proto.Rel{RelType: &proto.Rel_ExtensionSingle{ExtensionSingle: &proto.ExtensionSingleRel{
 				Common: emit201, Input: oneColInput, Detail: detail,
-			}}}, []string{"c", "a", "b"}),
+			}}}),
 		},
 		{
-			name: "Leaf/Direct",
-			plan: makePlan(&proto.Rel{RelType: &proto.Rel_ExtensionLeaf{ExtensionLeaf: &proto.ExtensionLeafRel{
-				Common: direct, Detail: detail,
-			}}}, []string{"a", "b", "c"}),
-		},
-		{
-			name:                 "Leaf/Emit",
-			panicsWithoutDecoder: true,
+			name: "Leaf",
 			plan: makePlan(&proto.Rel{RelType: &proto.Rel_ExtensionLeaf{ExtensionLeaf: &proto.ExtensionLeafRel{
 				Common: emit201, Detail: detail,
-			}}}, []string{"c", "a", "b"}),
+			}}}),
 		},
 		{
-			name: "Multi/Direct",
-			plan: makePlan(&proto.Rel{RelType: &proto.Rel_ExtensionMulti{ExtensionMulti: &proto.ExtensionMultiRel{
-				Common: direct, Inputs: []*proto.Rel{oneColInput, oneColInput}, Detail: detail,
-			}}}, []string{"a", "b", "c"}),
-		},
-		{
-			name:                 "Multi/Emit",
-			panicsWithoutDecoder: true,
+			name: "Multi",
 			plan: makePlan(&proto.Rel{RelType: &proto.Rel_ExtensionMulti{ExtensionMulti: &proto.ExtensionMultiRel{
 				Common: emit201, Inputs: []*proto.Rel{oneColInput, oneColInput}, Detail: detail,
-			}}}, []string{"c", "a", "b"}),
+			}}}),
 		},
 	}
 
-	for _, tc := range cases {
+	for _, tc := range successCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.panicsWithoutDecoder {
-				require.Panics(t, func() {
-					p, err := FromProto(tc.plan, c)
-					require.NoError(t, err)
-					_ = p.Relations()[0].Root().RecordType()
-				})
-			}
-
 			p, err := FromProtoWithDecoder(tc.plan, c, map[string]expr.ExtensionRelDecoder{typeURL: &customDecoder{schema: extSchema}})
 			require.NoError(t, err)
-
 			require.Len(t, p.Relations()[0].Root().RecordType().Struct.Types, 3)
 
 			roundTripped, err := p.ToProto()
@@ -571,43 +493,14 @@ func TestFromProtoWithDecoder(t *testing.T) {
 			}
 		})
 	}
-}
 
-// projectSetDecoderFor returns an ExtensionRelDecoder that handles the
-// ProjectSet-style extension: it unpacks a nested struct of SRF expressions
-// from the detail, resolves each expression's output type via ExprFromProto
-// against the provided inputSchema, and returns an ExtensionRelDefinition
-// whose Schema() = inputSchema + SRF output types.
-//
-// This mirrors the pattern used by SRF-style extension relations.
-func projectSetDecoderFor(inputSchema types.RecordType, reg expr.ExtensionRegistry) expr.ExtensionRelDecoder {
-	return &psStyleDecoder{inputSchema: inputSchema, reg: reg}
-}
-
-type psStyleDecoder struct {
-	inputSchema types.RecordType
-	reg         expr.ExtensionRegistry
-}
-
-func (d *psStyleDecoder) DecodeExtensionRel(detail *anypb.Any) (any, error) {
-	if detail == nil {
-		return nil, nil
-	}
-	var ns proto.Expression_Nested_Struct
-	if err := protobuf.Unmarshal(detail.Value, &ns); err != nil {
-		return nil, err
-	}
-	srfFields := ns.GetFields()
-	srfTypes := make([]types.Type, 0, len(srfFields))
-	for _, f := range srfFields {
-		stExpr, err := expr.ExprFromProto(f, &d.inputSchema, d.reg)
-		if err != nil {
-			return nil, err
-		}
-		srfTypes = append(srfTypes, stExpr.GetType())
-	}
-	fullSchema := d.inputSchema.Concat(*types.NewRecordTypeFromTypes(srfTypes))
-	return &customExtDef{schema: fullSchema, detail: detail}, nil
+	t.Run("decoder error propagates", func(t *testing.T) {
+		plan := makePlan(&proto.Rel{RelType: &proto.Rel_ExtensionSingle{ExtensionSingle: &proto.ExtensionSingleRel{
+			Common: direct, Input: oneColInput, Detail: detail,
+		}}})
+		_, err := FromProtoWithDecoder(plan, c, map[string]expr.ExtensionRelDecoder{typeURL: &errorDecoder{err: errors.New("decode failed")}})
+		require.ErrorContains(t, err, "decode failed")
+	})
 }
 
 // customExtDef is a test ExtensionRelDefinition that claims a fixed output schema.

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -501,6 +501,23 @@ func TestFromProtoWithDecoder(t *testing.T) {
 		_, err := FromProtoWithDecoder(plan, c, map[string]expr.ExtensionRelDecoder{typeURL: &errorDecoder{err: errors.New("decode failed")}})
 		require.ErrorContains(t, err, "decode failed")
 	})
+
+}
+
+func TestIsRecordTypeSupported(t *testing.T) {
+	fixedSchema := *types.NewRecordTypeFromTypes([]types.Type{
+		&types.Int64Type{Nullability: types.NullabilityRequired},
+	})
+	decoded := &customExtDef{schema: fixedSchema}
+	undecoded := &UndecodedExtension{}
+
+	assert.True(t, isRecordTypeSupported(&ExtensionSingleRel{definition: decoded}))
+	assert.True(t, isRecordTypeSupported(&ExtensionLeafRel{definition: decoded}))
+	assert.True(t, isRecordTypeSupported(&ExtensionMultiRel{definition: decoded}))
+
+	assert.False(t, isRecordTypeSupported(&ExtensionSingleRel{definition: undecoded}))
+	assert.False(t, isRecordTypeSupported(&ExtensionLeafRel{definition: undecoded}))
+	assert.False(t, isRecordTypeSupported(&ExtensionMultiRel{definition: undecoded}))
 }
 
 // customExtDef is a test ExtensionRelDefinition that claims a fixed output schema.

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -1,6 +1,7 @@
 package plan
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -625,6 +626,16 @@ func (cd *customDecoder) DecodeExtensionRel(detail *anypb.Any) (any, error) {
 	return &customExtDef{detail: detail, schema: cd.schema, typeURL: cd.typeURL}, nil
 }
 
+// errorDecoder always returns a non-nil error from DecodeExtensionRel.
+type errorDecoder struct{ err error }
+
+func (d *errorDecoder) DecodeExtensionRel(_ *anypb.Any) (any, error) { return nil, d.err }
+
+// wrongTypeDecoder returns a value that does not implement ExtensionRelDefinition.
+type wrongTypeDecoder struct{}
+
+func (d *wrongTypeDecoder) DecodeExtensionRel(_ *anypb.Any) (any, error) { return "not-a-def", nil }
+
 // extSchema2col is a 2-column RecordType used across extension decoder tests.
 var extSchema2col = *types.NewRecordTypeFromTypes([]types.Type{
 	&types.Int64Type{Nullability: types.NullabilityRequired},
@@ -716,6 +727,21 @@ func TestExtensionRelDecoder_Single(t *testing.T) {
 			_ = out.RecordType()
 		})
 	})
+
+	t.Run("decoder returning error propagates to RelFromProto", func(t *testing.T) {
+		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+		sentinel := errors.New("decode failed")
+		reg.SetExtensionRelDecoder(&errorDecoder{err: sentinel})
+		_, err := RelFromProto(rel, reg)
+		require.ErrorContains(t, err, "decode failed")
+	})
+
+	t.Run("decoder returning wrong type errors", func(t *testing.T) {
+		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+		reg.SetExtensionRelDecoder(&wrongTypeDecoder{})
+		_, err := RelFromProto(rel, reg)
+		require.ErrorContains(t, err, "does not implement ExtensionRelDefinition")
+	})
 }
 
 // TestExtensionRelDecoder_Leaf verifies the decoder hook for ExtensionLeafRel.
@@ -770,6 +796,20 @@ func TestExtensionRelDecoder_Leaf(t *testing.T) {
 			require.NoError(t, err)
 			_ = out.RecordType()
 		})
+	})
+
+	t.Run("decoder returning error propagates to RelFromProto", func(t *testing.T) {
+		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+		reg.SetExtensionRelDecoder(&errorDecoder{err: errors.New("decode failed")})
+		_, err := RelFromProto(rel, reg)
+		require.ErrorContains(t, err, "decode failed")
+	})
+
+	t.Run("decoder returning wrong type errors", func(t *testing.T) {
+		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+		reg.SetExtensionRelDecoder(&wrongTypeDecoder{})
+		_, err := RelFromProto(rel, reg)
+		require.ErrorContains(t, err, "does not implement ExtensionRelDefinition")
 	})
 }
 
@@ -826,6 +866,20 @@ func TestExtensionRelDecoder_Multi(t *testing.T) {
 			require.NoError(t, err)
 			_ = out.RecordType()
 		})
+	})
+
+	t.Run("decoder returning error propagates to RelFromProto", func(t *testing.T) {
+		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+		reg.SetExtensionRelDecoder(&errorDecoder{err: errors.New("decode failed")})
+		_, err := RelFromProto(rel, reg)
+		require.ErrorContains(t, err, "decode failed")
+	})
+
+	t.Run("decoder returning wrong type errors", func(t *testing.T) {
+		reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+		reg.SetExtensionRelDecoder(&wrongTypeDecoder{})
+		_, err := RelFromProto(rel, reg)
+		require.ErrorContains(t, err, "does not implement ExtensionRelDefinition")
 	})
 }
 


### PR DESCRIPTION
RelFromProto always wrapped extension relation details (ExtensionSingleRel, ExtensionMultiRel, ExtensionLeafRel) in UndecodedExtension, which returns only the input schema. This caused panics when an emit mapping referenced columns added by the extension itself, and gave callers no way to teach the deserializer about their custom extension schemas.

This PR implements an ExtensionRelDecoder interface, that callers can provide to decode their extension relation details into a schema. It adds this interface to ExtensionRegistry, and RelFromProto uses this to decode extension relation types, falling back to UndecodedExtension when the decoder returns (nil, nil).

