### PR TITLE
feat(codec): add a new codec module and wire it into ci

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -20,6 +20,12 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.1.6
+      # golangci-lint analyzes one module per run
+      - name: golangci-lint (codec)
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.1.6
+          working-directory: codec
   build:
     name: Build and Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -44,12 +50,24 @@ jobs:
       - name: Run Tests with Coverage
         if: runner.os == 'Linux'
         run: go test -v -coverprofile=coverage.out $(go list ./... | grep -v /proto)
+      # neither go build ./... nor go test ./... descends into a nested module
+      - name: Build codec
+        run: go build ./...
+        working-directory: codec
+      - name: Run codec Tests
+        if: runner.os != 'Linux'
+        run: go test -v ./...
+        working-directory: codec
+      - name: Run codec Tests with Coverage
+        if: runner.os == 'Linux'
+        run: go test -v -coverprofile=codec-coverage.out ./...
+        working-directory: codec
       - name: Upload coverage to Codecov
         if: runner.os == 'Linux' && github.repository == 'substrait-io/substrait-go'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           disable_search: true
-          file: ./coverage.out
+          files: ./coverage.out,./codec/codec-coverage.out
           fail_ci_if_error: true
           codecov_yml_path: .codecov.yml

--- a/codec/doc.go
+++ b/codec/doc.go
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package codec converts between substrait-go's domain types and the generated
+// Substrait protobuf messages. It is a separate module so that serialization is
+// optional.
+//
+// codec imports the core. The core must never import codec.
+package codec

--- a/codec/go.mod
+++ b/codec/go.mod
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+
+module github.com/substrait-io/substrait-go/codec
+
+go 1.23.0
+
+toolchain go1.24.4


### PR DESCRIPTION
The protobuf conversions need somewhere to live that isn't the core's module, so this adds `substrait-go/codec` with its own `go.mod`. It is currently empty, but will later be iteratively populated with all of the protobuf-related code. 

GH Actions support is added, and coverage reports for both modules are uploaded together. 

Part of #280.