### PR TITLE
feat(type)!: define Nullability instead of aliasing the protobuf enum

### DIFF
--- a/expr/expression.go
+++ b/expr/expression.go
@@ -358,7 +358,7 @@ func ExprFromProto(e *proto.Expression, baseSchema *types.RecordType, reg Extens
 		params := &types.StructType{
 			Types:            paramTypes,
 			TypeVariationRef: et.Lambda.Parameters.TypeVariationReference,
-			Nullability:      et.Lambda.Parameters.Nullability,
+			Nullability:      types.Nullability(et.Lambda.Parameters.Nullability),
 		}
 
 		if params.Nullability != types.NullabilityRequired {

--- a/expr/lambda.go
+++ b/expr/lambda.go
@@ -58,7 +58,7 @@ func (l *Lambda) ToProto() *proto.Expression {
 	paramsProto := &proto.Type_Struct{
 		Types:                  children,
 		TypeVariationReference: l.Parameters.TypeVariationRef,
-		Nullability:            l.Parameters.Nullability,
+		Nullability:            proto.Type_Nullability(l.Parameters.Nullability),
 	}
 
 	return &proto.Expression{

--- a/extensions/simple_extension_test.go
+++ b/extensions/simple_extension_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/substrait-io/substrait-go/v8/extensions"
 	"github.com/substrait-io/substrait-go/v8/types"
-	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
 )
 
 func TestUnmarshalSimpleExtension(t *testing.T) {
@@ -76,7 +75,7 @@ scalar_functions:
 	typ, err := arg1.Value.ValueType.ReturnType(nil, nil)
 	assert.NoError(t, err)
 	assert.IsType(t, &types.UserDefinedType{}, typ)
-	assert.Equal(t, proto.Type_NULLABILITY_REQUIRED, typ.GetNullability(), "expected NULLABILITY_REQUIRED")
+	assert.Equal(t, types.NullabilityRequired, typ.GetNullability(), "expected NULLABILITY_REQUIRED")
 
 	assert.Equal(t, "scalar2", f.ScalarFunctions[1].Name)
 	assert.IsType(t, extensions.ValueArg{}, f.ScalarFunctions[1].Impls[0].Args[0])
@@ -85,7 +84,7 @@ scalar_functions:
 	typ, err = ret.ValueType.ReturnType(nil, nil)
 	assert.NoError(t, err)
 	assert.IsType(t, &types.UserDefinedType{}, typ)
-	assert.Equal(t, proto.Type_NULLABILITY_NULLABLE, typ.GetNullability(), "expected NULLABILITY_NULLABLE")
+	assert.Equal(t, types.NullabilityNullable, typ.GetNullability(), "expected NULLABILITY_NULLABLE")
 }
 
 func TestUnmarshalSimpleExtensionScalarFunction(t *testing.T) {

--- a/literal/utils_test.go
+++ b/literal/utils_test.go
@@ -94,9 +94,9 @@ func TestNewDecimalFromString(t *testing.T) {
 }
 
 func createDecimalLiteral(value []byte, precision int32, scale int32, isNullable bool) *expr.ProtoLiteral {
-	nullability := proto.Type_NULLABILITY_REQUIRED
+	nullability := types.NullabilityRequired
 	if isNullable {
-		nullability = proto.Type_NULLABILITY_NULLABLE
+		nullability = types.NullabilityNullable
 	}
 	return &expr.ProtoLiteral{
 		Value: value[:16],
@@ -109,9 +109,9 @@ func createDecimalLiteral(value []byte, precision int32, scale int32, isNullable
 }
 
 func protoLiteralWithNullability(lit *expr.ProtoLiteral, nullable bool) (expr.Literal, error) {
-	nullability := proto.Type_NULLABILITY_REQUIRED
+	nullability := types.NullabilityRequired
 	if nullable {
-		nullability = proto.Type_NULLABILITY_NULLABLE
+		nullability = types.NullabilityNullable
 	}
 	decType := lit.GetType().WithNullability(nullability)
 
@@ -377,7 +377,7 @@ func createIntervalDaysLiteral(days, seconds int32, micros int64) *expr.ProtoLit
 			},
 		},
 		Type: &types.IntervalDayType{
-			Nullability: proto.Type_NULLABILITY_REQUIRED,
+			Nullability: types.NullabilityRequired,
 			Precision:   types.PrecisionMicroSeconds,
 		},
 	}
@@ -394,7 +394,7 @@ func createIntervalDaysLiteralWithNanos(days, seconds int32, nanos int64) *expr.
 			},
 		},
 		Type: &types.IntervalDayType{
-			Nullability: proto.Type_NULLABILITY_REQUIRED,
+			Nullability: types.NullabilityRequired,
 			Precision:   types.PrecisionNanoSeconds,
 		},
 	}
@@ -485,7 +485,7 @@ func createIntervalYearsLiteral(years, months int32) *expr.ProtoLiteral {
 			Months: months,
 		},
 		Type: &types.IntervalYearType{
-			Nullability: proto.Type_NULLABILITY_REQUIRED,
+			Nullability: types.NullabilityRequired,
 		},
 	}
 }
