### PR TITLE
feat(plan): support expression encoding for FetchRel offset and count

### DIFF
--- a/plan/builders.go
+++ b/plan/builders.go
@@ -74,10 +74,11 @@ type Builder interface {
 	AggregateExprs(input Rel, measures []AggRelMeasure, groups ...[]expr.Expression) (*AggregateRel, error)
 	CreateTableAsSelect(input Rel, tableName []string, schema types.NamedStruct) (*NamedTableWriteRel, error)
 	Cross(left, right Rel) (*CrossRel, error)
-	// Fetch constructs a fetch relation providing an offset (skipping some number of
-	// rows) and a count (restricting output to a maximum number of rows).  If count
-	// is FETCH_COUNT_ALL_RECORDS (-1) all records will be returned.
-	Fetch(input Rel, offset, count int64) (*FetchRel, error)
+	// Fetch constructs a Fetch relation that skips offset rows and returns at most count rows from the input.
+	//
+	// offset must evaluate to a non-negative integer or Substrait null. Pass a Go nil for no offset.
+	// count must evaluate to a non-negative integer or Substrait null. Pass a Go nil to return all records.
+	Fetch(input Rel, offset, count *expr.Expression) (*FetchRel, error)
 	Filter(input Rel, condition expr.Expression) (*FilterRel, error)
 	Join(left, right Rel, condition expr.Expression, joinType JoinType) (*JoinRel, error)
 	JoinAndFilter(left, right Rel, condition, postJoinFilter expr.Expression, joinType JoinType) (*JoinRel, error)
@@ -312,7 +313,7 @@ func (b *builder) Cross(left, right Rel) (*CrossRel, error) {
 	}, nil
 }
 
-func (b *builder) Fetch(input Rel, offset, count int64) (*FetchRel, error) {
+func (b *builder) Fetch(input Rel, offset, count *expr.Expression) (*FetchRel, error) {
 	if input == nil {
 		return nil, errNilInputRel
 	}

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -549,18 +549,34 @@ func RelFromProto(rel *proto.Rel, reg expr.ExtensionRegistry) (Rel, error) {
 			return nil, fmt.Errorf("error getting input to FetchRel: %w", err)
 		}
 
-		var offset int64
-		if off, ok := rel.Fetch.OffsetMode.(*proto.FetchRel_Offset); ok {
-			offset = off.Offset
-		} else {
-			return nil, fmt.Errorf("%w: missing required Offset field for Fetch Relation", substraitgo.ErrInvalidRel)
+		base := input.RecordType()
+
+		var offset *expr.Expression = nil
+		switch om := rel.Fetch.OffsetMode.(type) {
+		case *proto.FetchRel_Offset:
+			e := expr.Expression(expr.NewPrimitiveLiteral(om.Offset, false))
+			offset = &e
+		case *proto.FetchRel_OffsetExpr:
+			e, exprErr := expr.ExprFromProto(om.OffsetExpr, &base, reg)
+			if exprErr != nil {
+				return nil, fmt.Errorf("error getting offset expression for FetchRel: %w", exprErr)
+			}
+			offset = &e
 		}
 
-		var count int64
-		if cnt, ok := rel.Fetch.CountMode.(*proto.FetchRel_Count); ok {
-			count = cnt.Count
-		} else {
-			return nil, fmt.Errorf("%w: missing required Count field for Fetch Relation", substraitgo.ErrInvalidRel)
+		var count *expr.Expression = nil
+		switch cm := rel.Fetch.CountMode.(type) {
+		case *proto.FetchRel_Count:
+			if cm.Count != FETCH_COUNT_ALL_RECORDS {
+				e := expr.Expression(expr.NewPrimitiveLiteral(cm.Count, false))
+				count = &e
+			}
+		case *proto.FetchRel_CountExpr:
+			e, exprErr := expr.ExprFromProto(cm.CountExpr, &base, reg)
+			if exprErr != nil {
+				return nil, fmt.Errorf("error getting count expression for FetchRel: %w", exprErr)
+			}
+			count = &e
 		}
 
 		out := &FetchRel{

--- a/plan/plan_builder_test.go
+++ b/plan/plan_builder_test.go
@@ -512,8 +512,7 @@ func TestFetchRel(t *testing.T) {
 									}
 								}
 							},
-							"offset": 100,
-							"count": -1
+							"offsetExpr": {"literal": {"i64": "100"}}
 						}
 					},
 					"names": ["a"]
@@ -532,7 +531,8 @@ func TestFetchRel(t *testing.T) {
 		},
 	})
 
