### PR TITLE
feat: implement simple plan walking

### DIFF
--- a/expr/expression.go
+++ b/expr/expression.go
@@ -434,6 +434,10 @@ type Expression interface {
 	//   }
 	//   newExpr := preOrderVisit(oldExpr)
 	Visit(VisitFunc) Expression
+	// GetExprs returns the immediate child expressions of this expression node.
+	// Leaf expressions (literals, DynamicParameter) return nil.
+	// Does not cross subquery boundaries.
+	GetExprs() []Expression
 }
 
 type IfThenPair struct {
@@ -616,6 +620,15 @@ func (ex *IfThen) Visit(visit VisitFunc) Expression {
 	return out
 }
 
+func (ex *IfThen) GetExprs() []Expression {
+	var out []Expression
+	for _, c := range ex.ifs {
+		out = append(out, c.If, c.Then)
+	}
+	out = append(out, ex.elseClause)
+	return out
+}
+
 type Cast struct {
 	Type            types.Type
 	Input           Expression
@@ -675,6 +688,8 @@ func (ex *Cast) Visit(visit VisitFunc) Expression {
 	return &newCast
 }
 
+func (ex *Cast) GetExprs() []Expression { return []Expression{ex.Input} }
+
 type DynamicParameter struct {
 	OutputType         types.Type
 	ParameterReference uint32
@@ -722,6 +737,8 @@ func (dp *DynamicParameter) Equals(other Expression) bool {
 func (dp *DynamicParameter) Visit(visit VisitFunc) Expression {
 	return dp
 }
+
+func (dp *DynamicParameter) GetExprs() []Expression { return nil }
 
 type SwitchExpr struct {
 	match Expression
@@ -976,6 +993,18 @@ func (ex *SwitchExpr) Visit(visit VisitFunc) Expression {
 	}
 
 	out.elseClause = afterElse
+	return out
+}
+
+func (ex *SwitchExpr) GetExprs() []Expression {
+	var out []Expression
+	out = append(out, ex.match)
+	for _, c := range ex.ifs {
+		out = append(out, c.If, c.Then)
+	}
+	if ex.elseClause != nil {
+		out = append(out, ex.elseClause)
+	}
 	return out
 }
 
@@ -1239,6 +1268,22 @@ func (ex *MultiOrList) Visit(visit VisitFunc) Expression {
 	return out
 }
 
+func (ex *SingularOrList) GetExprs() []Expression {
+	var out []Expression
+	out = append(out, ex.Value)
+	out = append(out, ex.Options...)
+	return out
+}
+
+func (ex *MultiOrList) GetExprs() []Expression {
+	var out []Expression
+	out = append(out, ex.Value...)
+	for _, opts := range ex.Options {
+		out = append(out, opts...)
+	}
+	return out
+}
+
 type NestedExpr interface {
 	Expression
 
@@ -1345,6 +1390,14 @@ func (ex *MapExpr) Equals(other Expression) bool {
 		func(l, r struct{ Key, Value Expression }) bool {
 			return l.Key.Equals(r.Key) && l.Value.Equals(r.Value)
 		})
+}
+
+func (ex *MapExpr) GetExprs() []Expression {
+	var out []Expression
+	for _, kv := range ex.KeyValues {
+		out = append(out, kv.Key, kv.Value)
+	}
+	return out
 }
 
 func (ex *MapExpr) Visit(visit VisitFunc) Expression {
@@ -1465,6 +1518,8 @@ func (ex *StructExpr) Equals(other Expression) bool {
 		slices.EqualFunc(ex.Fields, rhs.Fields, exprEqual)
 }
 
+func (ex *StructExpr) GetExprs() []Expression { return ex.Fields }
+
 func (ex *StructExpr) Visit(visit VisitFunc) Expression {
 	var out *StructExpr
 	for i, f := range ex.Fields {
@@ -1584,6 +1639,8 @@ func (ex *ListExpr) Equals(other Expression) bool {
 
 	return slices.EqualFunc(ex.Values, rhs.Values, exprEqual)
 }
+
+func (ex *ListExpr) GetExprs() []Expression { return ex.Values }
 
 func (ex *ListExpr) Visit(visit VisitFunc) Expression {
 	var out *ListExpr

--- a/expr/expression.go
+++ b/expr/expression.go
@@ -434,7 +434,7 @@ type Expression interface {
 	//   }
 	//   newExpr := preOrderVisit(oldExpr)
 	Visit(VisitFunc) Expression
-	// GetExprs returns the immediate child expressions of this expression node.
+	// GetExprs returns the immediate child expressions of this Expression.
 	// Leaf expressions (literals, DynamicParameter) return nil.
 	// Does not cross subquery boundaries.
 	GetExprs() []Expression

--- a/expr/field_reference.go
+++ b/expr/field_reference.go
@@ -757,6 +757,13 @@ func (f *FieldReference) Visit(v VisitFunc) Expression {
 	return f
 }
 
+func (f *FieldReference) GetExprs() []Expression {
+	if e, ok := f.Root.(Expression); ok {
+		return []Expression{e}
+	}
+	return nil
+}
+
 func (*FieldReference) IsScalar() bool { return true }
 
 func FieldReferenceFromProto(p *proto.Expression_FieldReference, baseSchema *types.RecordType, reg ExtensionRegistry) (*FieldReference, error) {

--- a/expr/functions.go
+++ b/expr/functions.go
@@ -434,6 +434,16 @@ func (s *ScalarFunction) Equals(rhs Expression) bool {
 	})
 }
 
+func (s *ScalarFunction) GetExprs() []Expression {
+	var out []Expression
+	for _, arg := range s.args {
+		if e, ok := arg.(Expression); ok {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
 func (s *ScalarFunction) Visit(visit VisitFunc) Expression {
 	var args []types.FuncArg
 	for i, arg := range s.args {
@@ -733,6 +743,20 @@ func (w *WindowFunction) ToProtoFuncArg() *proto.FunctionArgument {
 			Value: w.ToProto(),
 		},
 	}
+}
+
+func (w *WindowFunction) GetExprs() []Expression {
+	var out []Expression
+	for _, arg := range w.args {
+		if e, ok := arg.(Expression); ok {
+			out = append(out, e)
+		}
+	}
+	out = append(out, w.Partitions...)
+	for _, sf := range w.Sorts {
+		out = append(out, sf.Expr)
+	}
+	return out
 }
 
 func (w *WindowFunction) Visit(visit VisitFunc) Expression {

--- a/expr/interval_compound_literal.go
+++ b/expr/interval_compound_literal.go
@@ -109,6 +109,7 @@ func (m IntervalCompoundLiteral) ToProtoFuncArg() *proto.FunctionArgument {
 	}
 }
 
+func (m IntervalCompoundLiteral) GetExprs() []Expression     { return nil }
 func (m IntervalCompoundLiteral) Visit(VisitFunc) Expression { return m }
 func (IntervalCompoundLiteral) IsScalar() bool               { return true }
 

--- a/expr/interval_year_to_month.go
+++ b/expr/interval_year_to_month.go
@@ -67,5 +67,6 @@ func (m IntervalYearToMonthLiteral) ToProtoFuncArg() *proto.FunctionArgument {
 	}
 }
 
+func (m IntervalYearToMonthLiteral) GetExprs() []Expression     { return nil }
 func (m IntervalYearToMonthLiteral) Visit(VisitFunc) Expression { return m }
 func (IntervalYearToMonthLiteral) IsScalar() bool               { return true }

--- a/expr/lambda.go
+++ b/expr/lambda.go
@@ -84,3 +84,5 @@ func (l *Lambda) Visit(visit VisitFunc) Expression {
 	}
 	return &Lambda{Parameters: l.Parameters, Body: newBody}
 }
+
+func (l *Lambda) GetExprs() []Expression { return []Expression{l.Body} }

--- a/expr/literals.go
+++ b/expr/literals.go
@@ -94,6 +94,7 @@ type Literal interface {
 	Visit(VisitFunc) Expression
 	// ValueString returns a human presentable representation of just the literal's value.
 	ValueString() string
+	GetExprs() []Expression
 }
 
 // A NullLiteral is a typed null, so it just contains its type with no value
@@ -143,6 +144,8 @@ func (n *NullLiteral) Equals(rhs Expression) bool {
 
 	return false
 }
+
+func (n *NullLiteral) GetExprs() []Expression { return nil }
 
 func (n *NullLiteral) Visit(VisitFunc) Expression {
 	return n
@@ -235,6 +238,7 @@ func (t *PrimitiveLiteral[T]) ToProtoFuncArg() *proto.FunctionArgument {
 	}
 }
 
+func (t *PrimitiveLiteral[T]) GetExprs() []Expression     { return nil }
 func (t *PrimitiveLiteral[T]) Visit(VisitFunc) Expression { return t }
 func (*PrimitiveLiteral[T]) IsScalar() bool               { return true }
 
@@ -330,6 +334,8 @@ func (t *NestedLiteral[T]) ToProtoFuncArg() *proto.FunctionArgument {
 	}
 }
 
+func (t *NestedLiteral[T]) GetExprs() []Expression { return nil }
+
 func (t *NestedLiteral[T]) Visit(VisitFunc) Expression {
 	return t
 }
@@ -410,6 +416,7 @@ func (t *MapLiteral) ToProtoFuncArg() *proto.FunctionArgument {
 	}
 }
 
+func (t *MapLiteral) GetExprs() []Expression     { return nil }
 func (t *MapLiteral) Visit(VisitFunc) Expression { return t }
 func (*MapLiteral) IsScalar() bool               { return true }
 
@@ -480,6 +487,7 @@ func (t *ByteSliceLiteral[T]) ToProtoFuncArg() *proto.FunctionArgument {
 	}
 }
 
+func (t *ByteSliceLiteral[T]) GetExprs() []Expression     { return nil }
 func (t *ByteSliceLiteral[T]) Visit(VisitFunc) Expression { return t }
 func (*ByteSliceLiteral[T]) IsScalar() bool               { return true }
 
@@ -694,6 +702,7 @@ func (t *ProtoLiteral) ToProtoFuncArg() *proto.FunctionArgument {
 	}
 }
 
+func (t *ProtoLiteral) GetExprs() []Expression     { return nil }
 func (t *ProtoLiteral) Visit(VisitFunc) Expression { return t }
 func (*ProtoLiteral) IsScalar() bool               { return true }
 

--- a/plan/common.go
+++ b/plan/common.go
@@ -66,7 +66,6 @@ func ValidateParameterBindings(root Rel, bindings []DynamicParameterBinding) err
 	return nil
 }
 
-
 type (
 	Hint              = proto.RelCommon_Hint
 	Stats             = proto.RelCommon_Hint_Stats

--- a/plan/common.go
+++ b/plan/common.go
@@ -39,7 +39,11 @@ func ValidateParameterBindings(root Rel, bindings []DynamicParameterBinding) err
 
 	// Collect all DynamicParameter output types keyed by anchor.
 	paramTypes := make(map[uint32]types.Type)
-	collectDynamicParams(root, paramTypes)
+	WalkRels(root, nil, func(e expr.Expression) {
+		if dp, ok := e.(*expr.DynamicParameter); ok {
+			paramTypes[dp.ParameterReference] = dp.OutputType
+		}
+	})
 
 	for _, b := range bindings {
 		declaredType, ok := paramTypes[b.ParameterAnchor]
@@ -62,60 +66,6 @@ func ValidateParameterBindings(root Rel, bindings []DynamicParameterBinding) err
 	return nil
 }
 
-// collectDynamicParams walks a relation tree and records the OutputType
-// of every DynamicParameter expression it encounters.
-func collectDynamicParams(rel Rel, out map[uint32]types.Type) {
-	if rel == nil {
-		return
-	}
-
-	// Walk child relations first.
-	for _, child := range rel.GetInputs() {
-		collectDynamicParams(child, out)
-	}
-
-	// Walk expressions owned by this relation.
-	walkRelExprs(rel, func(e expr.Expression) {
-		walkExpr(e, func(inner expr.Expression) {
-			if dp, ok := inner.(*expr.DynamicParameter); ok {
-				out[dp.ParameterReference] = dp.OutputType
-			}
-		})
-	})
-}
-
-// walkRelExprs invokes fn for every top-level expression in a relation.
-func walkRelExprs(rel Rel, fn func(expr.Expression)) {
-	switch r := rel.(type) {
-	case *FilterRel:
-		fn(r.Condition())
-	case *ProjectRel:
-		for _, e := range r.Expressions() {
-			fn(e)
-		}
-	case *JoinRel:
-		fn(r.Expr())
-		if pjf := r.PostJoinFilter(); pjf != nil {
-			fn(pjf)
-		}
-	case *SortRel:
-		for _, sf := range r.Sorts() {
-			fn(sf.Expr)
-		}
-	}
-}
-
-// walkExpr recursively visits every node in an expression tree.
-func walkExpr(e expr.Expression, fn func(expr.Expression)) {
-	if e == nil {
-		return
-	}
-	fn(e)
-	e.Visit(func(child expr.Expression) expr.Expression {
-		walkExpr(child, fn)
-		return child
-	})
-}
 
 type (
 	Hint              = proto.RelCommon_Hint

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -410,6 +410,9 @@ type Rel interface {
 	// GetInputs returns a list of zero or more inputs for this relation
 	GetInputs() []Rel
 
+	// GetExprs returns the immediate child expressions of this Relation
+	GetExprs() []expr.Expression
+
 	// CopyWithExpressionRewrite rewrites all expression trees in this Rel. Returns original Rel
 	// if no changes were made, otherwise a newly created rel that includes the given expressions
 	CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInputs ...Rel) (Rel, error)

--- a/plan/relations.go
+++ b/plan/relations.go
@@ -137,6 +137,17 @@ func (b *baseReadRel) GetInputs() []Rel {
 	return []Rel{}
 }
 
+func (b *baseReadRel) GetExprs() []expr.Expression {
+	var out []expr.Expression
+	if b.filter != nil {
+		out = append(out, b.filter)
+	}
+	if b.bestEffortFilter != nil {
+		out = append(out, b.bestEffortFilter)
+	}
+	return out
+}
+
 func (b *baseReadRel) copyExpressions(rewriteFunc RewriteFunc) ([]expr.Expression, error) {
 	filter, err := rewriteFunc(b.filter)
 	if err != nil {
@@ -757,6 +768,8 @@ func (p *ProjectRel) GetInputs() []Rel {
 	return []Rel{p.input}
 }
 
+func (p *ProjectRel) GetExprs() []expr.Expression { return p.exprs }
+
 func (p *ProjectRel) Copy(newInputs ...Rel) (Rel, error) {
 	if len(newInputs) != 1 {
 		return nil, substraitgo.ErrInvalidInputCount
@@ -917,6 +930,17 @@ func (j *JoinRel) GetInputs() []Rel {
 	return []Rel{j.left, j.right}
 }
 
+func (j *JoinRel) GetExprs() []expr.Expression {
+	var out []expr.Expression
+	if j.expr != nil {
+		out = append(out, j.expr)
+	}
+	if j.postJoinFilter != nil {
+		out = append(out, j.postJoinFilter)
+	}
+	return out
+}
+
 func (j *JoinRel) Copy(newInputs ...Rel) (Rel, error) {
 	if len(newInputs) != 2 {
 		return nil, substraitgo.ErrInvalidInputCount
@@ -1001,6 +1025,8 @@ func (c *CrossRel) GetInputs() []Rel {
 	return []Rel{c.left, c.right}
 }
 
+func (c *CrossRel) GetExprs() []expr.Expression { return nil }
+
 func (c *CrossRel) Copy(newInputs ...Rel) (Rel, error) {
 	if len(newInputs) != 2 {
 		return nil, substraitgo.ErrInvalidInputCount
@@ -1076,6 +1102,8 @@ func (f *FetchRel) ToProtoPlanRel() *proto.PlanRel {
 func (f *FetchRel) GetInputs() []Rel {
 	return []Rel{f.input}
 }
+
+func (f *FetchRel) GetExprs() []expr.Expression { return nil }
 
 func (f *FetchRel) Copy(newInputs ...Rel) (Rel, error) {
 	if len(newInputs) != 1 {
@@ -1210,6 +1238,25 @@ func (ar *AggregateRel) ToProtoPlanRel() *proto.PlanRel {
 
 func (ar *AggregateRel) GetInputs() []Rel {
 	return []Rel{ar.input}
+}
+
+func (ar *AggregateRel) GetExprs() []expr.Expression {
+	var out []expr.Expression
+	out = append(out, ar.groupingExpressions...)
+	for _, am := range ar.measures {
+		if am.filter != nil {
+			out = append(out, am.filter)
+		}
+		for i := range am.measure.NArgs() {
+			if e, ok := am.measure.Arg(i).(expr.Expression); ok {
+				out = append(out, e)
+			}
+		}
+		for _, sf := range am.measure.Sorts {
+			out = append(out, sf.Expr)
+		}
+	}
+	return out
 }
 
 func (ar *AggregateRel) Copy(newInputs ...Rel) (Rel, error) {
@@ -1368,6 +1415,14 @@ func (sr *SortRel) GetInputs() []Rel {
 	return []Rel{sr.input}
 }
 
+func (sr *SortRel) GetExprs() []expr.Expression {
+	var out []expr.Expression
+	for _, sf := range sr.sorts {
+		out = append(out, sf.Expr)
+	}
+	return out
+}
+
 func (sr *SortRel) Copy(newInputs ...Rel) (Rel, error) {
 	if len(newInputs) != 1 {
 		return nil, substraitgo.ErrInvalidInputCount
@@ -1453,6 +1508,8 @@ func (fr *FilterRel) ToProtoPlanRel() *proto.PlanRel {
 func (fr *FilterRel) GetInputs() []Rel {
 	return []Rel{fr.input}
 }
+
+func (fr *FilterRel) GetExprs() []expr.Expression { return []expr.Expression{fr.cond} }
 
 func (fr *FilterRel) Copy(newInputs ...Rel) (Rel, error) {
 	if len(newInputs) != 1 {
@@ -1548,6 +1605,8 @@ func (s *SetRel) ToProtoPlanRel() *proto.PlanRel {
 func (s *SetRel) GetInputs() []Rel {
 	return s.inputs
 }
+
+func (s *SetRel) GetExprs() []expr.Expression { return nil }
 
 func (s *SetRel) Copy(newInputs ...Rel) (Rel, error) {
 	set := *s
@@ -1660,6 +1719,8 @@ func (es *ExtensionSingleRel) GetInputs() []Rel {
 	return []Rel{es.input}
 }
 
+func (es *ExtensionSingleRel) GetExprs() []expr.Expression { return nil }
+
 func (es *ExtensionSingleRel) Copy(newInputs ...Rel) (Rel, error) {
 	if len(newInputs) != 1 {
 		return nil, substraitgo.ErrInvalidInputCount
@@ -1725,6 +1786,8 @@ func (el *ExtensionLeafRel) GetInputs() []Rel {
 	return []Rel{}
 }
 
+func (el *ExtensionLeafRel) GetExprs() []expr.Expression { return nil }
+
 func (el *ExtensionLeafRel) Copy(_ ...Rel) (Rel, error) {
 	return el, nil
 }
@@ -1788,6 +1851,8 @@ func (em *ExtensionMultiRel) ToProtoPlanRel() *proto.PlanRel {
 func (em *ExtensionMultiRel) GetInputs() []Rel {
 	return em.inputs
 }
+
+func (em *ExtensionMultiRel) GetExprs() []expr.Expression { return nil }
 
 func (em *ExtensionMultiRel) Copy(newInputs ...Rel) (Rel, error) {
 	proj := *em
@@ -2099,6 +2164,17 @@ func (hr *HashJoinRel) GetInputs() []Rel {
 	return []Rel{hr.left, hr.right}
 }
 
+func (hr *HashJoinRel) GetExprs() []expr.Expression {
+	var out []expr.Expression
+	for _, k := range hr.keys {
+		out = append(out, k.left, k.right)
+	}
+	if hr.postJoinFilter != nil {
+		out = append(out, hr.postJoinFilter)
+	}
+	return out
+}
+
 func (hr *HashJoinRel) Copy(newInputs ...Rel) (Rel, error) {
 	if len(newInputs) != 2 {
 		return nil, substraitgo.ErrInvalidInputCount
@@ -2214,6 +2290,17 @@ func (mr *MergeJoinRel) ToProtoPlanRel() *proto.PlanRel {
 
 func (mr *MergeJoinRel) GetInputs() []Rel {
 	return []Rel{mr.left, mr.right}
+}
+
+func (mr *MergeJoinRel) GetExprs() []expr.Expression {
+	var out []expr.Expression
+	for _, k := range mr.keys {
+		out = append(out, k.left, k.right)
+	}
+	if mr.postJoinFilter != nil {
+		out = append(out, mr.postJoinFilter)
+	}
+	return out
 }
 
 func (mr *MergeJoinRel) Copy(newInputs ...Rel) (Rel, error) {
@@ -2340,6 +2427,8 @@ func (wr *NamedTableWriteRel) ToProtoPlanRel() *proto.PlanRel {
 func (wr *NamedTableWriteRel) GetInputs() []Rel {
 	return []Rel{wr.input}
 }
+
+func (wr *NamedTableWriteRel) GetExprs() []expr.Expression { return nil }
 
 func (wr *NamedTableWriteRel) Copy(newInputs ...Rel) (Rel, error) {
 	if len(newInputs) != 1 {

--- a/plan/relations_test.go
+++ b/plan/relations_test.go
@@ -585,6 +585,8 @@ func (f *fakeRel) GetInputs() []Rel {
 	panic("unused")
 }
 
+func (f *fakeRel) GetExprs() []expr.Expression { return nil }
+
 func (f *fakeRel) CopyWithExpressionRewrite(rewriteFunc RewriteFunc, newInputs ...Rel) (Rel, error) {
 	panic("unused")
 }

--- a/plan/subquery.go
+++ b/plan/subquery.go
@@ -136,6 +136,8 @@ func (s *ScalarSubquery) Visit(visit expr.VisitFunc) expr.Expression {
 	return s
 }
 
+func (s *ScalarSubquery) GetExprs() []expr.Expression { return nil }
+
 // InPredicateSubquery checks that the left expressions are contained in the right subquery
 type InPredicateSubquery struct {
 	Needles  []expr.Expression // Expressions whose existence will be checked
@@ -229,6 +231,8 @@ func (s *InPredicateSubquery) Equals(other expr.Expression) bool {
 
 	return isRelEqual(s.Haystack, otherInPredicate.Haystack)
 }
+
+func (s *InPredicateSubquery) GetExprs() []expr.Expression { return s.Needles }
 
 func (s *InPredicateSubquery) Visit(visit expr.VisitFunc) expr.Expression {
 	var out *InPredicateSubquery
@@ -328,6 +332,8 @@ func (s *SetPredicateSubquery) Equals(other expr.Expression) bool {
 	return s.Operation == otherSetPredicate.Operation &&
 		isRelEqual(s.Tuples, otherSetPredicate.Tuples)
 }
+
+func (s *SetPredicateSubquery) GetExprs() []expr.Expression { return nil }
 
 func (s *SetPredicateSubquery) Visit(visit expr.VisitFunc) expr.Expression {
 	// SetPredicateSubquery doesn't contain expressions that need visiting
@@ -464,6 +470,8 @@ func (s *SetComparisonSubquery) Equals(other expr.Expression) bool {
 		s.Left.Equals(otherSetComparison.Left) &&
 		isRelEqual(s.Right, otherSetComparison.Right)
 }
+
+func (s *SetComparisonSubquery) GetExprs() []expr.Expression { return []expr.Expression{s.Left} }
 
 func (s *SetComparisonSubquery) Visit(visit expr.VisitFunc) expr.Expression {
 	afterLeft := visit(s.Left)

--- a/plan/walk.go
+++ b/plan/walk.go
@@ -1,0 +1,41 @@
+package plan
+
+import "github.com/substrait-io/substrait-go/v8/expr"
+
+// WalkExprs calls exprFn on e and every Expression reachable from it, pre-order.
+// When a subquery expression is encountered, relFn is called on its embedded Rel
+// and WalkRels is used to continue traversal through it.
+// Either fn may be nil.
+func WalkExprs(e expr.Expression, exprFn func(expr.Expression), relFn func(Rel)) {
+	if exprFn != nil {
+		exprFn(e)
+	}
+	switch sq := e.(type) {
+	case *ScalarSubquery:
+		WalkRels(sq.Input, relFn, exprFn)
+	case *InPredicateSubquery:
+		WalkRels(sq.Haystack, relFn, exprFn)
+	case *SetPredicateSubquery:
+		WalkRels(sq.Tuples, relFn, exprFn)
+	case *SetComparisonSubquery:
+		WalkRels(sq.Right, relFn, exprFn)
+	}
+	for _, child := range e.GetExprs() {
+		WalkExprs(child, exprFn, relFn)
+	}
+}
+
+// WalkRels calls relFn on rel and every Rel reachable from it, pre-order.
+// Expressions in each Rel are walked via WalkExprs, crossing subquery boundaries.
+// Either fn may be nil.
+func WalkRels(rel Rel, relFn func(Rel), exprFn func(expr.Expression)) {
+	if relFn != nil {
+		relFn(rel)
+	}
+	for _, e := range rel.GetExprs() {
+		WalkExprs(e, exprFn, relFn)
+	}
+	for _, input := range rel.GetInputs() {
+		WalkRels(input, relFn, exprFn)
+	}
+}

--- a/plan/walk_test.go
+++ b/plan/walk_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package plan_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/substrait-io/substrait-go/v8/expr"
+	"github.com/substrait-io/substrait-go/v8/plan"
+)
+
+// TestWalkRels verifies that WalkRels visits every Rel and Expression in the
+// tree, including Rels embedded inside subquery expressions (crossing subquery
+// boundaries).
+//
+// Plan shape:
+//
+//	ProjectRel  [exprs: ScalarSubquery(innerScan)]
+//	  FilterRel [cond: literal(true)]
+//	    outerScan
+//
+// innerScan is only reachable through the subquery boundary.
+func TestWalkRels(t *testing.T) {
+	b := plan.NewBuilderDefault()
+
+	innerScan := b.NamedScan([]string{"inner"}, baseSchema)
+	subquery := plan.NewScalarSubquery(innerScan)
+
+	outerScan := b.NamedScan([]string{"outer"}, baseSchema2)
+	filter, err := b.Filter(outerScan, expr.NewPrimitiveLiteral(true, false))
+	require.NoError(t, err)
+	project, err := b.Project(filter, subquery)
+	require.NoError(t, err)
+
+	var visitedRels []plan.Rel
+	var visitedExprs []expr.Expression
+	plan.WalkRels(project,
+		func(r plan.Rel) { visitedRels = append(visitedRels, r) },
+		func(e expr.Expression) { visitedExprs = append(visitedExprs, e) },
+	)
+
+	// ProjectRel, FilterRel, outerScan, innerScan (via subquery boundary)
+	assert.Len(t, visitedRels, 4)
+	// ScalarSubquery (project expr), literal(true) (filter cond)
+	assert.Len(t, visitedExprs, 2)
+
+	assert.IsType(t, &plan.ScalarSubquery{}, visitedExprs[0])
+}


### PR DESCRIPTION
Introduces GetExprs() as a method on Relation and Expression, which returns the
direct expression of the nodes.

When combined with the existing GetInput method on Relations, allows for a
straightforward implementations of:
* func WalkExprs(e expr.Expression, exprFn func(expr.Expression), relFn func(Rel))
* func WalkRels(rel Rel, relFn func(Rel), exprFn func(expr.Expression))

which exhaustively through all relations and expressions, even through subquery
boundaries.

Fixes an issue in ValidateParameterBindings, which did not check for
DynamicParameters through subquery boundaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added traversal support for relational plans and expressions.
  * Exposed immediate child expressions across plans, expressions, functions, literals, joins, aggregates, and subqueries.
  * Added utilities to walk nested plans and expressions, including supported subquery contents.

* **Bug Fixes**
  * Improved parameter-binding validation by using the shared plan traversal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->