### PR TITLE
refactor: invert control flow of *Remap builder functions

### DIFF
--- a/plan/builders.go
+++ b/plan/builders.go
@@ -335,20 +335,13 @@ func (b *builder) AggregateExprs(input Rel, measures []AggRelMeasure, groups ...
 	return arb.Build()
 }
 
-func (b *builder) CreateTableAsSelectRemap(input Rel, remap []int32, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error) {
+func (b *builder) CreateTableAsSelect(input Rel, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error) {
 	if input == nil {
 		return nil, errNilInputRel
 	}
 
-	nOutput := input.RecordType().FieldCount()
-	for _, idx := range remap {
-		if idx < 0 || idx >= nOutput {
-			return nil, errOutputMappingOutOfRange
-		}
-	}
-
 	return &NamedTableWriteRel{
-		RelCommon:   RelCommon{mapping: remap},
+		RelCommon:   RelCommon{mapping: nil},
 		names:       tableName,
 		tableSchema: schema,
 		op:          WriteOpCTAS,
@@ -357,8 +350,16 @@ func (b *builder) CreateTableAsSelectRemap(input Rel, remap []int32, tableName [
 	}, nil
 }
 
-func (b *builder) CreateTableAsSelect(input Rel, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error) {
-	return b.CreateTableAsSelectRemap(input, nil, tableName, schema)
+func (b *builder) CreateTableAsSelectRemap(input Rel, remap []int32, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error) {
+	ctas, err := b.CreateTableAsSelect(input, tableName, schema)
+	if err != nil {
+		return nil, err
+	}
+	rel, err := ctas.Remap(remap...)
+	if err != nil {
+		return nil, err
+	}
+	return rel.(*NamedTableWriteRel), nil
 }
 
 func (b *builder) CrossRemap(left, right Rel, remap []int32) (*CrossRel, error) {

--- a/plan/builders.go
+++ b/plan/builders.go
@@ -101,11 +101,10 @@ type Builder interface {
 	Filter(input Rel, condition expr.Expression) (*FilterRel, error)
 	// Deprecated: Use JoinAndFilter(...).Remap() instead.
 	JoinAndFilterRemap(left, right Rel, condition, postJoinFilter expr.Expression, joinType JoinType, remap []int32) (*JoinRel, error)
-	// Deprecated: Use Fetch(...).Remap() instead.
-	JoinAndFilter(left, right Rel, condition, postJoinFilter expr.Expression, joinType JoinType) (*JoinRel, error)
 	// Deprecated: Use Join(...).Remap() instead.
 	JoinRemap(left, right Rel, condition expr.Expression, joinType JoinType, remap []int32) (*JoinRel, error)
 	Join(left, right Rel, condition expr.Expression, joinType JoinType) (*JoinRel, error)
+	JoinAndFilter(left, right Rel, condition, postJoinFilter expr.Expression, joinType JoinType) (*JoinRel, error)
 	// Deprecated: Use NamedScan(...).Remap() instead.
 	NamedScanRemap(tableName []string, schema types.NamedStruct, remap []int32) (*NamedTableReadRel, error)
 	NamedScan(tableName []string, schema types.NamedStruct) *NamedTableReadRel

--- a/plan/builders.go
+++ b/plan/builders.go
@@ -541,29 +541,22 @@ func (b *builder) NamedDelete(input Rel, tableName []string, schema types.NamedS
 	return b.NamedWrite(input, WriteOpDelete, tableName, schema)
 }
 
-func (b *builder) NamedScanRemap(tableName []string, schema types.NamedStruct, remap []int32) (*NamedTableReadRel, error) {
-	noutput := int32(len(schema.Struct.Types))
-	for _, idx := range remap {
-		if idx < 0 || idx >= noutput {
-			return nil, fmt.Errorf("%w: output mapping index out of range",
-				substraitgo.ErrInvalidRel)
-		}
-	}
-
+func (b *builder) NamedScan(tableName []string, schema types.NamedStruct) *NamedTableReadRel {
 	return &NamedTableReadRel{
 		baseReadRel: baseReadRel{
-			RelCommon: RelCommon{
-				mapping: remap,
-			},
+			RelCommon:  RelCommon{mapping: nil},
 			baseSchema: schema,
 		},
 		names: tableName,
-	}, nil
+	}
 }
 
-func (b *builder) NamedScan(tableName []string, schema types.NamedStruct) *NamedTableReadRel {
-	n, _ := b.NamedScanRemap(tableName, schema, nil)
-	return n
+func (b *builder) NamedScanRemap(tableName []string, schema types.NamedStruct, remap []int32) (*NamedTableReadRel, error) {
+	rel, err := b.NamedScan(tableName, schema).Remap(remap...)
+	if err != nil {
+		return nil, err
+	}
+	return rel.(*NamedTableReadRel), nil
 }
 
 func (b *builder) VirtualTableRemap(fieldNames []string, remap []int32, values ...expr.StructLiteralValue) (*VirtualTableReadRel, error) {

--- a/plan/builders.go
+++ b/plan/builders.go
@@ -443,7 +443,7 @@ func (b *builder) FilterRemap(input Rel, condition expr.Expression, remap []int3
 	return rel.(*FilterRel), nil
 }
 
-func (b *builder) JoinAndFilterRemap(left, right Rel, condition, postJoinFilter expr.Expression, joinType JoinType, remap []int32) (*JoinRel, error) {
+func (b *builder) JoinAndFilter(left, right Rel, condition, postJoinFilter expr.Expression, joinType JoinType) (*JoinRel, error) {
 	if left == nil || right == nil {
 		return nil, errNilInputRel
 	}
@@ -470,33 +470,40 @@ func (b *builder) JoinAndFilterRemap(left, right Rel, condition, postJoinFilter 
 		}
 	}
 
-	out := &JoinRel{
-		RelCommon: RelCommon{mapping: remap},
+	return &JoinRel{
+		RelCommon: RelCommon{mapping: nil},
 		left:      left, right: right,
 		expr: condition, postJoinFilter: postJoinFilter,
 		joinType: joinType,
-	}
-
-	noutput := out.directOutputSchema().FieldCount()
-	for _, idx := range remap {
-		if idx < 0 || idx >= noutput {
-			return nil, errOutputMappingOutOfRange
-		}
-	}
-
-	return out, nil
+	}, nil
 }
 
-func (b *builder) JoinAndFilter(left, right Rel, condition, postJoinFilter expr.Expression, joinType JoinType) (*JoinRel, error) {
-	return b.JoinAndFilterRemap(left, right, condition, postJoinFilter, joinType, nil)
+func (b *builder) JoinAndFilterRemap(left, right Rel, condition, postJoinFilter expr.Expression, joinType JoinType, remap []int32) (*JoinRel, error) {
+	join, err := b.JoinAndFilter(left, right, condition, postJoinFilter, joinType)
+	if err != nil {
+		return nil, err
+	}
+	rel, err := join.Remap(remap...)
+	if err != nil {
+		return nil, err
+	}
+	return rel.(*JoinRel), nil
 }
 
 func (b *builder) JoinRemap(left, right Rel, condition expr.Expression, joinType JoinType, remap []int32) (*JoinRel, error) {
-	return b.JoinAndFilterRemap(left, right, condition, nil, joinType, remap)
+	join, err := b.Join(left, right, condition, joinType)
+	if err != nil {
+		return nil, err
+	}
+	rel, err := join.Remap(remap...)
+	if err != nil {
+		return nil, err
+	}
+	return rel.(*JoinRel), nil
 }
 
 func (b *builder) Join(left, right Rel, condition expr.Expression, joinType JoinType) (*JoinRel, error) {
-	return b.JoinAndFilterRemap(left, right, condition, nil, joinType, nil)
+	return b.JoinAndFilter(left, right, condition, nil, joinType)
 }
 
 func (b *builder) NamedWriteRemap(input Rel, op WriteOp, tableName []string, schema types.NamedStruct, remap []int32) (*NamedTableWriteRel, error) {

--- a/plan/builders.go
+++ b/plan/builders.go
@@ -362,26 +362,27 @@ func (b *builder) CreateTableAsSelectRemap(input Rel, remap []int32, tableName [
 	return rel.(*NamedTableWriteRel), nil
 }
 
-func (b *builder) CrossRemap(left, right Rel, remap []int32) (*CrossRel, error) {
+func (b *builder) Cross(left, right Rel) (*CrossRel, error) {
 	if left == nil || right == nil {
 		return nil, errNilInputRel
 	}
 
-	noutput := left.RecordType().FieldCount() + right.RecordType().FieldCount()
-	for _, idx := range remap {
-		if idx < 0 || idx >= noutput {
-			return nil, errOutputMappingOutOfRange
-		}
-	}
-
 	return &CrossRel{
-		RelCommon: RelCommon{mapping: remap},
+		RelCommon: RelCommon{mapping: nil},
 		left:      left, right: right,
 	}, nil
 }
 
-func (b *builder) Cross(left, right Rel) (*CrossRel, error) {
-	return b.CrossRemap(left, right, nil)
+func (b *builder) CrossRemap(left, right Rel, remap []int32) (*CrossRel, error) {
+	cross, err := b.Cross(left, right)
+	if err != nil {
+		return nil, err
+	}
+	rel, err := cross.Remap(remap...)
+	if err != nil {
+		return nil, err
+	}
+	return rel.(*CrossRel), nil
 }
 
 func (b *builder) FetchRemap(input Rel, offset, count int64, remap []int32) (*FetchRel, error) {

--- a/plan/builders.go
+++ b/plan/builders.go
@@ -722,7 +722,7 @@ func (b *builder) SortFields(input Rel, indices ...int32) ([]expr.SortField, err
 	return out, nil
 }
 
-func (b *builder) SetRemap(op SetOp, remap []int32, inputs ...Rel) (*SetRel, error) {
+func (b *builder) Set(op SetOp, inputs ...Rel) (*SetRel, error) {
 	if op == SetOpUnspecified {
 		return nil, fmt.Errorf("%w: operation for set relation must not be unspecified", substraitgo.ErrInvalidArg)
 	}
@@ -740,13 +740,6 @@ func (b *builder) SetRemap(op SetOp, remap []int32, inputs ...Rel) (*SetRel, err
 
 	output := inputs[0].RecordType()
 
-	noutput := output.FieldCount()
-	for _, idx := range remap {
-		if idx < 0 || idx >= noutput {
-			return nil, errOutputMappingOutOfRange
-		}
-	}
-
 	for _, in := range inputs[1:] {
 		t := in.RecordType()
 		if !output.Equals(&t) {
@@ -756,14 +749,22 @@ func (b *builder) SetRemap(op SetOp, remap []int32, inputs ...Rel) (*SetRel, err
 	}
 
 	return &SetRel{
-		RelCommon: RelCommon{mapping: remap},
+		RelCommon: RelCommon{mapping: nil},
 		op:        op,
 		inputs:    inputs,
 	}, nil
 }
 
-func (b *builder) Set(op SetOp, inputs ...Rel) (*SetRel, error) {
-	return b.SetRemap(op, nil, inputs...)
+func (b *builder) SetRemap(op SetOp, remap []int32, inputs ...Rel) (*SetRel, error) {
+	set, err := b.Set(op, inputs...)
+	if err != nil {
+		return nil, err
+	}
+	rel, err := set.Remap(remap...)
+	if err != nil {
+		return nil, err
+	}
+	return rel.(*SetRel), nil
 }
 
 func (b *builder) PlanWithTypes(root Rel, rootNames []string, expectedTypeURLs []string, others ...Rel) (*Plan, error) {

--- a/plan/builders.go
+++ b/plan/builders.go
@@ -506,20 +506,13 @@ func (b *builder) Join(left, right Rel, condition expr.Expression, joinType Join
 	return b.JoinAndFilter(left, right, condition, nil, joinType)
 }
 
-func (b *builder) NamedWriteRemap(input Rel, op WriteOp, tableName []string, schema types.NamedStruct, remap []int32) (*NamedTableWriteRel, error) {
+func (b *builder) NamedWrite(input Rel, op WriteOp, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error) {
 	if input == nil {
 		return nil, errNilInputRel
 	}
 
-	nOutput := input.RecordType().FieldCount()
-	for _, idx := range remap {
-		if idx < 0 || idx >= nOutput {
-			return nil, errOutputMappingOutOfRange
-		}
-	}
-
 	return &NamedTableWriteRel{
-		RelCommon:   RelCommon{mapping: remap},
+		RelCommon:   RelCommon{mapping: nil},
 		names:       tableName,
 		tableSchema: schema,
 		op:          op,
@@ -528,8 +521,16 @@ func (b *builder) NamedWriteRemap(input Rel, op WriteOp, tableName []string, sch
 	}, nil
 }
 
-func (b *builder) NamedWrite(input Rel, op WriteOp, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error) {
-	return b.NamedWriteRemap(input, op, tableName, schema, nil)
+func (b *builder) NamedWriteRemap(input Rel, op WriteOp, tableName []string, schema types.NamedStruct, remap []int32) (*NamedTableWriteRel, error) {
+	nw, err := b.NamedWrite(input, op, tableName, schema)
+	if err != nil {
+		return nil, err
+	}
+	rel, err := nw.Remap(remap...)
+	if err != nil {
+		return nil, err
+	}
+	return rel.(*NamedTableWriteRel), nil
 }
 
 func (b *builder) NamedInsert(input Rel, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error) {

--- a/plan/builders.go
+++ b/plan/builders.go
@@ -559,7 +559,7 @@ func (b *builder) NamedScanRemap(tableName []string, schema types.NamedStruct, r
 	return rel.(*NamedTableReadRel), nil
 }
 
-func (b *builder) VirtualTableRemap(fieldNames []string, remap []int32, values ...expr.StructLiteralValue) (*VirtualTableReadRel, error) {
+func (b *builder) VirtualTable(fieldNames []string, values ...expr.StructLiteralValue) (*VirtualTableReadRel, error) {
 	// convert Literal to Expression
 	exprs := make([]expr.VirtualTableExpressionValue, 0)
 	for _, row := range values {
@@ -569,14 +569,22 @@ func (b *builder) VirtualTableRemap(fieldNames []string, remap []int32, values .
 		}
 		exprs = append(exprs, rowExpr)
 	}
-	return b.VirtualTableFromExprRemap(fieldNames, remap, exprs...)
-}
-
-func (b *builder) VirtualTableFromExpr(fieldNames []string, values ...expr.VirtualTableExpressionValue) (*VirtualTableReadRel, error) {
-	return b.VirtualTableFromExprRemap(fieldNames, nil, values...)
+	return b.VirtualTableFromExpr(fieldNames, exprs...)
 }
 
 func (b *builder) VirtualTableFromExprRemap(fieldNames []string, remap []int32, values ...expr.VirtualTableExpressionValue) (*VirtualTableReadRel, error) {
+	vt, err := b.VirtualTableFromExpr(fieldNames, values...)
+	if err != nil {
+		return nil, err
+	}
+	rel, err := vt.Remap(remap...)
+	if err != nil {
+		return nil, err
+	}
+	return rel.(*VirtualTableReadRel), err
+}
+
+func (b *builder) VirtualTableFromExpr(fieldNames []string, values ...expr.VirtualTableExpressionValue) (*VirtualTableReadRel, error) {
 	if len(values) == 0 {
 		return nil, fmt.Errorf("%w: must provide at least one set of values. Consider EmptyVirtualTable to construct rowless Virtual Table", substraitgo.ErrInvalidArg)
 	}
@@ -585,13 +593,6 @@ func (b *builder) VirtualTableFromExprRemap(fieldNames []string, remap []int32, 
 	if len(values[0]) != nfields {
 		return nil, fmt.Errorf("%w: mismatched number of fields (%d) and literal values (%d) in virtual table",
 			substraitgo.ErrInvalidRel, nfields, len(values[0]))
-	}
-
-	for _, idx := range remap {
-		if idx < 0 || idx >= int32(nfields) {
-			return nil, fmt.Errorf("%w: output mapping index out of range",
-				substraitgo.ErrInvalidRel)
-		}
 	}
 
 	typeList := make([]types.Type, nfields)
@@ -618,15 +619,23 @@ func (b *builder) VirtualTableFromExprRemap(fieldNames []string, remap []int32, 
 
 	return &VirtualTableReadRel{
 		baseReadRel: baseReadRel{
-			RelCommon:  RelCommon{mapping: remap},
+			RelCommon:  RelCommon{mapping: nil},
 			baseSchema: baseSchema,
 		},
 		values: values,
 	}, nil
 }
 
-func (b *builder) VirtualTable(fields []string, values ...expr.StructLiteralValue) (*VirtualTableReadRel, error) {
-	return b.VirtualTableRemap(fields, nil, values...)
+func (b *builder) VirtualTableRemap(fields []string, remap []int32, values ...expr.StructLiteralValue) (*VirtualTableReadRel, error) {
+	vt, err := b.VirtualTable(fields, values...)
+	if err != nil {
+		return nil, err
+	}
+	rel, err := vt.Remap(remap...)
+	if err != nil {
+		return nil, err
+	}
+	return rel.(*VirtualTableReadRel), err
 }
 
 func (b *builder) EmptyVirtualTable(fieldNames []string, typeList []types.Type) (*VirtualTableReadRel, error) {

--- a/plan/builders.go
+++ b/plan/builders.go
@@ -385,27 +385,28 @@ func (b *builder) CrossRemap(left, right Rel, remap []int32) (*CrossRel, error) 
 	return rel.(*CrossRel), nil
 }
 
-func (b *builder) FetchRemap(input Rel, offset, count int64, remap []int32) (*FetchRel, error) {
+func (b *builder) Fetch(input Rel, offset, count int64) (*FetchRel, error) {
 	if input == nil {
 		return nil, errNilInputRel
 	}
 
-	noutput := input.RecordType().FieldCount()
-	for _, idx := range remap {
-		if idx < 0 || idx >= noutput {
-			return nil, errOutputMappingOutOfRange
-		}
-	}
-
 	return &FetchRel{
-		RelCommon: RelCommon{mapping: remap},
+		RelCommon: RelCommon{mapping: nil},
 		input:     input,
 		offset:    offset, count: count,
 	}, nil
 }
 
-func (b *builder) Fetch(input Rel, offset, count int64) (*FetchRel, error) {
-	return b.FetchRemap(input, offset, count, nil)
+func (b *builder) FetchRemap(input Rel, offset, count int64, remap []int32) (*FetchRel, error) {
+	fetch, err := b.Fetch(input, offset, count)
+	if err != nil {
+		return nil, err
+	}
+	rel, err := fetch.Remap(remap...)
+	if err != nil {
+		return nil, err
+	}
+	return rel.(*FetchRel), nil
 }
 
 func (b *builder) FilterRemap(input Rel, condition expr.Expression, remap []int32) (*FilterRel, error) {

--- a/plan/builders.go
+++ b/plan/builders.go
@@ -409,7 +409,7 @@ func (b *builder) FetchRemap(input Rel, offset, count int64, remap []int32) (*Fe
 	return rel.(*FetchRel), nil
 }
 
-func (b *builder) FilterRemap(input Rel, condition expr.Expression, remap []int32) (*FilterRel, error) {
+func (b *builder) Filter(input Rel, condition expr.Expression) (*FilterRel, error) {
 	if input == nil {
 		return nil, errNilInputRel
 	}
@@ -424,24 +424,23 @@ func (b *builder) FilterRemap(input Rel, condition expr.Expression, remap []int3
 			substraitgo.ErrInvalidArg, condition.GetType())
 	}
 
-	noutput := input.directOutputSchema().FieldCount()
-	for _, idx := range remap {
-		if idx < 0 || idx >= noutput {
-			return nil, errOutputMappingOutOfRange
-		}
-	}
-
 	return &FilterRel{
-		RelCommon: RelCommon{
-			mapping: remap,
-		},
-		input: input,
-		cond:  condition,
+		RelCommon: RelCommon{mapping: nil},
+		input:     input,
+		cond:      condition,
 	}, nil
 }
 
-func (b *builder) Filter(input Rel, condition expr.Expression) (*FilterRel, error) {
-	return b.FilterRemap(input, condition, nil)
+func (b *builder) FilterRemap(input Rel, condition expr.Expression, remap []int32) (*FilterRel, error) {
+	filter, err := b.Filter(input, condition)
+	if err != nil {
+		return nil, err
+	}
+	rel, err := filter.Remap(remap...)
+	if err != nil {
+		return nil, err
+	}
+	return rel.(*FilterRel), nil
 }
 
 func (b *builder) JoinAndFilterRemap(left, right Rel, condition, postJoinFilter expr.Expression, joinType JoinType, remap []int32) (*JoinRel, error) {

--- a/plan/builders.go
+++ b/plan/builders.go
@@ -682,16 +682,9 @@ func (b *builder) IcebergTableFromMetadataFile(metadataURI string, snapshot Iceb
 	}, nil
 }
 
-func (b *builder) SortRemap(input Rel, remap []int32, sorts ...expr.SortField) (*SortRel, error) {
+func (b *builder) Sort(input Rel, sorts ...expr.SortField) (*SortRel, error) {
 	if input == nil {
 		return nil, errNilInputRel
-	}
-
-	noutput := input.RecordType().FieldCount()
-	for _, idx := range remap {
-		if idx < 0 || idx >= noutput {
-			return nil, errOutputMappingOutOfRange
-		}
 	}
 
 	if len(sorts) == 0 {
@@ -699,14 +692,22 @@ func (b *builder) SortRemap(input Rel, remap []int32, sorts ...expr.SortField) (
 	}
 
 	return &SortRel{
-		RelCommon: RelCommon{mapping: remap},
+		RelCommon: RelCommon{mapping: nil},
 		input:     input,
 		sorts:     sorts,
 	}, nil
 }
 
-func (b *builder) Sort(input Rel, sorts ...expr.SortField) (*SortRel, error) {
-	return b.SortRemap(input, nil, sorts...)
+func (b *builder) SortRemap(input Rel, remap []int32, sorts ...expr.SortField) (*SortRel, error) {
+	sort, err := b.Sort(input, sorts...)
+	if err != nil {
+		return nil, err
+	}
+	rel, err := sort.Remap(remap...)
+	if err != nil {
+		return nil, err
+	}
+	return rel.(*SortRel), nil
 }
 
 func (b *builder) SortFields(input Rel, indices ...int32) ([]expr.SortField, error) {

--- a/plan/builders.go
+++ b/plan/builders.go
@@ -272,10 +272,6 @@ func (b *builder) AggregateFn(nameSpace, key string, opts []*types.FunctionOptio
 }
 
 func (b *builder) Project(input Rel, exprs ...expr.Expression) (*ProjectRel, error) {
-	return b.ProjectRemap(input, nil, exprs...)
-}
-
-func (b *builder) ProjectRemap(input Rel, remap []int32, exprs ...expr.Expression) (*ProjectRel, error) {
 	if input == nil {
 		return nil, errNilInputRel
 	}
@@ -283,19 +279,23 @@ func (b *builder) ProjectRemap(input Rel, remap []int32, exprs ...expr.Expressio
 	if len(exprs) == 0 {
 		return nil, fmt.Errorf("%w: must provide at least one expression for project relation", substraitgo.ErrInvalidRel)
 	}
-
-	noutput := input.RecordType().FieldCount() + int32(len(exprs))
-	for _, idx := range remap {
-		if idx < 0 || idx >= noutput {
-			return nil, errOutputMappingOutOfRange
-		}
-	}
-
 	return &ProjectRel{
-		RelCommon: RelCommon{mapping: remap},
+		RelCommon: RelCommon{mapping: nil},
 		input:     input,
 		exprs:     exprs,
 	}, nil
+}
+
+func (b *builder) ProjectRemap(input Rel, remap []int32, exprs ...expr.Expression) (*ProjectRel, error) {
+	project, err := b.Project(input, exprs...)
+	if err != nil {
+		return nil, err
+	}
+	rel, err := project.Remap(remap...)
+	if err != nil {
+		return nil, err
+	}
+	return rel.(*ProjectRel), err
 }
 
 func (b *builder) Measure(measure *expr.AggregateFunction, filter expr.Expression) AggRelMeasure {

--- a/plan/ctas_plan_test.go
+++ b/plan/ctas_plan_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/substrait-io/substrait-go/v8/expr"
 	"github.com/substrait-io/substrait-go/v8/extensions"
@@ -131,6 +132,24 @@ func getProjectionForTest2(t *testing.T, b plan.Builder) plan.Rel {
 
 	// projectRel output employee_id, name, department_id, salary, role
 	return makeProjectRel(t, b, filterRel, []int{1, 2, 3, 4, 0})
+}
+
+func TestCreateTableAsSelect(t *testing.T) {
+	b := plan.NewBuilderDefault()
+
+	tableNames := []string{"main", "employee_salaries"}
+	input := b.NamedScan(tableNames, employeeSchema)
+
+	ctasRel, err := b.CreateTableAsSelect(input, tableNames, employeeSchema)
+	require.NoError(t, err)
+	assert.Equal(t, plan.OutputModeModifiedRecords, ctasRel.OutputMode())
+	assert.Equal(t, ctasRel.TableSchema(), employeeSchema)
+	assert.Equal(t, tableNames, ctasRel.Names())
+	assert.Equal(t, "struct<i32, string?, i32?, decimal?<10,2>, string?>", ctasRel.RecordType().String())
+
+	ctasRel, err = b.CreateTableAsSelectRemap(input, []int32{0, 2}, tableNames, employeeSchema)
+	require.NoError(t, err)
+	assert.Equal(t, "struct<i32, i32?>", ctasRel.RecordType().String())
 }
 
 // TestCreateTableAsSelectRoundTrip verifies that generated plans match the expected JSON.

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -392,12 +392,16 @@ type Rel interface {
 
 	// Remap modifies the current relation by applying the provided
 	// mapping to the current relation.  Typically used to remove any
-	// unneeded columns or provide them in a different order.  If there
+	// unneeded columns or provide them in a different order. If there
 	// already is a mapping on this relation, this provides mapping over
 	// the current mapping.
 	//
 	// If any column numbers specified are outside the currently available
 	// input range an error is returned and the mapping is left unchanged.
+	//
+	// If Remap is called with no arguments, an empty mapping will be set
+	// on the relation, which removes ALL columns.
+
 	Remap(mapping ...int32) (Rel, error)
 
 	// setMapping sets the current mapping and is for internal use.

--- a/plan/plan_builder_test.go
+++ b/plan/plan_builder_test.go
@@ -899,6 +899,32 @@ func TestJoinAndFilterRelation(t *testing.T) {
 	checkRoundTrip(t, expectedJSON, p)
 }
 
+func TestJoinAndFilter(t *testing.T) {
+	b := plan.NewBuilderDefault()
+
+	left := b.NamedScan([]string{"left"}, baseSchema)
+	right := b.NamedScan([]string{"right"}, baseSchema2)
+
+	f1, err := b.JoinedRecordFieldRef(left, right, 1)
+	require.NoError(t, err)
+	f3, err := b.JoinedRecordFieldRef(left, right, 3)
+	require.NoError(t, err)
+
+	_, err = b.JoinAndFilter(left, right, f1, nil, plan.JoinTypeInner)
+	assert.ErrorContains(t, err, "condition for Join Relation must yield boolean")
+
+	_, err = b.JoinAndFilter(left, right, f3, f1, plan.JoinTypeInner)
+	assert.ErrorContains(t, err, "post join filter must be either nil or yield a boolean")
+
+	join, err := b.JoinAndFilter(left, right, f3, f3, plan.JoinTypeInner)
+	require.NoError(t, err)
+	assert.Equal(t, "struct<string, fp32, i32, boolean>", join.RecordType().String())
+
+	joinRemap, err := b.JoinAndFilterRemap(left, right, f3, f3, plan.JoinTypeInner, []int32{1, 2})
+	require.NoError(t, err)
+	assert.Equal(t, "struct<fp32, i32>", joinRemap.RecordType().String())
+}
+
 func TestJoinRelationError(t *testing.T) {
 	b := plan.NewBuilderDefault()
 	left := b.NamedScan([]string{"test"}, baseSchema)
@@ -1666,6 +1692,24 @@ func TestColumnlessVirtualTable(t *testing.T) {
 	require.NoError(t, err)
 
 	checkRoundTrip(t, expectedJSON, p)
+}
+
+func TestVirtualTable(t *testing.T) {
+	b := plan.NewBuilderDefault()
+	fieldNames := []string{"col0", "col1"}
+	c0 := expr.PrimitiveLiteral[int32]{Value: 1, Type: &types.Int32Type{Nullability: types.NullabilityRequired}}
+	c1 := expr.PrimitiveLiteral[int32]{Value: 'a', Type: &types.StringType{Nullability: types.NullabilityRequired}}
+	row := expr.StructLiteralValue{&c0, &c1}
+
+	vt, err := b.VirtualTable(fieldNames, row, row, row)
+	require.NoError(t, err)
+	assert.Equal(t, 3, len(vt.Values()))
+	assert.Equal(t, fieldNames, vt.BaseSchema().Names)
+	assert.Equal(t, "struct<i32, string>", vt.RecordType().String())
+
+	vtRemap, err := b.VirtualTableRemap(fieldNames, []int32{1}, row)
+	require.NoError(t, err)
+	assert.Equal(t, "struct<string>", vtRemap.RecordType().String())
 }
 
 func TestEmptyVirtualTable(t *testing.T) {

--- a/plan/virtual_table_from_expr_test.go
+++ b/plan/virtual_table_from_expr_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/substrait-io/substrait-go/v8/expr"
 	"github.com/substrait-io/substrait-go/v8/extensions"
@@ -37,6 +38,22 @@ func buildScalarAddExpression(t *testing.T, b plan.Builder) []expr.VirtualTableE
 	s1 := makeAddExpr(t, b, &v1, &v1)
 	s2 := makeAddExpr(t, b, &v2, &v2)
 	return []expr.VirtualTableExpressionValue{{s1, s2}}
+}
+
+func TestVirtualTableFromExpr(t *testing.T) {
+	b := plan.NewBuilderDefault()
+	values := buildLiteralExpressions(t, b)
+	fieldNames := []string{"col0", "col1"}
+
+	vt, err := b.VirtualTableFromExpr(fieldNames, values...)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(vt.Values()))
+	assert.Equal(t, fieldNames, vt.BaseSchema().Names)
+	assert.Equal(t, "struct<i32, i32>", vt.RecordType().String())
+
+	vtRemap, err := b.VirtualTableFromExprRemap(fieldNames, []int32{1}, values...)
+	require.NoError(t, err)
+	assert.Equal(t, "struct<i32>", vtRemap.RecordType().String())
 }
 
 // TestNamedTableInsertRoundTrip verifies that generated plans match the expected JSON.


### PR DESCRIPTION
The *Remap builder functions are deprecated. However, they are currently used to implement the non-*Remap functions, which makes them harder to remove.

This PR inverts the control flow so that the *Remap functions are implemented using non-deprecated functions, which will make future removal easier.

All existing tests for the builder functions pass with their new implementation. This PR is purely a mechanical change.