-	fetch, err := b.Fetch(scan, 100, plan.FETCH_COUNT_ALL_RECORDS)
+	offsetExpr := expr.Expression(expr.NewPrimitiveLiteral(int64(100), false))
+	fetch, err := b.Fetch(scan, &offsetExpr, nil)
 	require.NoError(t, err)
 
 	p, err := b.Plan(fetch, []string{"a"})
@@ -549,7 +549,10 @@ func TestFetchRel(t *testing.T) {
 func TestFetchRelErrors(t *testing.T) {
 	b := plan.NewBuilderDefault()
 
-	_, err := b.Fetch(nil, 0, 0)
+	zeroExpr := expr.Expression(expr.NewPrimitiveLiteral(int64(0), false))
+	zero := &zeroExpr
+
+	_, err := b.Fetch(nil, zero, zero)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "input Relation must not be nil")
 
@@ -562,13 +565,13 @@ func TestFetchRelErrors(t *testing.T) {
 		},
 	})
 
-	f, err := b.Fetch(scan, 0, 0)
+	f, err := b.Fetch(scan, zero, zero)
 	assert.NoError(t, err)
 	_, err = f.Remap(-1)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	assert.ErrorContains(t, err, "output mapping index out of range")
 
-	f, err = b.Fetch(scan, 0, 0)
+	f, err = b.Fetch(scan, zero, zero)
 	assert.NoError(t, err)
 	_, err = f.Remap(2)
 	assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)

--- a/plan/relations.go
+++ b/plan/relations.go
@@ -1027,7 +1027,7 @@ type FetchRel struct {
 	RelCommon
 
 	input         Rel
-	offset, count int64
+	offset, count *expr.Expression
 	advExtension  *extensions.AdvancedExtension
 }
 
