### PR TITLE
docs: add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing to Substrait Go
+
+Welcome! This page provides some orientation and recommendations on how to get
+the best results when engaging with the community.
+
+## Contributor License Agreement
+
+Substrait requires all contributors to sign the
+[Contributor License Agreement (CLA)](https://cla-assistant.io/substrait-io/substrait)
+before their contributions can be merged. A GitHub app checks this on every pull
+request and guides new contributors through signing it.
+
+## The specification is the source of truth
+
+Substrait Go is an implementation of the
+[Substrait specification](https://substrait.io/); it does not define Substrait
+semantics. Review behavioral changes against the spec text and the `.proto`
+comments in
+[`substrait-io/substrait`](https://github.com/substrait-io/substrait).
+
+Where the spec is genuinely unclear, don't settle it here — raise a clarification
+issue in
+[`substrait-io/substrait`](https://github.com/substrait-io/substrait/issues) or
+bring it to the [community](https://substrait.io/community/) channels rather than
+encoding a guess, and record the open question in the pull request so the
+assumption stays reviewable.
+
+## Commit Conventions
+
+Substrait Go follows
+[conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
+message structure, with an optional scope naming the affected package — for
+example `fix(expr): initialize MapLiteral KeyValue entries before use`. Append `!`
+after the type or scope for a breaking change (`refactor(extensions)!: …`).
+
+Releases are cut by
+[`go-semantic-release`](https://github.com/Nightapes/go-semantic-release), which
+derives the next version and the release notes from these commit messages, so the
+type and the `!` marker directly determine what gets released. Pull requests are
+squash-merged, so please ensure that your PR title and initial comment together
+form a valid commit message.
+
+## Building and testing
+
+```sh
+go build ./...
+go test ./...
+```
+
+CI builds and tests on Linux, Windows and macOS, and reports coverage from the
+Linux job to Codecov.
+
+## Linting
+
+Linting is done with [`golangci-lint`](https://golangci-lint.run) using the
+configuration in [`.golangci.yml`](.golangci.yml). The `Code Linting` CI job is
+authoritative for whether a change is clean:
+
+```sh
+golangci-lint run
+```
+
+`.golangci.yml` is a `version: "2"` configuration, so it requires golangci-lint
+2.x; CI currently runs 2.1.6.
+
+## License headers
+
+Go files carry an SPDX license header as their first line:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+```
+
+Please include one in new files. This is a convention rather than something CI
+currently enforces.


### PR DESCRIPTION
This repository had no contributor documentation at all, and the README carries no development or contributing guidance.

That matters most for the CLA. Substrait requires every contributor to sign the [Contributor License Agreement](https://cla-assistant.io/substrait-io/substrait), and CLA Assistant enforces this as a `license/cla` status check on pull requests here, but nothing in the repository mentioned it — so a contributor's first contact with the requirement is the check appearing on their PR, which is the problem described in substrait-io/substrait#630.

The new file documents:

- **The CLA**, using the wording carried by the other repositories in the organization.
- **The specification as source of truth**, and where to take a question when the spec is unclear rather than settling it in this tree.
- **Commit conventions** — conventional commits with an optional package scope and `!` for breaking changes. Worth being explicit here because `go-semantic-release` derives the version and release notes from these messages, so the type and the `!` marker directly determine what gets released.
- **Building, testing and linting**, plus the SPDX header convention on Go files.

Two notes on accuracy, since I checked rather than assumed:

- The SPDX header is described as a convention rather than a rule, because nothing in CI enforces it (58 of 99 Go files carry one, though 11 of the 12 most recently added files do, so it is clearly current practice).
- The linting section points at `golangci-lint` 2.x directly and does **not** recommend the configured `pre-commit` hook, because that hook pins golangci-lint `v1.52.2` while `.golangci.yml` is a `version: "2"` configuration that 1.x cannot parse. That mismatch looks like a genuine bug, but fixing it is out of scope for a docs change — happy to send a separate PR bumping the hook if you'd like.

Companion to substrait-io/substrait#1170, which fixes the specification repository's website and `CONTRIBUTING.md`.

See substrait-io/substrait#630

🤖 Generated with AI