@@ -773,7 +773,7 @@ func createVarCharLiteral(value string) *expr.ProtoLiteral {
 		//},
 		Value: value,
 		Type: &types.VarCharType{
-			Nullability: proto.Type_NULLABILITY_REQUIRED,
+			Nullability: types.NullabilityRequired,
 			Length:      int32(len(value)),
 		},
 	}

--- a/plan/plan_builder_test.go
+++ b/plan/plan_builder_test.go
@@ -554,7 +554,7 @@ func TestFetchRel(t *testing.T) {
 		Struct: types.StructType{
 			Nullability: types.NullabilityRequired,
 			Types: []types.Type{
-				&types.StringType{Nullability: substraitproto.Type_NULLABILITY_REQUIRED}},
+				&types.StringType{Nullability: types.NullabilityRequired}},
 		},
 	})
 
@@ -584,7 +584,7 @@ func TestFetchRelErrors(t *testing.T) {
 		Struct: types.StructType{
 			Nullability: types.NullabilityRequired,
 			Types: []types.Type{
-				&types.StringType{Nullability: substraitproto.Type_NULLABILITY_REQUIRED}},
+				&types.StringType{Nullability: types.NullabilityRequired}},
 		},
 	})
 
@@ -682,8 +682,8 @@ func TestFilterRelationErrors(t *testing.T) {
 		Struct: types.StructType{
 			Nullability: types.NullabilityRequired,
 			Types: []types.Type{
-				&types.StringType{Nullability: substraitproto.Type_NULLABILITY_NULLABLE},
-				&types.BooleanType{Nullability: substraitproto.Type_NULLABILITY_NULLABLE}},
+				&types.StringType{Nullability: types.NullabilityNullable},
+				&types.BooleanType{Nullability: types.NullabilityNullable}},
 		},
 	})
 

--- a/types/interval_compound_type.go
+++ b/types/interval_compound_type.go
@@ -66,7 +66,7 @@ func (m IntervalCompoundType) ToProto() *proto.Type {
 	return &proto.Type{Kind: &proto.Type_IntervalCompound_{
 		IntervalCompound: &proto.Type_IntervalCompound{
 			Precision:              m.precision.ToProtoVal(),
-			Nullability:            m.nullability,
+			Nullability:            proto.Type_Nullability(m.nullability),
 			TypeVariationReference: m.typeVariationRef}}}
 }
 

