### PR TITLE
feat(type)!: make Version a domain struct

### DIFF
--- a/expr/expression.go
+++ b/expr/expression.go
@@ -1700,7 +1700,7 @@ func ExtendedFromProto(ex *proto.ExtendedExpression, c *extensions.Collection) (
 	}
 
 	return &Extended{
-		Version:          ex.Version,
+		Version:          types.VersionFromProto(ex.Version),
 		Extensions:       extSet,
 		ReferredExpr:     refs,
 		BaseSchema:       base,
@@ -1718,7 +1718,7 @@ func (ex *Extended) ToProto() *proto.ExtendedExpression {
 	}
 
 	return &proto.ExtendedExpression{
-		Version:            ex.Version,
+		Version:            types.VersionToProto(ex.Version),
 		ExtensionUrns:      urns,
 		Extensions:         decls,
 		BaseSchema:         ex.BaseSchema.ToProto(),

--- a/expr/expression.go
+++ b/expr/expression.go
@@ -1658,7 +1658,7 @@ func (er *ExpressionReference) GetExpr() Expression            { return er.expr 
 func (er *ExpressionReference) GetMeasure() *AggregateFunction { return er.measure }
 
 type Extended struct {
-	Version          *types.Version
+	Version          types.Version
 	Extensions       extensions.Set
 	ReferredExpr     []ExpressionReference
 	BaseSchema       types.NamedStruct
@@ -1667,6 +1667,9 @@ type Extended struct {
 
 	reg ExtensionRegistry
 }
+
+// HasVersion reports whether the expression declared a version (false when Version is types.UnsetVersion).
+func (ex *Extended) HasVersion() bool { return ex.Version != types.UnsetVersion }
 
 func ExtendedFromProto(ex *proto.ExtendedExpression, c *extensions.Collection) (*Extended, error) {
 	extSet, err := extensions.GetExtensionSet(ex, c)
@@ -1699,8 +1702,12 @@ func ExtendedFromProto(ex *proto.ExtendedExpression, c *extensions.Collection) (
 		}
 	}
 
+	version := types.UnsetVersion
+	if ex.Version != nil {
+		version = *types.VersionFromProto(ex.Version)
+	}
 	return &Extended{
-		Version:          types.VersionFromProto(ex.Version),
+		Version:          version,
 		Extensions:       extSet,
 		ReferredExpr:     refs,
 		BaseSchema:       base,
@@ -1718,7 +1725,7 @@ func (ex *Extended) ToProto() *proto.ExtendedExpression {
 	}
 
 	return &proto.ExtendedExpression{
-		Version:            types.VersionToProto(ex.Version),
+		Version:            types.VersionToProto(&ex.Version),
 		ExtensionUrns:      urns,
 		Extensions:         decls,
 		BaseSchema:         ex.BaseSchema.ToProto(),

--- a/expr/expression.go
+++ b/expr/expression.go
@@ -1668,9 +1668,6 @@ type Extended struct {
 	reg ExtensionRegistry
 }
 
-// HasVersion reports whether the expression declared a version (false when Version is types.UnsetVersion).
-func (ex *Extended) HasVersion() bool { return ex.Version != types.UnsetVersion }
-
 func ExtendedFromProto(ex *proto.ExtendedExpression, c *extensions.Collection) (*Extended, error) {
 	extSet, err := extensions.GetExtensionSet(ex, c)
 	if err != nil {
@@ -1702,12 +1699,8 @@ func ExtendedFromProto(ex *proto.ExtendedExpression, c *extensions.Collection) (
 		}
 	}
 
-	version := types.UnsetVersion
-	if ex.Version != nil {
-		version = *types.VersionFromProto(ex.Version)
-	}
 	return &Extended{
-		Version:          version,
+		Version:          types.VersionFromProto(ex.Version),
 		Extensions:       extSet,
 		ReferredExpr:     refs,
 		BaseSchema:       base,
@@ -1725,7 +1718,7 @@ func (ex *Extended) ToProto() *proto.ExtendedExpression {
 	}
 
 	return &proto.ExtendedExpression{
-		Version:            types.VersionToProto(&ex.Version),
+		Version:            types.VersionToProto(ex.Version),
 		ExtensionUrns:      urns,
 		Extensions:         decls,
 		BaseSchema:         ex.BaseSchema.ToProto(),

--- a/expr/testdata/lambda/lambda-field-ref.json
+++ b/expr/testdata/lambda/lambda-field-ref.json
@@ -1,4 +1,8 @@
 {
+  "version": {
+    "majorNumber": 0,
+    "minorNumber": 79
+  },
   "extensionUrns": [
     {
       "extensionUrnAnchor": 1,

--- a/expr/testdata/lambda/lambda-with-function.json
+++ b/expr/testdata/lambda/lambda-with-function.json
@@ -1,4 +1,8 @@
 {
+  "version": {
+    "majorNumber": 0,
+    "minorNumber": 79
+  },
   "extensionUrns": [
     {
       "extensionUrnAnchor": 1,

--- a/expr/testdata/lambda/lambda-with-list-transform.json
+++ b/expr/testdata/lambda/lambda-with-list-transform.json
@@ -1,4 +1,8 @@
 {
+  "version": {
+    "majorNumber": 0,
+    "minorNumber": 79
+  },
   "extensionUrns": [
     {
       "extensionUrnAnchor": 1,

--- a/expr/testdata/lambda/nested-lambda-outer-ref.json
+++ b/expr/testdata/lambda/nested-lambda-outer-ref.json
@@ -1,4 +1,8 @@
 {
+  "version": {
+    "majorNumber": 0,
+    "minorNumber": 79
+  },
   "extensionUrns": [
     {
       "extensionUrnAnchor": 1,

--- a/expr/version_test.go
+++ b/expr/version_test.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package expr_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/substrait-io/substrait-go/v9/expr"
+	ext "github.com/substrait-io/substrait-go/v9/extensions"
+	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
+)
+
+// An absent version must stay absent through a round trip, not become an empty message. The
+// populated case is already covered by TestRoundTripExtendedExpression.
+func TestExtendedWithoutAVersion(t *testing.T) {
+	in := &proto.ExtendedExpression{}
+	result, err := expr.ExtendedFromProto(in, ext.GetDefaultCollectionWithNoError())
+	require.NoError(t, err)
+	assert.Nil(t, result.Version)
+
+	assert.Nil(t, result.ToProto().Version)
+}

--- a/expr/version_test.go
+++ b/expr/version_test.go
@@ -9,16 +9,20 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/substrait-io/substrait-go/v9/expr"
 	ext "github.com/substrait-io/substrait-go/v9/extensions"
+	"github.com/substrait-io/substrait-go/v9/types"
 	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
 )
 
-// An absent version must stay absent through a round trip, not become an empty message. The
-// populated case is already covered by TestRoundTripExtendedExpression.
+// An extended expression parsed with no version is accepted but flagged: HasVersion is false and
+// Version is the UnsetVersion sentinel that renders as "0.0.0 (UNSET)".
 func TestExtendedWithoutAVersion(t *testing.T) {
-	in := &proto.ExtendedExpression{}
-	result, err := expr.ExtendedFromProto(in, ext.GetDefaultCollectionWithNoError())
+	result, err := expr.ExtendedFromProto(&proto.ExtendedExpression{}, ext.GetDefaultCollectionWithNoError())
 	require.NoError(t, err)
-	assert.Nil(t, result.Version)
 
-	assert.Nil(t, result.ToProto().Version)
+	assert.False(t, result.HasVersion())
+	assert.Equal(t, types.UnsetVersion, result.Version)
+	assert.Equal(t, "0.0.0 (UNSET)", result.Version.String())
+
+	// the sentinel is written back out, so the missing version stays visible on the wire
+	assert.Equal(t, "UNSET", result.ToProto().Version.GetProducer())
 }

--- a/expr/version_test.go
+++ b/expr/version_test.go
@@ -9,20 +9,14 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/substrait-io/substrait-go/v9/expr"
 	ext "github.com/substrait-io/substrait-go/v9/extensions"
-	"github.com/substrait-io/substrait-go/v9/types"
 	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
 )
 
-// An extended expression parsed with no version is accepted but flagged: HasVersion is false and
-// Version is the UnsetVersion sentinel that renders as "0.0.0 (UNSET)".
+// An extended expression parsed with no version is accepted; the missing version surfaces as
+// "0.0.0 (UNSET)", including on the way back out.
 func TestExtendedWithoutAVersion(t *testing.T) {
 	result, err := expr.ExtendedFromProto(&proto.ExtendedExpression{}, ext.GetDefaultCollectionWithNoError())
 	require.NoError(t, err)
-
-	assert.False(t, result.HasVersion())
-	assert.Equal(t, types.UnsetVersion, result.Version)
 	assert.Equal(t, "0.0.0 (UNSET)", result.Version.String())
-
-	// the sentinel is written back out, so the missing version stays visible on the wire
 	assert.Equal(t, "UNSET", result.ToProto().Version.GetProducer())
 }

--- a/plan/builders.go
+++ b/plan/builders.go
@@ -612,7 +612,7 @@ func (b *builder) PlanWithBindings(root Rel, rootNames []string, expectedTypeURL
 	reg := b.reg
 	reg.SetSubqueryConverter(&ExpressionConverter{ExtensionRegistry: reg})
 	return &Plan{
-		version:           &CurrentVersion,
+		version:           CurrentVersion,
 		extensions:        b.extSet,
 		reg:               reg,
 		expectedTypeURLs:  expectedTypeURLs,

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -143,7 +143,7 @@ type AdvancedExtension interface {
 // Plan describes a set of operations to complete. For
 // compactness, identifiers are normalized at the plan level.
 type Plan struct {
-	version           *types.Version
+	version           types.Version
 	extensions        extensions.Set
 	expectedTypeURLs  []string
 	advExtension      *extensions.AdvancedExtension
@@ -153,8 +153,11 @@ type Plan struct {
 	reg expr.ExtensionRegistry
 }
 
-// Version returns the substrait version of the plan, or nil if the plan declares none.
-func (p *Plan) Version() *types.Version { return p.version }
+// Version returns the plan's version, or types.UnsetVersion if it declared none.
+func (p *Plan) Version() types.Version { return p.version }
+
+// HasVersion reports whether the plan declared a version (false when Version is types.UnsetVersion).
+func (p *Plan) HasVersion() bool { return p.version != types.UnsetVersion }
 
 // ExtensionRegistry returns the set of registered extensions for this plan
 // that it may depend on.
@@ -228,8 +231,12 @@ func FromProtoWithDecoder(plan *proto.Plan, c *extensions.Collection, decoders m
 	if err != nil {
 		return nil, err
 	}
+	version := types.UnsetVersion
+	if plan.Version != nil {
+		version = *types.VersionFromProto(plan.Version)
+	}
 	ret := &Plan{
-		version:          types.VersionFromProto(plan.Version),
+		version:          version,
 		extensions:       extSet,
 		advExtension:     plan.AdvancedExtensions,
 		expectedTypeURLs: plan.ExpectedTypeUrls,
@@ -281,7 +288,7 @@ func (p *Plan) ToProto() (*proto.Plan, error) {
 	}
 
 	return &proto.Plan{
-		Version:            types.VersionToProto(p.version),
+		Version:            types.VersionToProto(&p.version),
 		ExpectedTypeUrls:   p.expectedTypeURLs,
 		AdvancedExtensions: p.advExtension,
 		Relations:          relations,

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -135,15 +135,6 @@ func (r *Relation) ToProto() *proto.PlanRel {
 	return r.rel.ToProtoPlanRel()
 }
 
-type Version interface {
-	GetGitHash() string
-	GetMajorNumber() uint32
-	GetMinorNumber() uint32
-	GetPatchNumber() uint32
-	GetProducer() string
-	fmt.Stringer
-}
-
 type AdvancedExtension interface {
 	GetEnhancement() *anypb.Any
 	GetOptimization() []*anypb.Any
@@ -162,8 +153,8 @@ type Plan struct {
 	reg expr.ExtensionRegistry
 }
 
-// Version returns the substrait version of the plan.
-func (p *Plan) Version() Version { return p.version }
+// Version returns the substrait version of the plan, or nil if the plan declares none.
+func (p *Plan) Version() *types.Version { return p.version }
 
 // ExtensionRegistry returns the set of registered extensions for this plan
 // that it may depend on.
@@ -238,7 +229,7 @@ func FromProtoWithDecoder(plan *proto.Plan, c *extensions.Collection, decoders m
 		return nil, err
 	}
 	ret := &Plan{
-		version:          plan.Version,
+		version:          types.VersionFromProto(plan.Version),
 		extensions:       extSet,
 		advExtension:     plan.AdvancedExtensions,
 		expectedTypeURLs: plan.ExpectedTypeUrls,
@@ -290,7 +281,7 @@ func (p *Plan) ToProto() (*proto.Plan, error) {
 	}
 
 	return &proto.Plan{
-		Version:            p.version,
+		Version:            types.VersionToProto(p.version),
 		ExpectedTypeUrls:   p.expectedTypeURLs,
 		AdvancedExtensions: p.advExtension,
 		Relations:          relations,

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -153,11 +153,8 @@ type Plan struct {
 	reg expr.ExtensionRegistry
 }
 
-// Version returns the plan's version, or types.UnsetVersion if it declared none.
+// Version returns the plan's version.
 func (p *Plan) Version() types.Version { return p.version }
-
-// HasVersion reports whether the plan declared a version (false when Version is types.UnsetVersion).
-func (p *Plan) HasVersion() bool { return p.version != types.UnsetVersion }
 
 // ExtensionRegistry returns the set of registered extensions for this plan
 // that it may depend on.
@@ -231,10 +228,7 @@ func FromProtoWithDecoder(plan *proto.Plan, c *extensions.Collection, decoders m
 	if err != nil {
 		return nil, err
 	}
-	version := types.UnsetVersion
-	if plan.Version != nil {
-		version = *types.VersionFromProto(plan.Version)
-	}
+	version := types.VersionFromProto(plan.Version)
 	ret := &Plan{
 		version:          version,
 		extensions:       extSet,
@@ -288,7 +282,7 @@ func (p *Plan) ToProto() (*proto.Plan, error) {
 	}
 
 	return &proto.Plan{
-		Version:            types.VersionToProto(&p.version),
+		Version:            types.VersionToProto(p.version),
 		ExpectedTypeUrls:   p.expectedTypeURLs,
 		AdvancedExtensions: p.advExtension,
 		Relations:          relations,

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -92,6 +92,7 @@ func TestPlanRoundTripWithExtensions(t *testing.T) {
 	require.NoError(t, err)
 
 	original := &proto.Plan{
+		Version: &proto.Version{MinorNumber: 29},
 		ExtensionUrns: []*extensionspb.SimpleExtensionURN{
 			{ExtensionUrnAnchor: 1, Urn: "extension:test:sample"},
 		},
@@ -191,6 +192,7 @@ func TestPlanRoundTripWithSubqueries(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			original := &proto.Plan{
+				Version: &proto.Version{MinorNumber: 29},
 				Relations: []*proto.PlanRel{{
 					RelType: &proto.PlanRel_Root{
 						Root: &proto.RelRoot{
@@ -304,6 +306,7 @@ func TestFromProtoWithSubqueries(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			p := &proto.Plan{
+				Version: &proto.Version{MinorNumber: 29},
 				Relations: []*proto.PlanRel{{
 					RelType: &proto.PlanRel_Root{
 						Root: &proto.RelRoot{
@@ -451,7 +454,7 @@ func TestFromProtoWithDecoder(t *testing.T) {
 	}}}
 
 	makePlan := func(extRel *proto.Rel) *proto.Plan {
-		return &proto.Plan{Relations: []*proto.PlanRel{{
+		return &proto.Plan{Version: &proto.Version{MinorNumber: 29}, Relations: []*proto.PlanRel{{
 			RelType: &proto.PlanRel_Root{Root: &proto.RelRoot{Names: []string{"c", "a", "b"}, Input: extRel}},
 		}}}
 	}

--- a/plan/version_test.go
+++ b/plan/version_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package plan_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/substrait-io/substrait-go/v9/extensions"
+	"github.com/substrait-io/substrait-go/v9/plan"
+	substraitproto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
+)
+
+// A plan can hold no version, in which case Version() returns nil.
+func TestPlanWithoutAVersion(t *testing.T) {
+	p, err := plan.FromProto(&substraitproto.Plan{}, extensions.GetDefaultCollectionWithNoError())
+	require.NoError(t, err)
+
+	assert.Nil(t, p.Version())
+
+	roundTrip, err := p.ToProto()
+	require.NoError(t, err)
+	assert.Nil(t, roundTrip.Version, "an absent version must not come back as an empty message")
+}
+
+// ToProto used to hand out &CurrentVersion itself. It now encodes a copy, so editing the returned
+// message no longer rewrites the version every later plan reports.
+func TestPlanToProtoCopiesTheVersion(t *testing.T) {
+	producer := plan.CurrentVersion.Producer
+
+	b := plan.NewBuilderDefault()
+	p, err := b.Plan(b.NamedScan([]string{"test"}, baseSchema), []string{"a", "b"})
+	require.NoError(t, err)
+
+	protoPlan, err := p.ToProto()
+	require.NoError(t, err)
+	require.Equal(t, producer, protoPlan.Version.Producer)
+
+	protoPlan.Version.Producer = "some other producer"
+	assert.Equal(t, producer, plan.CurrentVersion.Producer)
+	assert.Equal(t, producer, p.Version().Producer)
+}

--- a/plan/version_test.go
+++ b/plan/version_test.go
@@ -24,8 +24,8 @@ func TestPlanWithoutAVersion(t *testing.T) {
 	assert.Nil(t, roundTrip.Version, "an absent version must not come back as an empty message")
 }
 
-// ToProto used to hand out &CurrentVersion itself. It now encodes a copy, so editing the returned
-// message no longer rewrites the version every later plan reports.
+// ToProto encodes a copy of the version, so editing the returned message doesn't rewrite the
+// version every later plan reports.
 func TestPlanToProtoCopiesTheVersion(t *testing.T) {
 	producer := plan.CurrentVersion.Producer
 

--- a/plan/version_test.go
+++ b/plan/version_test.go
@@ -9,19 +9,23 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/substrait-io/substrait-go/v9/extensions"
 	"github.com/substrait-io/substrait-go/v9/plan"
+	"github.com/substrait-io/substrait-go/v9/types"
 	substraitproto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
 )
 
-// A plan can hold no version, in which case Version() returns nil.
+// A plan parsed with no version is accepted but flagged: HasVersion is false, Version is the
+// UnsetVersion sentinel, and it surfaces as "0.0.0 (UNSET)" including on the way back out.
 func TestPlanWithoutAVersion(t *testing.T) {
 	p, err := plan.FromProto(&substraitproto.Plan{}, extensions.GetDefaultCollectionWithNoError())
 	require.NoError(t, err)
 
-	assert.Nil(t, p.Version())
+	assert.False(t, p.HasVersion())
+	assert.Equal(t, types.UnsetVersion, p.Version())
+	assert.Equal(t, "0.0.0 (UNSET)", p.Version().String())
 
 	roundTrip, err := p.ToProto()
 	require.NoError(t, err)
-	assert.Nil(t, roundTrip.Version, "an absent version must not come back as an empty message")
+	assert.Equal(t, "UNSET", roundTrip.Version.GetProducer())
 }
 
 // ToProto encodes a copy of the version, so editing the returned message doesn't rewrite the

--- a/plan/version_test.go
+++ b/plan/version_test.go
@@ -9,18 +9,14 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/substrait-io/substrait-go/v9/extensions"
 	"github.com/substrait-io/substrait-go/v9/plan"
-	"github.com/substrait-io/substrait-go/v9/types"
 	substraitproto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
 )
 
-// A plan parsed with no version is accepted but flagged: HasVersion is false, Version is the
-// UnsetVersion sentinel, and it surfaces as "0.0.0 (UNSET)" including on the way back out.
+// A plan parsed with no version is accepted; the missing version surfaces as "0.0.0 (UNSET)",
+// including on the way back out.
 func TestPlanWithoutAVersion(t *testing.T) {
 	p, err := plan.FromProto(&substraitproto.Plan{}, extensions.GetDefaultCollectionWithNoError())
 	require.NoError(t, err)
-
-	assert.False(t, p.HasVersion())
-	assert.Equal(t, types.UnsetVersion, p.Version())
 	assert.Equal(t, "0.0.0 (UNSET)", p.Version().String())
 
 	roundTrip, err := p.ToProto()

--- a/types/types.go
+++ b/types/types.go
@@ -16,7 +16,61 @@ import (
 	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
 )
 
-type Version = proto.Version
+// Version is the Substrait version a plan or extended expression was built against.
+type Version struct {
+	MajorNumber uint32
+	MinorNumber uint32
+	PatchNumber uint32
+	GitHash     string
+	Producer    string
+}
+
+// String reports a readable version like "0.29.0+abc123 (producer)".
+func (v *Version) String() string {
+	if v == nil {
+		return "<nil>"
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d.%d.%d", v.MajorNumber, v.MinorNumber, v.PatchNumber)
+	if v.GitHash != "" {
+		// semver build metadata: the hash pins a commit between releases
+		b.WriteString("+" + v.GitHash)
+	}
+	if v.Producer != "" {
+		b.WriteString(" (" + v.Producer + ")")
+	}
+	return b.String()
+}
+
+// VersionFromProto converts a protobuf version message to the domain Version.
+func VersionFromProto(v *proto.Version) *Version {
+	if v == nil {
+		return nil
+	}
+	return &Version{
+		MajorNumber: v.MajorNumber,
+		MinorNumber: v.MinorNumber,
+		PatchNumber: v.PatchNumber,
+		GitHash:     v.GitHash,
+		Producer:    v.Producer,
+	}
+}
+
+// VersionToProto encodes a version. A nil stays absent rather than an empty message, so a plan
+// with no version round trips unchanged.
+func VersionToProto(v *Version) *proto.Version {
+	if v == nil {
+		return nil
+	}
+	return &proto.Version{
+		MajorNumber: v.MajorNumber,
+		MinorNumber: v.MinorNumber,
+		PatchNumber: v.PatchNumber,
+		GitHash:     v.GitHash,
+		Producer:    v.Producer,
+	}
+}
 
 // Nullability indicates whether values of a Substrait type may be null.
 type Nullability int32

--- a/types/types.go
+++ b/types/types.go
@@ -34,7 +34,6 @@ func (v *Version) String() string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "%d.%d.%d", v.MajorNumber, v.MinorNumber, v.PatchNumber)
 	if v.GitHash != "" {
-		// semver build metadata: the hash pins a commit between releases
 		b.WriteString("+" + v.GitHash)
 	}
 	if v.Producer != "" {

--- a/types/types.go
+++ b/types/types.go
@@ -25,8 +25,9 @@ type Version struct {
 	Producer    string
 }
 
-// UnsetVersion marks a version-less plan or expression; it renders as "0.0.0 (UNSET)".
-var UnsetVersion = Version{Producer: "UNSET"}
+// unsetVersion stands in for a plan or expression parsed from proto with no version; it renders as
+// "0.0.0 (UNSET)".
+var unsetVersion = Version{Producer: "UNSET"}
 
 // String reports a readable version like "0.29.0+abc123 (producer)".
 func (v Version) String() string {
@@ -42,11 +43,11 @@ func (v Version) String() string {
 }
 
 // VersionFromProto converts a protobuf version message to the domain Version.
-func VersionFromProto(v *proto.Version) *Version {
+func VersionFromProto(v *proto.Version) Version {
 	if v == nil {
-		return nil
+		return unsetVersion
 	}
-	return &Version{
+	return Version{
 		MajorNumber: v.MajorNumber,
 		MinorNumber: v.MinorNumber,
 		PatchNumber: v.PatchNumber,
@@ -55,11 +56,8 @@ func VersionFromProto(v *proto.Version) *Version {
 	}
 }
 
-// VersionToProto encodes a version; a nil pointer stays absent.
-func VersionToProto(v *Version) *proto.Version {
-	if v == nil {
-		return nil
-	}
+// VersionToProto encodes a version as its protobuf message.
+func VersionToProto(v Version) *proto.Version {
 	return &proto.Version{
 		MajorNumber: v.MajorNumber,
 		MinorNumber: v.MinorNumber,

--- a/types/types.go
+++ b/types/types.go
@@ -25,12 +25,11 @@ type Version struct {
 	Producer    string
 }
 
-// String reports a readable version like "0.29.0+abc123 (producer)".
-func (v *Version) String() string {
-	if v == nil {
-		return "<nil>"
-	}
+// UnsetVersion marks a version-less plan or expression; it renders as "0.0.0 (UNSET)".
+var UnsetVersion = Version{Producer: "UNSET"}
 
+// String reports a readable version like "0.29.0+abc123 (producer)".
+func (v Version) String() string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "%d.%d.%d", v.MajorNumber, v.MinorNumber, v.PatchNumber)
 	if v.GitHash != "" {
@@ -56,8 +55,7 @@ func VersionFromProto(v *proto.Version) *Version {
 	}
 }
 
-// VersionToProto encodes a version. A nil stays absent rather than an empty message, so a plan
-// with no version round trips unchanged.
+// VersionToProto encodes a version; a nil pointer stays absent.
 func VersionToProto(v *Version) *proto.Version {
 	if v == nil {
 		return nil

--- a/types/version_test.go
+++ b/types/version_test.go
@@ -15,9 +15,12 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
-// UnsetVersion renders as a visible sentinel so a missing version stands out in output.
-func TestUnsetVersionString(t *testing.T) {
-	assert.Equal(t, "0.0.0 (UNSET)", types.UnsetVersion.String())
+// A version-less proto maps to the unset placeholder, which renders visibly and serializes back out
+// as a producer "UNSET" version rather than an absent one.
+func TestVersionFromProtoNilIsUnset(t *testing.T) {
+	unset := types.VersionFromProto(nil)
+	assert.Equal(t, "0.0.0 (UNSET)", unset.String())
+	assert.Equal(t, "UNSET", types.VersionToProto(unset).GetProducer())
 }
 
 func TestVersionString(t *testing.T) {
@@ -42,8 +45,8 @@ func TestVersionString(t *testing.T) {
 	}
 }
 
-// Pin the hand written struct to the generated descriptor: the field set and wire numbers, which
-// a spec change can move without breaking the build.
+// Guard against spec drift: fail if the Version proto message gains, drops, or renumbers a field
+// that the hand-written types.Version does not mirror.
 func TestVersionMatchesDescriptor(t *testing.T) {
 	ours := map[protoreflect.Name]protoreflect.FieldNumber{
 		"major_number": 1,
@@ -66,12 +69,10 @@ func TestVersionMatchesDescriptor(t *testing.T) {
 	}
 }
 
-// Both directions carry every field and leave an absent version absent. A non-hash git value
-// ("HEAD") shows the hash is copied as given, not validated.
 func TestVersionRoundTrip(t *testing.T) {
 	for _, td := range []struct {
-		name string
-		wire *proto.Version
+		name         string
+		protoVersion *proto.Version
 	}{
 		// distinct numbers, so a conversion reading the wrong field shows up
 		{"every field", &proto.Version{
@@ -82,20 +83,16 @@ func TestVersionRoundTrip(t *testing.T) {
 		{"not a hash at all", &proto.Version{MinorNumber: 29, GitHash: "HEAD"}},
 	} {
 		t.Run(td.name, func(t *testing.T) {
-			domain := types.VersionFromProto(td.wire)
-			require.NotNil(t, domain)
-			assert.Equal(t, td.wire.GetMajorNumber(), domain.MajorNumber)
-			assert.Equal(t, td.wire.GetMinorNumber(), domain.MinorNumber)
-			assert.Equal(t, td.wire.GetPatchNumber(), domain.PatchNumber)
-			assert.Equal(t, td.wire.GetGitHash(), domain.GitHash)
-			assert.Equal(t, td.wire.GetProducer(), domain.Producer)
+			domain := types.VersionFromProto(td.protoVersion)
+			assert.Equal(t, td.protoVersion.GetMajorNumber(), domain.MajorNumber)
+			assert.Equal(t, td.protoVersion.GetMinorNumber(), domain.MinorNumber)
+			assert.Equal(t, td.protoVersion.GetPatchNumber(), domain.PatchNumber)
+			assert.Equal(t, td.protoVersion.GetGitHash(), domain.GitHash)
+			assert.Equal(t, td.protoVersion.GetProducer(), domain.Producer)
 
-			if diff := cmp.Diff(td.wire, types.VersionToProto(domain), protocmp.Transform()); diff != "" {
+			if diff := cmp.Diff(td.protoVersion, types.VersionToProto(domain), protocmp.Transform()); diff != "" {
 				t.Errorf("version proto didn't match, diff:\n%v", diff)
 			}
 		})
 	}
-
-	assert.Nil(t, types.VersionFromProto(nil))
-	assert.Nil(t, types.VersionToProto(nil))
 }

--- a/types/version_test.go
+++ b/types/version_test.go
@@ -15,10 +15,9 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
-// Plan.Version() can return a nil *Version, so String() must stay nil safe.
-func TestVersionStringOnNil(t *testing.T) {
-	var v *types.Version
-	assert.Equal(t, "<nil>", v.String())
+// UnsetVersion renders as a visible sentinel so a missing version stands out in output.
+func TestUnsetVersionString(t *testing.T) {
+	assert.Equal(t, "0.0.0 (UNSET)", types.UnsetVersion.String())
 }
 
 func TestVersionString(t *testing.T) {

--- a/types/version_test.go
+++ b/types/version_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package types_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/substrait-io/substrait-go/v9/types"
+	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+// Plan.Version() can return a nil *Version, so String() must stay nil safe.
+func TestVersionStringOnNil(t *testing.T) {
+	var v *types.Version
+	assert.Equal(t, "<nil>", v.String())
+}
+
+func TestVersionString(t *testing.T) {
+	for _, td := range []struct {
+		name     string
+		version  *types.Version
+		expected string
+	}{
+		{"numbers only", &types.Version{MinorNumber: 29}, "0.29.0"},
+		{"zero value", &types.Version{}, "0.0.0"},
+		{"with producer", &types.Version{MinorNumber: 29, Producer: "substrait-go v8"}, "0.29.0 (substrait-go v8)"},
+		{"with git hash", &types.Version{MinorNumber: 29, GitHash: "abc123"}, "0.29.0+abc123"},
+		{
+			"everything",
+			&types.Version{MajorNumber: 1, MinorNumber: 2, PatchNumber: 3, GitHash: "abc123", Producer: "acme"},
+			"1.2.3+abc123 (acme)",
+		},
+	} {
+		t.Run(td.name, func(t *testing.T) {
+			assert.Equal(t, td.expected, td.version.String())
+		})
+	}
+}
+
+// Pin the hand written struct to the generated descriptor: the field set and wire numbers, which
+// a spec change can move without breaking the build.
+func TestVersionMatchesDescriptor(t *testing.T) {
+	ours := map[protoreflect.Name]protoreflect.FieldNumber{
+		"major_number": 1,
+		"minor_number": 2,
+		"patch_number": 3,
+		"git_hash":     4,
+		"producer":     5,
+	}
+
+	fields := (&proto.Version{}).ProtoReflect().Descriptor().Fields()
+	require.Equal(t, len(ours), fields.Len(), "the set of spec version fields changed")
+	require.Equal(t, len(ours), reflect.TypeOf(types.Version{}).NumField(),
+		"types.Version carries a field the spec does not")
+
+	for i := 0; i < fields.Len(); i++ {
+		f := fields.Get(i)
+		number, ok := ours[f.Name()]
+		require.Truef(t, ok, "no types.Version field covers %s", f.Name())
+		assert.EqualValues(t, number, f.Number(), "wire number for %s", f.Name())
+	}
+}
+
+// Both directions carry every field and leave an absent version absent. A non-hash git value
+// ("HEAD") shows the hash is copied as given, not validated.
+func TestVersionRoundTrip(t *testing.T) {
+	for _, td := range []struct {
+		name string
+		wire *proto.Version
+	}{
+		// distinct numbers, so a conversion reading the wrong field shows up
+		{"every field", &proto.Version{
+			MajorNumber: 1, MinorNumber: 29, PatchNumber: 3,
+			GitHash: "0123456789abcdef", Producer: "substrait-go",
+		}},
+		{"no git hash", &proto.Version{MinorNumber: 29}},
+		{"not a hash at all", &proto.Version{MinorNumber: 29, GitHash: "HEAD"}},
+	} {
+		t.Run(td.name, func(t *testing.T) {
+			domain := types.VersionFromProto(td.wire)
+			require.NotNil(t, domain)
+			assert.Equal(t, td.wire.GetMajorNumber(), domain.MajorNumber)
+			assert.Equal(t, td.wire.GetMinorNumber(), domain.MinorNumber)
+			assert.Equal(t, td.wire.GetPatchNumber(), domain.PatchNumber)
+			assert.Equal(t, td.wire.GetGitHash(), domain.GitHash)
+			assert.Equal(t, td.wire.GetProducer(), domain.Producer)
+
+			if diff := cmp.Diff(td.wire, types.VersionToProto(domain), protocmp.Transform()); diff != "" {
+				t.Errorf("version proto didn't match, diff:\n%v", diff)
+			}
+		})
+	}
+
+	assert.Nil(t, types.VersionFromProto(nil))
+	assert.Nil(t, types.VersionToProto(nil))
+}


### PR DESCRIPTION
`types.Version` was `= proto.Version`, so the generated message was substrait-go's public API. It becomes substrait-go's own struct with the same field names and the same wire numbers, so consumers still compile.

BREAKING CHANGE: `types.Version` is no longer an alias for `proto.Version`.

Part of #280.