@@ -1035,9 +1035,9 @@ func (f *FetchRel) directOutputSchema() types.RecordType { return f.input.Record
 func (f *FetchRel) RecordType() types.RecordType {
 	return f.remap(f.directOutputSchema())
 }
-func (f *FetchRel) Input() Rel    { return f.input }
-func (f *FetchRel) Offset() int64 { return f.offset }
-func (f *FetchRel) Count() int64  { return f.count }
+func (f *FetchRel) Input() Rel               { return f.input }
+func (f *FetchRel) Offset() *expr.Expression { return f.offset }
+func (f *FetchRel) Count() *expr.Expression  { return f.count }
 func (f *FetchRel) GetAdvancedExtension() *extensions.AdvancedExtension {
 	return f.advExtension
 }
@@ -1048,21 +1048,18 @@ func (f *FetchRel) SetAdvancedExtension(advExtension *extensions.AdvancedExtensi
 }
 
 func (f *FetchRel) ToProto() *proto.Rel {
-	return &proto.Rel{
-		RelType: &proto.Rel_Fetch{
-			Fetch: &proto.FetchRel{
-				Common: f.toProto(),
-				Input:  f.input.ToProto(),
-				OffsetMode: &proto.FetchRel_Offset{
-					Offset: f.offset,
-				},
-				CountMode: &proto.FetchRel_Count{
-					Count: f.count,
-				},
-				AdvancedExtension: f.advExtension,
-			},
-		},
+	fetchRel := &proto.FetchRel{
+		Common:            f.toProto(),
+		Input:             f.input.ToProto(),
+		AdvancedExtension: f.advExtension,
 	}
+	if f.offset != nil {
+		fetchRel.OffsetMode = &proto.FetchRel_OffsetExpr{OffsetExpr: (*f.offset).ToProto()}
+	}
+	if f.count != nil {
+		fetchRel.CountMode = &proto.FetchRel_CountExpr{CountExpr: (*f.count).ToProto()}
+	}
+	return &proto.Rel{RelType: &proto.Rel_Fetch{Fetch: fetchRel}}
 }
 
 func (f *FetchRel) ToProtoPlanRel() *proto.PlanRel {
@@ -1086,14 +1083,27 @@ func (f *FetchRel) Copy(newInputs ...Rel) (Rel, error) {
 	return &fetch, nil
 }
 
-func (f *FetchRel) CopyWithExpressionRewrite(_ RewriteFunc, newInputs ...Rel) (Rel, error) {
+func (f *FetchRel) CopyWithExpressionRewrite(rewrite RewriteFunc, newInputs ...Rel) (Rel, error) {
 	if len(newInputs) != 1 {
 		return nil, substraitgo.ErrInvalidInputCount
 	}
-	if newInputs[0] == f.input {
-		return f, nil
+	fetch := *f
+	fetch.input = newInputs[0]
+	if f.offset != nil {
+		newOffset, err := rewrite(*f.offset)
+		if err != nil {
+			return nil, err
+		}
+		fetch.offset = &newOffset
 	}
-	return f.Copy(newInputs...)
+	if f.count != nil {
+		newCount, err := rewrite(*f.count)
+		if err != nil {
+			return nil, err
+		}
+		fetch.count = &newCount
+	}
+	return &fetch, nil
 }
 
 func (f *FetchRel) Remap(mapping ...int32) (Rel, error) {

--- a/plan/relations_test.go
+++ b/plan/relations_test.go
@@ -75,7 +75,8 @@ func TestRelations_Copy(t *testing.T) {
 	crossRel := &CrossRel{left: createVirtualTableReadRel(1), right: createVirtualTableReadRel(2)}
 	extensionLeafRel := &ExtensionLeafRel{}
 	extensionMultiRel := &ExtensionMultiRel{inputs: []Rel{createVirtualTableReadRel(1), createVirtualTableReadRel(2)}}
-	fetchRel := &FetchRel{input: createVirtualTableReadRel(1), offset: 1, count: 2}
+	fetchOffset, fetchCount := expr.Expression(expr.NewPrimitiveLiteral(int64(1), false)), expr.Expression(expr.NewPrimitiveLiteral(int64(2), false))
+	fetchRel := &FetchRel{input: createVirtualTableReadRel(1), offset: &fetchOffset, count: &fetchCount}
 	filterRel := &FilterRel{input: createVirtualTableReadRel(1), cond: expr.NewPrimitiveLiteral(true, false)}
 	hashJoinRel := &HashJoinRel{left: createVirtualTableReadRel(1), right: createVirtualTableReadRel(2), joinType: HashMergeInner, keys: []*ComparisonJoinKey{}, postJoinFilter: expr.NewPrimitiveLiteral(true, false)}
 	joinRel := &JoinRel{left: createVirtualTableReadRel(1), right: createVirtualTableReadRel(2), joinType: JoinTypeInner, expr: expr.NewPrimitiveLiteral(true, false), postJoinFilter: expr.NewPrimitiveLiteral(true, false)}
@@ -168,7 +169,7 @@ func TestRelations_Copy(t *testing.T) {
 			name:        "FetchRel Copy with new inputs",
 			relation:    fetchRel,
 			newInputs:   []Rel{createVirtualTableReadRel(6)},
-			expectedRel: &FetchRel{input: createVirtualTableReadRel(6), offset: 1, count: 2},
+			expectedRel: &FetchRel{input: createVirtualTableReadRel(6), offset: &fetchOffset, count: &fetchCount},
 		},
 		{
 			name:            "FetchRel Copy with same inputs and noOpRewrite",
@@ -457,7 +458,8 @@ func TestRelations_AdvancedExtensions(t *testing.T) {
 	crossRel := &CrossRel{left: createVirtualTableReadRel(1), right: createVirtualTableReadRel(2)}
 	extensionLeafRel := &ExtensionLeafRel{}
 	extensionMultiRel := &ExtensionMultiRel{inputs: []Rel{createVirtualTableReadRel(1), createVirtualTableReadRel(2)}}
-	fetchRel := &FetchRel{input: createVirtualTableReadRel(1), offset: 1, count: 2}
+	fetchOffset, fetchCount := expr.Expression(expr.NewPrimitiveLiteral(int64(1), false)), expr.Expression(expr.NewPrimitiveLiteral(int64(2), false))
+	fetchRel := &FetchRel{input: createVirtualTableReadRel(1), offset: &fetchOffset, count: &fetchCount}
 	filterRel := &FilterRel{input: createVirtualTableReadRel(1), cond: expr.NewPrimitiveLiteral(true, false)}
 	hashJoinRel := &HashJoinRel{left: createVirtualTableReadRel(1), right: createVirtualTableReadRel(2), joinType: HashMergeInner, keys: []*ComparisonJoinKey{}, postJoinFilter: expr.NewPrimitiveLiteral(true, false)}
 	joinRel := &JoinRel{left: createVirtualTableReadRel(1), right: createVirtualTableReadRel(2), joinType: JoinTypeInner, expr: expr.NewPrimitiveLiteral(true, false), postJoinFilter: expr.NewPrimitiveLiteral(true, false)}


### PR DESCRIPTION
FetchRel now stores offset and count as *expr.Expression rather than int64,
enabling both the literal and expression variants of:
* count_mode: count/count_expr 
* offset_mode: offset/offset_expr

to be processed.

When reading from a FetchRel from a proto, the library promotes count and offset
to expression equivalents. When outputting protobufs, the library outputs
count_expr and offset_expr when they are set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fetch operations now support optional expression-based offset and count values.
  * Omitting the offset starts from the beginning; omitting the count returns all records.
  * Fetch plans can now preserve and process non-literal offset and count expressions.

* **Bug Fixes**
  * Improved compatibility when reading legacy fetch plans, including offset-only and count-only configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->