### PR TITLE
feat(type)!: make CastFailBehavior a domain enum

### DIFF
--- a/expr/builder_test.go
+++ b/expr/builder_test.go
@@ -54,7 +54,7 @@ func TestExprBuilder(t *testing.T) {
 			b.ScalarFunc(subID).Args(
 				b.RootRef(expr.NewStructFieldRef(3)),
 				b.Cast(b.RootRef(expr.NewStructFieldRef(6)), &types.Int32Type{}).
-					FailBehavior(types.BehaviorThrowException),
+					FailBehavior(types.CastFailBehaviorThrowException),
 			), ""},
 		{"expression with lit", "subtract(.field(3) => i32, i32(3)) => i32",
 			b.ScalarFunc(subID).Args(b.RootRef(expr.NewStructFieldRef(3)),

--- a/expr/expression.go
+++ b/expr/expression.go
@@ -260,7 +260,7 @@ func ExprFromProto(e *proto.Expression, baseSchema *types.RecordType, reg Extens
 		return &Cast{
 			Type:            types.TypeFromProto(et.Cast.Type),
 			Input:           input,
-			FailureBehavior: et.Cast.FailureBehavior,
+			FailureBehavior: types.CastFailBehavior(et.Cast.FailureBehavior),
 		}, nil
 	case *proto.Expression_Nested_:
 		var err error
@@ -649,7 +649,7 @@ func (ex *Cast) ToProto() *proto.Expression {
 			Cast: &proto.Expression_Cast{
 				Type:            types.TypeToProto(ex.Type),
 				Input:           ex.Input.ToProto(),
-				FailureBehavior: ex.FailureBehavior,
+				FailureBehavior: proto.Expression_Cast_FailureBehavior(ex.FailureBehavior),
 			},
 		},
 	}

--- a/expr/expressions_test.go
+++ b/expr/expressions_test.go
@@ -502,7 +502,7 @@ func TestCastVisit(t *testing.T) {
 	castExpr := expr.MustExpr(builder.GetExprBuilder().Cast(builder.GetExprBuilder().Wrap(
 		expr.NewLiteral[float64](12.0, true)),
 		&types.Float64Type{Nullability: types.NullabilityRequired}).FailBehavior(
-		types.BehaviorThrowException).BuildExpr())
+		types.CastFailBehaviorThrowException).BuildExpr())
 
 	type relationTestCase struct {
 		name            string

--- a/types/cast_fail_behavior_test.go
+++ b/types/cast_fail_behavior_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/substrait-io/substrait-go/v9/types"
-	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
 )
 
 func TestCastFailBehaviorString(t *testing.T) {
@@ -26,4 +25,3 @@ func TestCastFailBehaviorString(t *testing.T) {
 		})
 	}
 }
-

--- a/types/cast_fail_behavior_test.go
+++ b/types/cast_fail_behavior_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package types_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/substrait-io/substrait-go/v9/types"
+	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
+)
+
+func TestCastFailBehaviorString(t *testing.T) {
+	for _, td := range []struct {
+		b        types.CastFailBehavior
+		expected string
+	}{
+		{types.CastFailBehaviorUnspecified, "FAILURE_BEHAVIOR_UNSPECIFIED"},
+		{types.CastFailBehaviorReturnNull, "FAILURE_BEHAVIOR_RETURN_NULL"},
+		{types.CastFailBehaviorThrowException, "FAILURE_BEHAVIOR_THROW_EXCEPTION"},
+	} {
+		t.Run(td.expected, func(t *testing.T) {
+			assert.Equal(t, td.expected, td.b.String())
+			assert.Equal(t, td.expected, fmt.Sprintf("%v", td.b))
+		})
+	}
+}
+
+func TestCastFailBehaviorMatchesProto(t *testing.T) {
+	cases := []struct {
+		domain types.CastFailBehavior
+		pb     proto.Expression_Cast_FailureBehavior
+	}{
+		{types.CastFailBehaviorUnspecified, proto.Expression_Cast_FAILURE_BEHAVIOR_UNSPECIFIED},
+		{types.CastFailBehaviorReturnNull, proto.Expression_Cast_FAILURE_BEHAVIOR_RETURN_NULL},
+		{types.CastFailBehaviorThrowException, proto.Expression_Cast_FAILURE_BEHAVIOR_THROW_EXCEPTION},
+	}
+	// fail if the spec adds a value we don't mirror
+	assert.Equal(t, proto.Expression_Cast_FAILURE_BEHAVIOR_UNSPECIFIED.Descriptor().Values().Len(), len(cases),
+		"a proto cast failure behavior value is not covered")
+	for _, td := range cases {
+		assert.EqualValues(t, td.pb, td.domain, "wire number for %s", td.pb)
+		assert.Equal(t, td.pb.String(), td.domain.String(), "enum name for %s", td.pb)
+	}
+}

