### PR TITLE
refactor: remove deprecated *Remap builder functions

### DIFF
--- a/plan/builders.go
+++ b/plan/builders.go
@@ -67,49 +67,21 @@ type Builder interface {
 	// Consisting of the provided aggregate function and optional filter expression.
 	Measure(measure *expr.AggregateFunction, filter expr.Expression) AggRelMeasure
 
-	// The Remap variant for each method produces that type of relation
-	// with an optional output mapping to reorder or exclude specific columns
-	// from the output.
-
 	Project(input Rel, exprs ...expr.Expression) (*ProjectRel, error)
-	// Deprecated: Use Project(...).Remap() instead.
-	ProjectRemap(input Rel, remap []int32, exprs ...expr.Expression) (*ProjectRel, error)
 	// Deprecated: Use GetRelBuilder().AggregateRel(...) instead.
 	AggregateColumns(input Rel, measures []AggRelMeasure, groupByCols ...int32) (*AggregateRel, error)
 	// Deprecated: Use GetRelBuilder().AggregateRel(...) instead.
 	AggregateExprs(input Rel, measures []AggRelMeasure, groups ...[]expr.Expression) (*AggregateRel, error)
-	// Deprecated: Use CreateTableAsSelect(...).Remap() instead.
-	CreateTableAsSelectRemap(input Rel, remap []int32, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error)
 	CreateTableAsSelect(input Rel, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error)
-	// Deprecated: Use Cross(...).Remap() instead.
-	CrossRemap(left, right Rel, remap []int32) (*CrossRel, error)
 	Cross(left, right Rel) (*CrossRel, error)
-	// FetchRemap constructs a fetch relation providing an offset (skipping some
-	// number of rows) and a count (restricting output to a maximum number of
-	// rows).  If count is FETCH_COUNT_ALL_RECORDS (-1) all records will be
-	// returned.  Similar to Fetch but allows for reordering and restricting the
-	// returned columns.
-	//
-	// Deprecated: Use Fetch(...).Remap() instead.
-	FetchRemap(input Rel, offset, count int64, remap []int32) (*FetchRel, error)
 	// Fetch constructs a fetch relation providing an offset (skipping some number of
 	// rows) and a count (restricting output to a maximum number of rows).  If count
 	// is FETCH_COUNT_ALL_RECORDS (-1) all records will be returned.
 	Fetch(input Rel, offset, count int64) (*FetchRel, error)
-	// Deprecated: Use Filter(...).Remap() instead.
-	FilterRemap(input Rel, condition expr.Expression, remap []int32) (*FilterRel, error)
 	Filter(input Rel, condition expr.Expression) (*FilterRel, error)
-	// Deprecated: Use JoinAndFilter(...).Remap() instead.
-	JoinAndFilterRemap(left, right Rel, condition, postJoinFilter expr.Expression, joinType JoinType, remap []int32) (*JoinRel, error)
-	// Deprecated: Use Join(...).Remap() instead.
-	JoinRemap(left, right Rel, condition expr.Expression, joinType JoinType, remap []int32) (*JoinRel, error)
 	Join(left, right Rel, condition expr.Expression, joinType JoinType) (*JoinRel, error)
 	JoinAndFilter(left, right Rel, condition, postJoinFilter expr.Expression, joinType JoinType) (*JoinRel, error)
-	// Deprecated: Use NamedScan(...).Remap() instead.
-	NamedScanRemap(tableName []string, schema types.NamedStruct, remap []int32) (*NamedTableReadRel, error)
 	NamedScan(tableName []string, schema types.NamedStruct) *NamedTableReadRel
-	// Deprecated: Use NamedWrite(...).Remap() instead.
-	NamedWriteRemap(input Rel, op WriteOp, tableName []string, schema types.NamedStruct, remap []int32) (*NamedTableWriteRel, error)
 	// NamedWrite performs the given write operation from the input relation over a named table.
 	NamedWrite(input Rel, op WriteOp, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error)
 	// NamedInsert inserts data from the input relation into a named table.
@@ -118,20 +90,12 @@ type Builder interface {
 	// provided input relation, which typically includes conditions that filter
 	// the rows to delete.
 	NamedDelete(input Rel, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error)
-	// Deprecated: Use VirtualTable(...).Remap() instead.
-	VirtualTableRemap(fields []string, remap []int32, values ...expr.StructLiteralValue) (*VirtualTableReadRel, error)
 	VirtualTable(fields []string, values ...expr.StructLiteralValue) (*VirtualTableReadRel, error)
-	// Deprecated: Use VirtualTableFromExpr(...).Remap() instead.
-	VirtualTableFromExprRemap(fieldNames []string, remap []int32, values ...expr.VirtualTableExpressionValue) (*VirtualTableReadRel, error)
 	VirtualTableFromExpr(fieldNames []string, values ...expr.VirtualTableExpressionValue) (*VirtualTableReadRel, error)
 	EmptyVirtualTable(fieldNames []string, types []types.Type) (*VirtualTableReadRel, error)
 	ExtensionTable(detail *anypb.Any, schema types.NamedStruct) *ExtensionTableReadRel
 	IcebergTableFromMetadataFile(metadataURI string, snapshot IcebergSnapshot, schema types.NamedStruct) (*IcebergTableReadRel, error)
-	// Deprecated: Use Sort(...).Remap() instead.
-	SortRemap(input Rel, remap []int32, sorts ...expr.SortField) (*SortRel, error)
 	Sort(input Rel, sorts ...expr.SortField) (*SortRel, error)
-	// Deprecated: Use Set(...).Remap() instead.
-	SetRemap(op SetOp, remap []int32, inputs ...Rel) (*SetRel, error)
 	Set(op SetOp, inputs ...Rel) (*SetRel, error)
 
 	// Plan constructs a new plan with the provided root relation and optionally
@@ -285,18 +249,6 @@ func (b *builder) Project(input Rel, exprs ...expr.Expression) (*ProjectRel, err
 	}, nil
 }
 
-func (b *builder) ProjectRemap(input Rel, remap []int32, exprs ...expr.Expression) (*ProjectRel, error) {
-	project, err := b.Project(input, exprs...)
-	if err != nil {
-		return nil, err
-	}
-	rel, err := project.Remap(remap...)
-	if err != nil {
-		return nil, err
-	}
-	return rel.(*ProjectRel), err
-}
-
 func (b *builder) Measure(measure *expr.AggregateFunction, filter expr.Expression) AggRelMeasure {
 	return AggRelMeasure{
 		measure: measure,
@@ -349,18 +301,6 @@ func (b *builder) CreateTableAsSelect(input Rel, tableName []string, schema type
 	}, nil
 }
 
-func (b *builder) CreateTableAsSelectRemap(input Rel, remap []int32, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error) {
-	ctas, err := b.CreateTableAsSelect(input, tableName, schema)
-	if err != nil {
-		return nil, err
-	}
-	rel, err := ctas.Remap(remap...)
-	if err != nil {
-		return nil, err
-	}
-	return rel.(*NamedTableWriteRel), nil
-}
-
 func (b *builder) Cross(left, right Rel) (*CrossRel, error) {
 	if left == nil || right == nil {
 		return nil, errNilInputRel
@@ -370,18 +310,6 @@ func (b *builder) Cross(left, right Rel) (*CrossRel, error) {
 		RelCommon: RelCommon{mapping: nil},
 		left:      left, right: right,
 	}, nil
-}
-
-func (b *builder) CrossRemap(left, right Rel, remap []int32) (*CrossRel, error) {
-	cross, err := b.Cross(left, right)
-	if err != nil {
-		return nil, err
-	}
-	rel, err := cross.Remap(remap...)
-	if err != nil {
-		return nil, err
-	}
-	return rel.(*CrossRel), nil
 }
 
 func (b *builder) Fetch(input Rel, offset, count int64) (*FetchRel, error) {
@@ -394,18 +322,6 @@ func (b *builder) Fetch(input Rel, offset, count int64) (*FetchRel, error) {
 		input:     input,
 		offset:    offset, count: count,
 	}, nil
-}
-
-func (b *builder) FetchRemap(input Rel, offset, count int64, remap []int32) (*FetchRel, error) {
-	fetch, err := b.Fetch(input, offset, count)
-	if err != nil {
-		return nil, err
-	}
-	rel, err := fetch.Remap(remap...)
-	if err != nil {
-		return nil, err
-	}
-	return rel.(*FetchRel), nil
 }
 
 func (b *builder) Filter(input Rel, condition expr.Expression) (*FilterRel, error) {
@@ -428,18 +344,6 @@ func (b *builder) Filter(input Rel, condition expr.Expression) (*FilterRel, erro
 		input:     input,
 		cond:      condition,
 	}, nil
-}
-
-func (b *builder) FilterRemap(input Rel, condition expr.Expression, remap []int32) (*FilterRel, error) {
-	filter, err := b.Filter(input, condition)
-	if err != nil {
-		return nil, err
-	}
-	rel, err := filter.Remap(remap...)
-	if err != nil {
-		return nil, err
-	}
-	return rel.(*FilterRel), nil
 }
 
 func (b *builder) JoinAndFilter(left, right Rel, condition, postJoinFilter expr.Expression, joinType JoinType) (*JoinRel, error) {
@@ -477,30 +381,6 @@ func (b *builder) JoinAndFilter(left, right Rel, condition, postJoinFilter expr.
 	}, nil
 }
 
-func (b *builder) JoinAndFilterRemap(left, right Rel, condition, postJoinFilter expr.Expression, joinType JoinType, remap []int32) (*JoinRel, error) {
-	join, err := b.JoinAndFilter(left, right, condition, postJoinFilter, joinType)
-	if err != nil {
-		return nil, err
-	}
-	rel, err := join.Remap(remap...)
-	if err != nil {
-		return nil, err
-	}
-	return rel.(*JoinRel), nil
-}
-
-func (b *builder) JoinRemap(left, right Rel, condition expr.Expression, joinType JoinType, remap []int32) (*JoinRel, error) {
-	join, err := b.Join(left, right, condition, joinType)
-	if err != nil {
-		return nil, err
-	}
-	rel, err := join.Remap(remap...)
-	if err != nil {
-		return nil, err
-	}
-	return rel.(*JoinRel), nil
-}
-
 func (b *builder) Join(left, right Rel, condition expr.Expression, joinType JoinType) (*JoinRel, error) {
 	return b.JoinAndFilter(left, right, condition, nil, joinType)
 }
@@ -518,18 +398,6 @@ func (b *builder) NamedWrite(input Rel, op WriteOp, tableName []string, schema t
 		input:       input,
 		outputMode:  OutputModeNoOutput,
 	}, nil
-}
-
-func (b *builder) NamedWriteRemap(input Rel, op WriteOp, tableName []string, schema types.NamedStruct, remap []int32) (*NamedTableWriteRel, error) {
-	nw, err := b.NamedWrite(input, op, tableName, schema)
-	if err != nil {
-		return nil, err
-	}
-	rel, err := nw.Remap(remap...)
-	if err != nil {
-		return nil, err
-	}
-	return rel.(*NamedTableWriteRel), nil
 }
 
 func (b *builder) NamedInsert(input Rel, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error) {
@@ -550,14 +418,6 @@ func (b *builder) NamedScan(tableName []string, schema types.NamedStruct) *Named
 	}
 }
 
-func (b *builder) NamedScanRemap(tableName []string, schema types.NamedStruct, remap []int32) (*NamedTableReadRel, error) {
-	rel, err := b.NamedScan(tableName, schema).Remap(remap...)
-	if err != nil {
-		return nil, err
-	}
-	return rel.(*NamedTableReadRel), nil
-}
-
 func (b *builder) VirtualTable(fieldNames []string, values ...expr.StructLiteralValue) (*VirtualTableReadRel, error) {
 	// convert Literal to Expression
 	exprs := make([]expr.VirtualTableExpressionValue, 0)
@@ -569,18 +429,6 @@ func (b *builder) VirtualTable(fieldNames []string, values ...expr.StructLiteral
 		exprs = append(exprs, rowExpr)
 	}
 	return b.VirtualTableFromExpr(fieldNames, exprs...)
-}
-
-func (b *builder) VirtualTableFromExprRemap(fieldNames []string, remap []int32, values ...expr.VirtualTableExpressionValue) (*VirtualTableReadRel, error) {
-	vt, err := b.VirtualTableFromExpr(fieldNames, values...)
-	if err != nil {
-		return nil, err
-	}
-	rel, err := vt.Remap(remap...)
-	if err != nil {
-		return nil, err
-	}
-	return rel.(*VirtualTableReadRel), err
 }
 
 func (b *builder) VirtualTableFromExpr(fieldNames []string, values ...expr.VirtualTableExpressionValue) (*VirtualTableReadRel, error) {
@@ -623,18 +471,6 @@ func (b *builder) VirtualTableFromExpr(fieldNames []string, values ...expr.Virtu
 		},
 		values: values,
 	}, nil
-}
-
-func (b *builder) VirtualTableRemap(fields []string, remap []int32, values ...expr.StructLiteralValue) (*VirtualTableReadRel, error) {
-	vt, err := b.VirtualTable(fields, values...)
-	if err != nil {
-		return nil, err
-	}
-	rel, err := vt.Remap(remap...)
-	if err != nil {
-		return nil, err
-	}
-	return rel.(*VirtualTableReadRel), err
 }
 
 func (b *builder) EmptyVirtualTable(fieldNames []string, typeList []types.Type) (*VirtualTableReadRel, error) {
@@ -697,18 +533,6 @@ func (b *builder) Sort(input Rel, sorts ...expr.SortField) (*SortRel, error) {
 	}, nil
 }
 