--- a/types/interval_compound_type_test.go
+++ b/types/interval_compound_type_test.go
@@ -42,7 +42,7 @@ func assertIntervalCompoundTypeProto(t *testing.T, expectedPrecision TimePrecisi
 	expectedTypeProto := &proto.Type{Kind: &proto.Type_IntervalCompound_{
 		IntervalCompound: &proto.Type_IntervalCompound{
 			Precision:   expectedPrecision.ToProtoVal(),
-			Nullability: expectedNullability,
+			Nullability: proto.Type_Nullability(expectedNullability),
 		},
 	}}
 	if diff := cmp.Diff(toVerifyType.ToProto(), expectedTypeProto, protocmp.Transform()); diff != "" {

--- a/types/interval_day_type.go
+++ b/types/interval_day_type.go
@@ -44,7 +44,7 @@ func (m *IntervalDayType) ToProto() *proto.Type {
 	return &proto.Type{Kind: &proto.Type_IntervalDay_{
 		IntervalDay: &proto.Type_IntervalDay{
 			Precision:              &precisionVal,
-			Nullability:            m.Nullability,
+			Nullability:            proto.Type_Nullability(m.Nullability),
 			TypeVariationReference: m.TypeVariationRef}}}
 }
 

--- a/types/interval_day_type_test.go
+++ b/types/interval_day_type_test.go
@@ -49,7 +49,7 @@ func assertIntervalDayTypeProto(t *testing.T, expectedPrecision TimePrecision, e
 	expectedTypeProto := &proto.Type{Kind: &proto.Type_IntervalDay_{
 		IntervalDay: &proto.Type_IntervalDay{
 			Precision:   &expectedPrecisionProtoVal,
-			Nullability: expectedNullability,
+			Nullability: proto.Type_Nullability(expectedNullability),
 		},
 	}}
 	if diff := cmp.Diff(toVerifyType.ToProto(), expectedTypeProto, protocmp.Transform()); diff != "" {

--- a/types/interval_year_month_type.go
+++ b/types/interval_year_month_type.go
@@ -50,7 +50,7 @@ func (m IntervalYearToMonthType) ToProtoFuncArg() *proto.FunctionArgument {
 func (m IntervalYearToMonthType) ToProto() *proto.Type {
 	return &proto.Type{Kind: &proto.Type_IntervalYear_{
 		IntervalYear: &proto.Type_IntervalYear{
-			Nullability:            m.nullability,
+			Nullability:            proto.Type_Nullability(m.nullability),
 			TypeVariationReference: m.typeVariationRef}}}
 }
 

--- a/types/interval_year_month_type_test.go
+++ b/types/interval_year_month_type_test.go
@@ -35,7 +35,7 @@ func assertIntervalYearToMonthTypeProto(t *testing.T, expectedNullability Nullab
 
 	expectedTypeProto := &proto.Type{Kind: &proto.Type_IntervalYear_{
 		IntervalYear: &proto.Type_IntervalYear{
-			Nullability: expectedNullability,
+			Nullability: proto.Type_Nullability(expectedNullability),
 		},
 	}}
 	if diff := cmp.Diff(toVerifyType.ToProto(), expectedTypeProto, protocmp.Transform()); diff != "" {

--- a/types/nullability_test.go
+++ b/types/nullability_test.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package types_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/substrait-io/substrait-go/v8/types"
+)
+
+func TestNullabilityString(t *testing.T) {
+	for _, td := range []struct {
+		n        types.Nullability
+		expected string
+	}{
+		{types.NullabilityUnspecified, "NULLABILITY_UNSPECIFIED"},
+		{types.NullabilityNullable, "NULLABILITY_NULLABLE"},
+		{types.NullabilityRequired, "NULLABILITY_REQUIRED"},
+		// unmodelled value
+		{types.Nullability(7), "7"},
+	} {
+		t.Run(td.expected, func(t *testing.T) {
+			assert.Equal(t, td.expected, td.n.String())
+			assert.Equal(t, td.expected, fmt.Sprintf("%v", td.n))
+		})
+	}
+}

--- a/types/nullability_test.go
+++ b/types/nullability_test.go
@@ -18,8 +18,6 @@ func TestNullabilityString(t *testing.T) {
 		{types.NullabilityUnspecified, "NULLABILITY_UNSPECIFIED"},
 		{types.NullabilityNullable, "NULLABILITY_NULLABLE"},
 		{types.NullabilityRequired, "NULLABILITY_REQUIRED"},
-		// unmodelled value
-		{types.Nullability(7), "7"},
 	} {
 		t.Run(td.expected, func(t *testing.T) {
 			assert.Equal(t, td.expected, td.n.String())

--- a/types/precison_timestamp_types.go
+++ b/types/precison_timestamp_types.go
@@ -123,7 +123,7 @@ func (m *PrecisionTimestampType) ToProto() *proto.Type {
 	return &proto.Type{Kind: &proto.Type_PrecisionTimestamp_{
 		PrecisionTimestamp: &proto.Type_PrecisionTimestamp{
 			Precision:              m.Precision.ToProtoVal(),
-			Nullability:            m.Nullability,
+			Nullability:            proto.Type_Nullability(m.Nullability),
 			TypeVariationReference: m.TypeVariationRef}}}
 }
 
@@ -180,7 +180,7 @@ func (m *PrecisionTimestampTzType) ToProto() *proto.Type {
 	return &proto.Type{Kind: &proto.Type_PrecisionTimestampTz{
 		PrecisionTimestampTz: &proto.Type_PrecisionTimestampTZ{
 			Precision:              m.Precision.ToProtoVal(),
-			Nullability:            m.Nullability,
+			Nullability:            proto.Type_Nullability(m.Nullability),
 			TypeVariationReference: m.TypeVariationRef}}}
 }
 
@@ -279,7 +279,7 @@ func (m *PrecisionTimeType) ToProto() *proto.Type {
 	return &proto.Type{Kind: &proto.Type_PrecisionTime_{
 		PrecisionTime: &proto.Type_PrecisionTime{
 			Precision:              m.Precision.ToProtoVal(),
-			Nullability:            m.Nullability,
+			Nullability:            proto.Type_Nullability(m.Nullability),
 			TypeVariationReference: m.TypeVariationRef}}}
 }
 

--- a/types/precison_timestamp_types_test.go
+++ b/types/precison_timestamp_types_test.go
@@ -73,7 +73,7 @@ func assertPrecisionTimeProto(t *testing.T, expectedPrecision TimePrecision, exp
 	expectedTypeProto := &proto.Type{Kind: &proto.Type_PrecisionTime_{
 		PrecisionTime: &proto.Type_PrecisionTime{
 			Precision:   expectedPrecision.ToProtoVal(),
-			Nullability: expectedNullability,
+			Nullability: proto.Type_Nullability(expectedNullability),
 		},
 	}}
 	if diff := cmp.Diff(toVerifyType.ToProto(), expectedTypeProto, protocmp.Transform()); diff != "" {
@@ -138,7 +138,7 @@ func assertPrecisionTimeStampProto(t *testing.T, expectedPrecision TimePrecision
 	expectedTypeProto := &proto.Type{Kind: &proto.Type_PrecisionTimestamp_{
 		PrecisionTimestamp: &proto.Type_PrecisionTimestamp{
 			Precision:   expectedPrecision.ToProtoVal(),
-			Nullability: expectedNullability,
+			Nullability: proto.Type_Nullability(expectedNullability),
 		},
 	}}
 	if diff := cmp.Diff(toVerifyType.ToProto(), expectedTypeProto, protocmp.Transform()); diff != "" {
@@ -157,7 +157,7 @@ func assertPrecisionTimeStampTzProto(t *testing.T, expectedPrecision TimePrecisi
 	expectedTypeProto := &proto.Type{Kind: &proto.Type_PrecisionTimestampTz{
 		PrecisionTimestampTz: &proto.Type_PrecisionTimestampTZ{
 			Precision:   expectedPrecision.ToProtoVal(),
-			Nullability: expectedNullability,
+			Nullability: proto.Type_Nullability(expectedNullability),
 		},
 	}}
 	if diff := cmp.Diff(toVerifyType.ToProto(), expectedTypeProto, protocmp.Transform()); diff != "" {

--- a/types/types.go
+++ b/types/types.go
@@ -18,13 +18,29 @@ import (
 
 type Version = proto.Version
 
-type Nullability = proto.Type_Nullability
+// Nullability mirrors the Type.Nullability enum in the Substrait spec. substrait-go declares it
+// rather than aliasing the generated enum so that serialization can move out of the core.
+type Nullability int32
 
 const (
-	NullabilityUnspecified = proto.Type_NULLABILITY_UNSPECIFIED
-	NullabilityNullable    = proto.Type_NULLABILITY_NULLABLE
-	NullabilityRequired    = proto.Type_NULLABILITY_REQUIRED
+	NullabilityUnspecified Nullability = 0
+	NullabilityNullable    Nullability = 1
+	NullabilityRequired    Nullability = 2
 )
+
+// String reports the spec name. Unknown values print as the number.
+func (n Nullability) String() string {
+	switch n {
+	case NullabilityUnspecified:
+		return "NULLABILITY_UNSPECIFIED"
+	case NullabilityNullable:
+		return "NULLABILITY_NULLABLE"
+	case NullabilityRequired:
+		return "NULLABILITY_REQUIRED"
+	default:
+		return strconv.Itoa(int(n))
+	}
+}
 
 type TypeName string
 
@@ -211,67 +227,67 @@ func TypeFromProto(t *proto.Type) Type {
 	switch t := t.Kind.(type) {
 	case *proto.Type_Bool:
 		return &BooleanType{
-			Nullability:      t.Bool.Nullability,
+			Nullability:      Nullability(t.Bool.Nullability),
 			TypeVariationRef: t.Bool.TypeVariationReference,
 		}
 	case *proto.Type_I8_:
 		return &Int8Type{
-			Nullability:      t.I8.Nullability,
+			Nullability:      Nullability(t.I8.Nullability),
 			TypeVariationRef: t.I8.TypeVariationReference,
 		}
 	case *proto.Type_I16_:
 		return &Int16Type{
-			Nullability:      t.I16.Nullability,
+			Nullability:      Nullability(t.I16.Nullability),
 			TypeVariationRef: t.I16.TypeVariationReference,
 		}
 	case *proto.Type_I32_:
 		return &Int32Type{
-			Nullability:      t.I32.Nullability,
+			Nullability:      Nullability(t.I32.Nullability),
 			TypeVariationRef: t.I32.TypeVariationReference,
 		}
 	case *proto.Type_I64_:
 		return &Int64Type{
-			Nullability:      t.I64.Nullability,
+			Nullability:      Nullability(t.I64.Nullability),
 			TypeVariationRef: t.I64.TypeVariationReference,
 		}
 	case *proto.Type_Fp32:
 		return &Float32Type{
-			Nullability:      t.Fp32.Nullability,
+			Nullability:      Nullability(t.Fp32.Nullability),
 			TypeVariationRef: t.Fp32.TypeVariationReference,
 		}
 	case *proto.Type_Fp64:
 		return &Float64Type{
-			Nullability:      t.Fp64.Nullability,
+			Nullability:      Nullability(t.Fp64.Nullability),
 			TypeVariationRef: t.Fp64.TypeVariationReference,
 		}
 	case *proto.Type_String_:
 		return &StringType{
-			Nullability:      t.String_.Nullability,
+			Nullability:      Nullability(t.String_.Nullability),
 			TypeVariationRef: t.String_.TypeVariationReference,
 		}
 	case *proto.Type_Binary_:
 		return &BinaryType{
-			Nullability:      t.Binary.Nullability,
+			Nullability:      Nullability(t.Binary.Nullability),
 			TypeVariationRef: t.Binary.TypeVariationReference,
 		}
 	case *proto.Type_Timestamp_:
 		return &TimestampType{
-			Nullability:      t.Timestamp.Nullability,
+			Nullability:      Nullability(t.Timestamp.Nullability),
 			TypeVariationRef: t.Timestamp.TypeVariationReference,
 		}
 	case *proto.Type_Date_:
 		return &DateType{
-			Nullability:      t.Date.Nullability,
+			Nullability:      Nullability(t.Date.Nullability),
 			TypeVariationRef: t.Date.TypeVariationReference,
 		}
 	case *proto.Type_Time_:
 		return &TimeType{
-			Nullability:      t.Time.Nullability,
+			Nullability:      Nullability(t.Time.Nullability),
 			TypeVariationRef: t.Time.TypeVariationReference,
 		}
 	case *proto.Type_IntervalYear_:
 		return &IntervalYearType{
-			Nullability:      t.IntervalYear.Nullability,
+			Nullability:      Nullability(t.IntervalYear.Nullability),
 			TypeVariationRef: t.IntervalYear.TypeVariationReference,
 		}
 	case *proto.Type_IntervalDay_:
@@ -284,7 +300,7 @@ func TypeFromProto(t *proto.Type) Type {
 			}
 		}
 		return &IntervalDayType{
-			Nullability:      t.IntervalDay.Nullability,
+			Nullability:      Nullability(t.IntervalDay.Nullability),
 			TypeVariationRef: t.IntervalDay.TypeVariationReference,
 			Precision:        precision,
 		}
@@ -294,41 +310,41 @@ func TypeFromProto(t *proto.Type) Type {
 			panic(fmt.Sprintf("Invalid precision %v", err))
 		}
 		return &IntervalCompoundType{
-			nullability:      t.IntervalCompound.Nullability,
+			nullability:      Nullability(t.IntervalCompound.Nullability),
 			typeVariationRef: t.IntervalCompound.TypeVariationReference,
 			precision:        precision,
 		}
 	case *proto.Type_TimestampTz:
 		return &TimestampTzType{
-			Nullability:      t.TimestampTz.Nullability,
+			Nullability:      Nullability(t.TimestampTz.Nullability),
 			TypeVariationRef: t.TimestampTz.TypeVariationReference,
 		}
 	case *proto.Type_Uuid:
 		return &UUIDType{
-			Nullability:      t.Uuid.Nullability,
+			Nullability:      Nullability(t.Uuid.Nullability),
 			TypeVariationRef: t.Uuid.TypeVariationReference,
 		}
 	case *proto.Type_FixedBinary_:
 		return &FixedBinaryType{
-			Nullability:      t.FixedBinary.Nullability,
+			Nullability:      Nullability(t.FixedBinary.Nullability),
 			TypeVariationRef: t.FixedBinary.TypeVariationReference,
 			Length:           t.FixedBinary.Length,
 		}
 	case *proto.Type_FixedChar_:
 		return &FixedCharType{
-			Nullability:      t.FixedChar.Nullability,
+			Nullability:      Nullability(t.FixedChar.Nullability),
 			TypeVariationRef: t.FixedChar.TypeVariationReference,
 			Length:           t.FixedChar.Length,
 		}
 	case *proto.Type_Varchar:
 		return &VarCharType{
-			Nullability:      t.Varchar.Nullability,
+			Nullability:      Nullability(t.Varchar.Nullability),
 			TypeVariationRef: t.Varchar.TypeVariationReference,
 			Length:           t.Varchar.Length,
 		}
 	case *proto.Type_Decimal_:
 		return &DecimalType{
-			Nullability:      t.Decimal.Nullability,
+			Nullability:      Nullability(t.Decimal.Nullability),
 			TypeVariationRef: t.Decimal.TypeVariationReference,
 			Scale:            t.Decimal.Scale,
 			Precision:        t.Decimal.Precision,
@@ -339,7 +355,7 @@ func TypeFromProto(t *proto.Type) Type {
 			panic(fmt.Sprintf("Invalid precision %v", err))
 		}
 		return &PrecisionTimeType{
-			Nullability:      t.PrecisionTime.Nullability,
+			Nullability:      Nullability(t.PrecisionTime.Nullability),
 			TypeVariationRef: t.PrecisionTime.TypeVariationReference,
 			Precision:        precision,
 		}
@@ -349,7 +365,7 @@ func TypeFromProto(t *proto.Type) Type {
 			panic(fmt.Sprintf("Invalid precision %v", err))
 		}
 		return &PrecisionTimestampType{
-			Nullability:      t.PrecisionTimestamp.Nullability,
+			Nullability:      Nullability(t.PrecisionTimestamp.Nullability),
 			TypeVariationRef: t.PrecisionTimestamp.TypeVariationReference,
 			Precision:        precision,
 		}
@@ -359,7 +375,7 @@ func TypeFromProto(t *proto.Type) Type {
 			panic(fmt.Sprintf("Invalid precision %v", err))
 		}
 		return &PrecisionTimestampTzType{PrecisionTimestampType{
-			Nullability:      t.PrecisionTimestampTz.Nullability,
+			Nullability:      Nullability(t.PrecisionTimestampTz.Nullability),
 			TypeVariationRef: t.PrecisionTimestampTz.TypeVariationReference,
 			Precision:        precision,
 		}}
@@ -369,7 +385,7 @@ func TypeFromProto(t *proto.Type) Type {
 			fields[i] = TypeFromProto(f)
 		}
 		return &StructType{
-			Nullability:      t.Struct.Nullability,
+			Nullability:      Nullability(t.Struct.Nullability),
 			TypeVariationRef: t.Struct.TypeVariationReference,
 			Types:            fields,
 		}
@@ -379,19 +395,19 @@ func TypeFromProto(t *proto.Type) Type {
 			params[i] = TypeFromProto(p)
 		}
 		return &FuncType{
-			Nullability:    t.Func.Nullability,
+			Nullability:    Nullability(t.Func.Nullability),
 			ParameterTypes: params,
 			ReturnType:     TypeFromProto(t.Func.ReturnType),
 		}
 	case *proto.Type_List_:
 		return &ListType{
-			Nullability:      t.List.Nullability,
+			Nullability:      Nullability(t.List.Nullability),
 			TypeVariationRef: t.List.TypeVariationReference,
 			Type:             TypeFromProto(t.List.Type),
 		}
 	case *proto.Type_Map_:
 		return &MapType{
-			Nullability:      t.Map.Nullability,
+			Nullability:      Nullability(t.Map.Nullability),
 			TypeVariationRef: t.Map.TypeVariationReference,
 			Key:              TypeFromProto(t.Map.Key),
 			Value:            TypeFromProto(t.Map.Value),
@@ -402,7 +418,7 @@ func TypeFromProto(t *proto.Type) Type {
 			params[i] = TypeParamFromProto(p)
 		}
 		return &UserDefinedType{
-			Nullability:      t.UserDefined.Nullability,
+			Nullability:      Nullability(t.UserDefined.Nullability),
 			TypeVariationRef: t.UserDefined.TypeVariationReference,
 			TypeReference:    t.UserDefined.TypeReference,
 			TypeParameters:   params,
@@ -649,109 +665,109 @@ func TypeToProto(t Type) *proto.Type {
 	case *BooleanType:
 		return &proto.Type{Kind: &proto.Type_Bool{
 			Bool: &proto.Type_Boolean{
-				Nullability:            t.Nullability,
+				Nullability:            proto.Type_Nullability(t.Nullability),
 				TypeVariationReference: t.TypeVariationRef}}}
 	case *Int8Type:
 		return &proto.Type{Kind: &proto.Type_I8_{
 			I8: &proto.Type_I8{
-				Nullability:            t.Nullability,
+				Nullability:            proto.Type_Nullability(t.Nullability),
 				TypeVariationReference: t.TypeVariationRef}}}
 	case *Int16Type:
 		return &proto.Type{Kind: &proto.Type_I16_{
 			I16: &proto.Type_I16{
-				Nullability:            t.Nullability,
+				Nullability:            proto.Type_Nullability(t.Nullability),
 				TypeVariationReference: t.TypeVariationRef}}}
 	case *Int32Type:
 		return &proto.Type{Kind: &proto.Type_I32_{
 			I32: &proto.Type_I32{
-				Nullability:            t.Nullability,
+				Nullability:            proto.Type_Nullability(t.Nullability),
 				TypeVariationReference: t.TypeVariationRef}}}
 	case *Int64Type:
 		return &proto.Type{Kind: &proto.Type_I64_{
 			I64: &proto.Type_I64{
-				Nullability:            t.Nullability,
+				Nullability:            proto.Type_Nullability(t.Nullability),
 				TypeVariationReference: t.TypeVariationRef}}}
 	case *Float32Type:
 		return &proto.Type{Kind: &proto.Type_Fp32{
 			Fp32: &proto.Type_FP32{
-				Nullability:            t.Nullability,
+				Nullability:            proto.Type_Nullability(t.Nullability),
 				TypeVariationReference: t.TypeVariationRef}}}
 	case *Float64Type:
 		return &proto.Type{Kind: &proto.Type_Fp64{
 			Fp64: &proto.Type_FP64{
-				Nullability:            t.Nullability,
+				Nullability:            proto.Type_Nullability(t.Nullability),
 				TypeVariationReference: t.TypeVariationRef}}}
 	case *StringType:
 		return &proto.Type{Kind: &proto.Type_String_{
 			String_: &proto.Type_String{
-				Nullability:            t.Nullability,
+				Nullability:            proto.Type_Nullability(t.Nullability),
 				TypeVariationReference: t.TypeVariationRef}}}
 	case *BinaryType:
 		return &proto.Type{Kind: &proto.Type_Binary_{
 			Binary: &proto.Type_Binary{
-				Nullability:            t.Nullability,
+				Nullability:            proto.Type_Nullability(t.Nullability),
 				TypeVariationReference: t.TypeVariationRef}}}
 	case *DateType:
 		return &proto.Type{Kind: &proto.Type_Date_{
 			Date: &proto.Type_Date{
-				Nullability:            t.Nullability,
+				Nullability:            proto.Type_Nullability(t.Nullability),
 				TypeVariationReference: t.TypeVariationRef}}}
 	case *TimeType:
 		return &proto.Type{Kind: &proto.Type_Time_{
 			Time: &proto.Type_Time{
-				Nullability:            t.Nullability,
+				Nullability:            proto.Type_Nullability(t.Nullability),
 				TypeVariationReference: t.TypeVariationRef}}}
 	case *TimestampTzType:
 		return &proto.Type{Kind: &proto.Type_TimestampTz{
 			TimestampTz: &proto.Type_TimestampTZ{
-				Nullability:            t.Nullability,
+				Nullability:            proto.Type_Nullability(t.Nullability),
 				TypeVariationReference: t.TypeVariationRef}}}
 	case *TimestampType:
 		return &proto.Type{Kind: &proto.Type_Timestamp_{
 			Timestamp: &proto.Type_Timestamp{
-				Nullability:            t.Nullability,
+				Nullability:            proto.Type_Nullability(t.Nullability),
 				TypeVariationReference: t.TypeVariationRef}}}
 	case *IntervalYearType:
 		return &proto.Type{Kind: &proto.Type_IntervalYear_{
 			IntervalYear: &proto.Type_IntervalYear{
-				Nullability:            t.Nullability,
+				Nullability:            proto.Type_Nullability(t.Nullability),
 				TypeVariationReference: t.TypeVariationRef}}}
 	case *IntervalDayType:
 		precision := t.Precision.ToProtoVal()
 		return &proto.Type{Kind: &proto.Type_IntervalDay_{
 			IntervalDay: &proto.Type_IntervalDay{
 				Precision:              &precision,
-				Nullability:            t.Nullability,
+				Nullability:            proto.Type_Nullability(t.Nullability),
 				TypeVariationReference: t.TypeVariationRef}}}
 	case IntervalCompoundType:
 		precision := t.precision.ToProtoVal()
 		return &proto.Type{Kind: &proto.Type_IntervalCompound_{
 			IntervalCompound: &proto.Type_IntervalCompound{
 				Precision:              precision,
-				Nullability:            t.nullability,
+				Nullability:            proto.Type_Nullability(t.nullability),
 				TypeVariationReference: t.typeVariationRef}}}
 	case *UUIDType:
 		return &proto.Type{Kind: &proto.Type_Uuid{
 			Uuid: &proto.Type_UUID{
-				Nullability:            t.Nullability,
+				Nullability:            proto.Type_Nullability(t.Nullability),
 				TypeVariationReference: t.TypeVariationRef}}}
 	case *FixedCharType:
 		return &proto.Type{Kind: &proto.Type_FixedChar_{
 			FixedChar: &proto.Type_FixedChar{
 				Length:                 t.Length,
-				Nullability:            t.Nullability,
+				Nullability:            proto.Type_Nullability(t.Nullability),
 				TypeVariationReference: t.TypeVariationRef}}}
 	case *VarCharType:
 		return &proto.Type{Kind: &proto.Type_Varchar{
 			Varchar: &proto.Type_VarChar{
 				Length:                 t.Length,
-				Nullability:            t.Nullability,
+				Nullability:            proto.Type_Nullability(t.Nullability),
 				TypeVariationReference: t.TypeVariationRef}}}
 	case *FixedBinaryType:
 		return &proto.Type{Kind: &proto.Type_FixedBinary_{
 			FixedBinary: &proto.Type_FixedBinary{
 				Length:                 t.Length,
-				Nullability:            t.Nullability,
+				Nullability:            proto.Type_Nullability(t.Nullability),
 				TypeVariationReference: t.TypeVariationRef}}}
 	case *DecimalType:
 		return t.ToProto()
@@ -759,19 +775,19 @@ func TypeToProto(t Type) *proto.Type {
 		return &proto.Type{Kind: &proto.Type_PrecisionTime_{
 			PrecisionTime: &proto.Type_PrecisionTime{
 				Precision:              int32(t.Precision),
-				Nullability:            t.Nullability,
+				Nullability:            proto.Type_Nullability(t.Nullability),
 				TypeVariationReference: t.TypeVariationRef}}}
 	case *PrecisionTimestampType:
 		return &proto.Type{Kind: &proto.Type_PrecisionTimestamp_{
 			PrecisionTimestamp: &proto.Type_PrecisionTimestamp{
 				Precision:              int32(t.Precision),
-				Nullability:            t.Nullability,
+				Nullability:            proto.Type_Nullability(t.Nullability),
 				TypeVariationReference: t.TypeVariationRef}}}
 	case *PrecisionTimestampTzType:
 		return &proto.Type{Kind: &proto.Type_PrecisionTimestampTz{
 			PrecisionTimestampTz: &proto.Type_PrecisionTimestampTZ{
 				Precision:              int32(t.Precision),
-				Nullability:            t.Nullability,
+				Nullability:            proto.Type_Nullability(t.Nullability),
 				TypeVariationReference: t.TypeVariationRef}}}
 	case *StructType:
 		return t.ToProto()
@@ -1088,7 +1104,7 @@ func (s *DecimalType) ToProto() *proto.Type {
 	return &proto.Type{Kind: &proto.Type_Decimal_{
 		Decimal: &proto.Type_Decimal{
 			Scale: s.Scale, Precision: s.Precision,
-			Nullability:            s.Nullability,
+			Nullability:            proto.Type_Nullability(s.Nullability),
 			TypeVariationReference: s.TypeVariationRef}}}
 }
 
@@ -1161,7 +1177,7 @@ func (t *StructType) ToProto() *proto.Type {
 	return &proto.Type{Kind: &proto.Type_Struct_{
 		Struct: &proto.Type_Struct{Types: children,
 			TypeVariationReference: t.TypeVariationRef,
-			Nullability:            t.Nullability}}}
+			Nullability:            proto.Type_Nullability(t.Nullability)}}}
 }
 
 func (t *StructType) ToProtoFuncArg() *proto.FunctionArgument {
@@ -1297,7 +1313,7 @@ func (f *FuncType) ToProto() *proto.Type {
 		Func: &proto.Type_Func{
 			ParameterTypes: params,
 			ReturnType:     TypeToProto(f.ReturnType),
-			Nullability:    f.Nullability,
+			Nullability:    proto.Type_Nullability(f.Nullability),
 		}}}
 }
 
@@ -1364,7 +1380,7 @@ func (t *ListType) Equals(rhs Type) bool {
 
 func (t *ListType) ToProto() *proto.Type {
 	return &proto.Type{Kind: &proto.Type_List_{
-		List: &proto.Type_List{Nullability: t.Nullability,
+		List: &proto.Type_List{Nullability: proto.Type_Nullability(t.Nullability),
 			Type:                   TypeToProto(t.Type),
 			TypeVariationReference: t.TypeVariationRef}}}
 }
@@ -1426,7 +1442,7 @@ func (t *MapType) Equals(rhs Type) bool {
 
 func (t *MapType) ToProto() *proto.Type {
 	return &proto.Type{Kind: &proto.Type_Map_{
-		Map: &proto.Type_Map{Nullability: t.Nullability,
+		Map: &proto.Type_Map{Nullability: proto.Type_Nullability(t.Nullability),
 			TypeVariationReference: t.TypeVariationRef,
 			Key:                    TypeToProto(t.Key),
 			Value:                  TypeToProto(t.Value)}}}
@@ -1642,7 +1658,7 @@ func (t *UserDefinedType) ToProto() *proto.Type {
 
 	return &proto.Type{Kind: &proto.Type_UserDefined_{
 		UserDefined: &proto.Type_UserDefined{
-			Nullability:            t.Nullability,
+			Nullability:            proto.Type_Nullability(t.Nullability),
 			TypeVariationReference: t.TypeVariationRef,
 			TypeReference:          t.TypeReference,
 			TypeParameters:         params,
@@ -1690,7 +1706,7 @@ func NewNamedStructFromProto(n *proto.NamedStruct) NamedStruct {
 	return NamedStruct{
 		Names: n.Names,
 		Struct: StructType{
-			Nullability:      n.Struct.Nullability,
+			Nullability:      Nullability(n.Struct.Nullability),
 			TypeVariationRef: n.Struct.TypeVariationReference,
 			Types:            fields,
 		},

--- a/types/types.go
+++ b/types/types.go
@@ -18,8 +18,7 @@ import (
 
 type Version = proto.Version
 
-// Nullability mirrors the Type.Nullability enum in the Substrait spec. substrait-go declares it
-// rather than aliasing the generated enum so that serialization can move out of the core.
+// Nullability indicates whether values of a Substrait type may be null.
 type Nullability int32
 
 const (
@@ -28,7 +27,7 @@ const (
 	NullabilityRequired    Nullability = 2
 )
 
-// String reports the spec name. Unknown values print as the number.
+// String returns the protobuf enum name for the nullability value.
 func (n Nullability) String() string {
 	switch n {
 	case NullabilityUnspecified:


### PR DESCRIPTION
`types.Nullability` was `= proto.Type_Nullability`, so the generated enum was substrait-go's public API. It becomes substrait-go's own `int32` with the same constant names and the same wire numbers, so most consumers still compile.

`go mod graph` doesn't change here. The core still imports substrait-protobuf.

BREAKING CHANGE: `types.Nullability` is no longer an alias for `proto.Type_Nullability`. Code that passes one where the other is expected needs a cast.

Part of #280.