--- a/types/cast_fail_behavior_test.go
+++ b/types/cast_fail_behavior_test.go
@@ -27,20 +27,3 @@ func TestCastFailBehaviorString(t *testing.T) {
 	}
 }
 
-func TestCastFailBehaviorMatchesProto(t *testing.T) {
-	cases := []struct {
-		domain types.CastFailBehavior
-		pb     proto.Expression_Cast_FailureBehavior
-	}{
-		{types.CastFailBehaviorUnspecified, proto.Expression_Cast_FAILURE_BEHAVIOR_UNSPECIFIED},
-		{types.CastFailBehaviorReturnNull, proto.Expression_Cast_FAILURE_BEHAVIOR_RETURN_NULL},
-		{types.CastFailBehaviorThrowException, proto.Expression_Cast_FAILURE_BEHAVIOR_THROW_EXCEPTION},
-	}
-	// fail if the spec adds a value we don't mirror
-	assert.Equal(t, proto.Expression_Cast_FAILURE_BEHAVIOR_UNSPECIFIED.Descriptor().Values().Len(), len(cases),
-		"a proto cast failure behavior value is not covered")
-	for _, td := range cases {
-		assert.EqualValues(t, td.pb, td.domain, "wire number for %s", td.pb)
-		assert.Equal(t, td.pb.String(), td.domain.String(), "enum name for %s", td.pb)
-	}
-}

--- a/types/types.go
+++ b/types/types.go
@@ -201,13 +201,28 @@ func (f FunctionRef) String() string { return "comparison_func_ref: " + strconv.
 
 func (FunctionRef) isSortKind() {}
 
-type CastFailBehavior = proto.Expression_Cast_FailureBehavior
+// CastFailBehavior indicates how a cast behaves when the input can't be converted to the target type.
+type CastFailBehavior int32
 
 const (
-	BehaviorUnspecified    = proto.Expression_Cast_FAILURE_BEHAVIOR_UNSPECIFIED
-	BehaviorReturnNil      = proto.Expression_Cast_FAILURE_BEHAVIOR_RETURN_NULL
-	BehaviorThrowException = proto.Expression_Cast_FAILURE_BEHAVIOR_THROW_EXCEPTION
+	CastFailBehaviorUnspecified    CastFailBehavior = 0
+	CastFailBehaviorReturnNull     CastFailBehavior = 1
+	CastFailBehaviorThrowException CastFailBehavior = 2
 )
+
+// String returns the protobuf enum name for the cast failure behavior.
+func (b CastFailBehavior) String() string {
+	switch b {
+	case CastFailBehaviorUnspecified:
+		return "FAILURE_BEHAVIOR_UNSPECIFIED"
+	case CastFailBehaviorReturnNull:
+		return "FAILURE_BEHAVIOR_RETURN_NULL"
+	case CastFailBehaviorThrowException:
+		return "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+	default:
+		return strconv.Itoa(int(b))
+	}
+}
 
 type (
 	IntervalYearToMonth  = proto.Expression_Literal_IntervalYearToMonth


### PR DESCRIPTION
`types.CastFailBehavior` was `= proto.Expression_Cast_FailureBehavior`, so the generated enum was substrait-go's public API. It becomes substrait-go's own `int32` with the same wire numbers.

BREAKING CHANGE: `types.CastFailBehavior` is no longer an alias for `proto.Expression_Cast_FailureBehavior`, and the `Behavior*` constants are renamed to `CastFailBehavior*`.

Part of #280.