-func (b *builder) SortRemap(input Rel, remap []int32, sorts ...expr.SortField) (*SortRel, error) {
-	sort, err := b.Sort(input, sorts...)
-	if err != nil {
-		return nil, err
-	}
-	rel, err := sort.Remap(remap...)
-	if err != nil {
-		return nil, err
-	}
-	return rel.(*SortRel), nil
-}
-
 func (b *builder) SortFields(input Rel, indices ...int32) ([]expr.SortField, error) {
 	out := make([]expr.SortField, len(indices))
 	for i, idx := range indices {
@@ -752,18 +576,6 @@ func (b *builder) Set(op SetOp, inputs ...Rel) (*SetRel, error) {
 		op:        op,
 		inputs:    inputs,
 	}, nil
-}
-
-func (b *builder) SetRemap(op SetOp, remap []int32, inputs ...Rel) (*SetRel, error) {
-	set, err := b.Set(op, inputs...)
-	if err != nil {
-		return nil, err
-	}
-	rel, err := set.Remap(remap...)
-	if err != nil {
-		return nil, err
-	}
-	return rel.(*SetRel), nil
 }
 
 func (b *builder) PlanWithTypes(root Rel, rootNames []string, expectedTypeURLs []string, others ...Rel) (*Plan, error) {

--- a/plan/ctas_plan_test.go
+++ b/plan/ctas_plan_test.go
@@ -140,16 +140,16 @@ func TestCreateTableAsSelect(t *testing.T) {
 	tableNames := []string{"main", "employee_salaries"}
 	input := b.NamedScan(tableNames, employeeSchema)
 
-	ctasRel, err := b.CreateTableAsSelect(input, tableNames, employeeSchema)
+	ctas, err := b.CreateTableAsSelect(input, tableNames, employeeSchema)
 	require.NoError(t, err)
-	assert.Equal(t, plan.OutputModeModifiedRecords, ctasRel.OutputMode())
-	assert.Equal(t, ctasRel.TableSchema(), employeeSchema)
-	assert.Equal(t, tableNames, ctasRel.Names())
-	assert.Equal(t, "struct<i32, string?, i32?, decimal?<10,2>, string?>", ctasRel.RecordType().String())
+	assert.Equal(t, plan.OutputModeModifiedRecords, ctas.OutputMode())
+	assert.Equal(t, ctas.TableSchema(), employeeSchema)
+	assert.Equal(t, tableNames, ctas.Names())
+	assert.Equal(t, "struct<i32, string?, i32?, decimal?<10,2>, string?>", ctas.RecordType().String())
 
-	ctasRel, err = b.CreateTableAsSelectRemap(input, []int32{0, 2}, tableNames, employeeSchema)
+	ctasRemap, err := ctas.Remap(0, 2)
 	require.NoError(t, err)
-	assert.Equal(t, "struct<i32, i32?>", ctasRel.RecordType().String())
+	assert.Equal(t, "struct<i32, i32?>", ctasRemap.RecordType().String())
 }
 
 // TestCreateTableAsSelectRoundTrip verifies that generated plans match the expected JSON.

--- a/plan/plan_builder_test.go
+++ b/plan/plan_builder_test.go
@@ -58,8 +58,7 @@ var baseSchemaReverse = types.NamedStruct{Names: []string{"x", "y"},
 
 func TestBasicEmitPlan(t *testing.T) {
 	b := plan.NewBuilderDefault()
-	root, err := b.NamedScanRemap([]string{"test"},
-		baseSchema, []int32{1, 0})
+	root, err := b.NamedScan([]string{"test"}, baseSchema).Remap(1, 0)
 	require.NoError(t, err)
 	p, err := b.Plan(root, []string{"a", "b"})
 	require.NoError(t, err)
@@ -77,14 +76,7 @@ func TestBasicEmitPlan(t *testing.T) {
 
 func TestEmitEmptyPlan(t *testing.T) {
 	b := plan.NewBuilderDefault()
-	root, err := b.NamedScanRemap([]string{"test"},
-		baseSchema, []int32{})
-	require.NoError(t, err)
-	_, err = b.Plan(root, []string{})
-	require.NoError(t, err)
-
-	b = plan.NewBuilderDefault()
-	root = b.NamedScan([]string{"test"}, baseSchema)
+	root := b.NamedScan([]string{"test"}, baseSchema)
 	newRoot, err := root.Remap()
 	require.NoError(t, err)
 	_, err = b.Plan(newRoot, []string{})
@@ -115,14 +107,8 @@ func TestEmitEmptyPlan(t *testing.T) {
 
 func TestBuildEmitOutOfRangePlan(t *testing.T) {
 	b := plan.NewBuilderDefault()
-	_, err := b.NamedScanRemap([]string{"test"},
-		baseSchema, []int32{2})
-	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
-	assert.ErrorContains(t, err, "output mapping index out of range")
-
-	b = plan.NewBuilderDefault()
 	root := b.NamedScan([]string{"test"}, baseSchema)
-	_, err = root.Remap(2)
+	_, err := root.Remap(2)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 }
@@ -479,17 +465,9 @@ func TestCrossRelErrors(t *testing.T) {
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "input Relation must not be nil")
 
-	_, err = b.CrossRemap(left, right, []int32{-1})
-	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
-	assert.ErrorContains(t, err, "output mapping index out of range")
-
 	c, err := b.Cross(left, right)
 	assert.NoError(t, err)
 	_, err = c.Remap(-1)
-	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
-	assert.ErrorContains(t, err, "output mapping index out of range")
-
-	_, err = b.CrossRemap(left, right, []int32{5})
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -498,10 +476,6 @@ func TestCrossRelErrors(t *testing.T) {
 	_, err = c.Remap(5)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
-
-	// Output is length 2 + 2
-	_, err = b.CrossRemap(left, right, []int32{2, 3})
-	assert.NoError(t, err)
 
 	// Output is length 2 + 2
 	c, err = b.Cross(left, right)
@@ -588,17 +562,9 @@ func TestFetchRelErrors(t *testing.T) {
 		},
 	})
 
-	_, err = b.FetchRemap(scan, 0, 0, []int32{-1})
-	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
-	assert.ErrorContains(t, err, "output mapping index out of range")
-
 	f, err := b.Fetch(scan, 0, 0)
 	assert.NoError(t, err)
 	_, err = f.Remap(-1)
-	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
-	assert.ErrorContains(t, err, "output mapping index out of range")
-
-	_, err = b.FetchRemap(scan, 0, 0, []int32{2})
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -607,7 +573,6 @@ func TestFetchRelErrors(t *testing.T) {
 	_, err = f.Remap(2)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
-
 }
 
 func TestFilterRelation(t *testing.T) {
@@ -698,17 +663,9 @@ func TestFilterRelationErrors(t *testing.T) {
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidArg)
 	assert.ErrorContains(t, err, "condition for Filter Relation must yield boolean, not string")
 
-	_, err = b.FilterRemap(scan, refBool, []int32{-1})
-	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
-	assert.ErrorContains(t, err, "output mapping index out of range")
-
 	f, err := b.Filter(scan, refBool)
 	assert.NoError(t, err)
 	_, err = f.Remap(-1)
-	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
-	assert.ErrorContains(t, err, "output mapping index out of range")
-
-	_, err = b.FilterRemap(scan, refBool, []int32{3})
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -920,7 +877,7 @@ func TestJoinAndFilter(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "struct<string, fp32, i32, boolean>", join.RecordType().String())
 
-	joinRemap, err := b.JoinAndFilterRemap(left, right, f3, f3, plan.JoinTypeInner, []int32{1, 2})
+	joinRemap, err := join.Remap(1, 2)
 	require.NoError(t, err)
 	assert.Equal(t, "struct<fp32, i32>", joinRemap.RecordType().String())
 }
@@ -953,17 +910,9 @@ func TestJoinRelationError(t *testing.T) {
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidArg)
 	assert.ErrorContains(t, err, "join type must not be unspecified for Join relations")
 
-	_, err = b.JoinRemap(left, right, goodcond, plan.JoinTypeInner, []int32{-1})
-	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
-	assert.ErrorContains(t, err, "output mapping index out of range")
-
 	j, err := b.Join(left, right, goodcond, plan.JoinTypeInner)
 	assert.NoError(t, err)
 	_, err = j.Remap(-1)
-	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
-	assert.ErrorContains(t, err, "output mapping index out of range")
-
-	_, err = b.JoinRemap(left, right, goodcond, plan.JoinTypeLeftAnti, []int32{2})
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -1193,11 +1142,6 @@ func TestSortRelationErrors(t *testing.T) {
 	assert.ErrorContains(t, err, "cannot create field ref index -1")
 
 	fields, _ := b.SortFields(scan, 1, 0)
-	_, err = b.SortRemap(scan, []int32{-1}, fields...)
-	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
-	assert.ErrorContains(t, err, "output mapping index out of range")
-
-	fields, _ = b.SortFields(scan, 1, 0)
 	s, err := b.Sort(scan, fields...)
 	assert.NoError(t, err)
 	_, err = s.Remap(-1)
@@ -1211,10 +1155,6 @@ func TestSortRelationErrors(t *testing.T) {
 	_, err = b.Sort(scan)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "must provide at least one SortField for sort relation")
-
-	_, err = b.SortRemap(scan, []int32{3}, fields...)
-	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
-	assert.ErrorContains(t, err, "output mapping index out of range")
 
 	sortRel, err := b.Sort(scan, fields...)
 	assert.NoError(t, err)
@@ -1520,17 +1460,9 @@ func TestProjectErrors(t *testing.T) {
 	ref, err := b.RootFieldRef(scan, 1)
 	require.NoError(t, err)
 
-	_, err = b.ProjectRemap(scan, []int32{-1}, ref)
-	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
-	assert.ErrorContains(t, err, "output mapping index out of range")
-
 	p, err := b.Project(scan, ref)
 	assert.NoError(t, err)
 	_, err = p.Remap(-1)
-	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
-	assert.ErrorContains(t, err, "output mapping index out of range")
-
-	_, err = b.ProjectRemap(scan, []int32{3}, ref)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
@@ -1539,9 +1471,6 @@ func TestProjectErrors(t *testing.T) {
 	_, err = p.Remap(3)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
-
-	_, err = b.ProjectRemap(scan, []int32{2}, ref)
-	assert.NoError(t, err, "Expected expression mapping to be in-bounds")
 
 	p, err = b.Project(scan, ref)
 	assert.NoError(t, err)
@@ -1636,7 +1565,7 @@ func TestSetRelations(t *testing.T) {
 
 	b := plan.NewBuilderDefault()
 	scan1 := b.NamedScan([]string{"test"}, baseSchema)
-	scan2, err := b.NamedScanRemap([]string{"test2"}, baseSchemaReverse, []int32{1, 0})
+	scan2, err := b.NamedScan([]string{"test2"}, baseSchemaReverse).Remap(1, 0)
 	require.NoError(t, err)
 
 	virtual, err := b.VirtualTable([]string{"c", "d"},
@@ -1707,7 +1636,7 @@ func TestVirtualTable(t *testing.T) {
 	assert.Equal(t, fieldNames, vt.BaseSchema().Names)
 	assert.Equal(t, "struct<i32, string>", vt.RecordType().String())
 
-	vtRemap, err := b.VirtualTableRemap(fieldNames, []int32{1}, row)
+	vtRemap, err := vt.Remap(1)
 	require.NoError(t, err)
 	assert.Equal(t, "struct<string>", vtRemap.RecordType().String())
 }
@@ -1755,7 +1684,7 @@ func TestSetRelErrors(t *testing.T) {
 	b := plan.NewBuilderDefault()
 
 	scan1 := b.NamedScan([]string{"test"}, baseSchema)
-	scan2, err := b.NamedScanRemap([]string{"test2"}, baseSchemaReverse, []int32{1, 0})
+	scan2, err := b.NamedScan([]string{"test2"}, baseSchemaReverse).Remap(1, 0)
 	require.NoError(t, err)
 
 	virtual, err := b.VirtualTable([]string{"c", "d"},
@@ -1791,17 +1720,9 @@ func TestSetRelErrors(t *testing.T) {
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "mismatched column types in set relation, struct<string, fp32> vs struct<string, i32>")
 
-	_, err = b.SetRemap(plan.SetOpMinusMultiset, []int32{-1}, scan1, scan2)
-	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
-	assert.ErrorContains(t, err, "output mapping index out of range")
-
 	s, err := b.Set(plan.SetOpMinusMultiset, scan1, scan2)
 	assert.NoError(t, err)
 	_, err = s.Remap(-1)
-	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
-	assert.ErrorContains(t, err, "output mapping index out of range")
-
-	_, err = b.SetRemap(plan.SetOpMinusMultiset, []int32{3}, scan1, scan2)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 

--- a/plan/virtual_table_from_expr_test.go
+++ b/plan/virtual_table_from_expr_test.go
@@ -51,7 +51,7 @@ func TestVirtualTableFromExpr(t *testing.T) {
 	assert.Equal(t, fieldNames, vt.BaseSchema().Names)
 	assert.Equal(t, "struct<i32, i32>", vt.RecordType().String())
 
-	vtRemap, err := b.VirtualTableFromExprRemap(fieldNames, []int32{1}, values...)
+	vtRemap, err := vt.Remap(1)
 	require.NoError(t, err)
 	assert.Equal(t, "struct<i32>", vtRemap.RecordType().String())
 }


### PR DESCRIPTION
BREAKING CHANGE: *Remap builder functions have been removed
BREAKING CHANGE: *Remap builder functions have been removed from Builder interface

This follows #293 and removes the builders entirely.