### PR TITLE
fix(types): normalize nullable any return bindings

### DIFF
--- a/extensions/variants_test.go
+++ b/extensions/variants_test.go
@@ -26,6 +26,7 @@ func TestEvaluateTypeExpression(t *testing.T) {
 		strNonNull, _   = parser.ParseType("string")
 		any1NonNull, _  = parser.ParseType("any1")
 		any1Nullable, _ = parser.ParseType("any1?")
+		any2Nullable, _ = parser.ParseType("any2?")
 		any1listNonNull = mkFuncArgList(any1NonNull)
 
 		// Few shortcut type definitions.
@@ -100,6 +101,23 @@ func TestEvaluateTypeExpression(t *testing.T) {
 			extArgs:  extensions.FuncParameterList{valArg(any1NonNull), valArg(any1NonNull)},
 			args:     []types.Type{i64TypeReq, i64TypeReq},
 			expected: &types.Int64Type{Nullability: types.NullabilityNullable},
+		},
+		{
+			name:  "map(list<any1?>, list<any2?>) -> map<any1, any2?>",
+			nulls: extensions.MirrorNullability,
+			ret:   mkFuncArgMap(any1NonNull, any2Nullable),
+			extArgs: extensions.FuncParameterList{
+				valArg(mkFuncArgList(any1Nullable)),
+				valArg(mkFuncArgList(any2Nullable)),
+			},
+			args: []types.Type{
+				mkList(&types.StringType{Nullability: types.NullabilityNullable}),
+				mkList(&types.Int64Type{Nullability: types.NullabilityNullable}),
+			},
+			expected: mkMap(
+				&types.StringType{Nullability: types.NullabilityRequired},
+				&types.Int64Type{Nullability: types.NullabilityNullable},
+			),
 		},
 		{
 			name:     "element_at(list<any1>, i64) -> any1",

--- a/types/any_type.go
+++ b/types/any_type.go
@@ -51,13 +51,22 @@ func (m *AnyType) ShortString() string {
 }
 
 // unwrapAnyTypeWithName searches for AnyType in p with the specified name,
-// and if found, returns argType.  If p is a composite type,
-// recursively unwraps p to search for AnyType in p's parameters.
-// Returns nil Type if AnyType was not found.
+// and if found, returns the concrete type bound by that occurrence. A nullable
+// occurrence binds the required base type; ReturnType reapplies the return
+// occurrence's declared nullability. If p is a composite type, the search
+// recurses through its parameters. Returns nil Type if AnyType was not found.
 func unwrapAnyTypeWithName(name string, p FuncDefArgType, argType Type) (Type, error) {
 	switch arg := p.(type) {
 	case *AnyType:
 		if arg.Name == name {
+			// A nullable any occurrence represents a nullable use of the required
+			// base type. Strip the occurrence's nullability from the binding here;
+			// ReturnType reapplies the return occurrence's declared nullability.
+			// This lets a signature relate any1 and any1? across structures, for
+			// example j(any1, list<any1?>) -> any1.
+			if arg.Nullability == NullabilityNullable {
+				return argType.WithNullability(NullabilityRequired), nil
+			}
 			return argType, nil
 		}
 	case *ParameterizedListType:

--- a/types/any_type_test.go
+++ b/types/any_type_test.go
@@ -51,6 +51,32 @@ func TestAnyType(t *testing.T) {
 			expectedString:     "any1",
 		},
 		{
+			testName: "list<any1?> binds required any1",
+			argName:  "any1",
+			parameters: []FuncDefArgType{
+				&ParameterizedListType{Type: &AnyType{Name: "any1", Nullability: NullabilityNullable}},
+			},
+			args: []Type{
+				&ListType{Type: &Int64Type{Nullability: NullabilityNullable}},
+			},
+			concreteReturnType: &Int64Type{Nullability: NullabilityRequired},
+			nullability:        NullabilityRequired,
+			expectedString:     "any1",
+		},
+		{
+			testName: "list<any1?> with nullable any1 return",
+			argName:  "any1",
+			parameters: []FuncDefArgType{
+				&ParameterizedListType{Type: &AnyType{Name: "any1", Nullability: NullabilityNullable}},
+			},
+			args: []Type{
+				&ListType{Type: &Int64Type{Nullability: NullabilityNullable}},
+			},
+			concreteReturnType: &Int64Type{Nullability: NullabilityNullable},
+			nullability:        NullabilityNullable,
+			expectedString:     "any1?",
+		},
+		{
 			testName: "wrong_list<any1>",
 			argName:  "any1",
 			parameters: []FuncDefArgType{
@@ -359,4 +385,23 @@ func TestAnyType(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAnyTypeReturnTypeDoesNotMutateArgument(t *testing.T) {
+	argumentElement := &IntervalDayType{
+		Precision:        PrecisionMilliSeconds,
+		TypeVariationRef: 42,
+		Nullability:      NullabilityNullable,
+	}
+	parameter := &ParameterizedListType{
+		Type: &AnyType{Name: "any1", Nullability: NullabilityNullable},
+	}
+	argument := &ListType{Type: argumentElement}
+	returnType := &AnyType{Name: "any1", Nullability: NullabilityRequired}
+
+	resolved, err := returnType.ReturnType([]FuncDefArgType{parameter}, []Type{argument})
+
+	require.NoError(t, err)
+	require.Equal(t, NullabilityRequired, resolved.GetNullability())
+	require.Equal(t, NullabilityNullable, argumentElement.GetNullability())
 }

--- a/types/interval_day_type.go
+++ b/types/interval_day_type.go
@@ -19,8 +19,9 @@ func (m *IntervalDayType) GetPrecisionProtoVal() int32 {
 
 func (*IntervalDayType) isRootRef() {}
 func (m *IntervalDayType) WithNullability(n Nullability) Type {
-	m.Nullability = n
-	return m
+	out := *m
+	out.Nullability = n
+	return &out
 }
 
 func (m *IntervalDayType) GetType() Type                     { return m }

--- a/types/interval_day_type_test.go
+++ b/types/interval_day_type_test.go
@@ -42,6 +42,22 @@ func TestIntervalDayType(t *testing.T) {
 	}
 }
 
+func TestIntervalDayTypeWithNullabilityReturnsCopy(t *testing.T) {
+	original := &IntervalDayType{
+		Precision:        PrecisionMilliSeconds,
+		TypeVariationRef: 42,
+		Nullability:      NullabilityNullable,
+	}
+
+	updated := original.WithNullability(NullabilityRequired).(*IntervalDayType)
+
+	assert.NotSame(t, original, updated)
+	assert.Equal(t, NullabilityNullable, original.Nullability)
+	assert.Equal(t, NullabilityRequired, updated.Nullability)
+	assert.Equal(t, original.Precision, updated.Precision)
+	assert.Equal(t, original.TypeVariationRef, updated.TypeVariationRef)
+}
+
 func assertIntervalDayTypeProto(t *testing.T, expectedPrecision TimePrecision, expectedNullability Nullability,
 	toVerifyType *IntervalDayType) {
 


### PR DESCRIPTION
## Summary

Normalize a nullable `anyN?` occurrence to the required base binding when deriving polymorphic return types, then let the return occurrence reapply its declared nullability.

This implements the return-substitution side of the semantics documented in substrait-io/substrait#960. In particular:

```text
list<string?> against list<any1?> binds any1 = string
list<i64?> against list<any2?> binds any2 = i64
map<any1, any2?> resolves to map<string, i64?>
```

Without this change, the map key incorrectly remains nullable and resolves as `map<string?, i64?>`.

## Details

- Normalize nullable `anyN?` source occurrences in `unwrapAnyTypeWithName`.
- Preserve the return occurrence's declaration, so `anyN` remains required and `anyN?` is nullable.
- Add direct required/nullable substitution tests and a composite map regression test.
- Make `IntervalDayType.WithNullability` honor the `Type` interface's copy contract. This prevents return derivation from mutating an input argument while normalizing its binding.

This is complementary to draft #244. That PR addresses broader argument matching and constrained-binding consistency; this PR is narrowly about extracting the correct binding for return-type substitution.

## Testing

```text
go test ./...
git diff --check
```

Both pass.

---

This PR was developed with AI assistance. All changes have been reviewed, and I take full responsibility for this contribution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of nullable generic types, ensuring required and nullable values are resolved correctly in nested type expressions.
  - Prevented type resolution from unintentionally changing the nullability of input arguments.
  - Updated interval day type nullability changes to preserve the original type while returning an independent copy.

- **Tests**
  - Added coverage for nullable generic type resolution and non-mutating type behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->