### PR TITLE
feat(plan)!: make SimpleComparisonType a domain enum

### DIFF
--- a/plan/relations.go
+++ b/plan/relations.go
@@ -5,6 +5,7 @@ package plan
 import (
 	"fmt"
 	"slices"
+	"strconv"
 
 	substraitgo "github.com/substrait-io/substrait-go/v9"
 	"github.com/substrait-io/substrait-go/v9/expr"
@@ -1822,14 +1823,30 @@ const (
 
 // SimpleComparisonType describes one of the predefined comparison behaviors
 // used by a ComparisonJoinKey.
-type SimpleComparisonType = proto.ComparisonJoinKey_SimpleComparisonType
+type SimpleComparisonType int32
 
 const (
-	SimpleComparisonTypeUnspecified       = proto.ComparisonJoinKey_SIMPLE_COMPARISON_TYPE_UNSPECIFIED
-	SimpleComparisonTypeEq                = proto.ComparisonJoinKey_SIMPLE_COMPARISON_TYPE_EQ
-	SimpleComparisonTypeIsNotDistinctFrom = proto.ComparisonJoinKey_SIMPLE_COMPARISON_TYPE_IS_NOT_DISTINCT_FROM
-	SimpleComparisonTypeMightEqual        = proto.ComparisonJoinKey_SIMPLE_COMPARISON_TYPE_MIGHT_EQUAL
+	SimpleComparisonTypeUnspecified       SimpleComparisonType = 0
+	SimpleComparisonTypeEq                SimpleComparisonType = 1
+	SimpleComparisonTypeIsNotDistinctFrom SimpleComparisonType = 2
+	SimpleComparisonTypeMightEqual        SimpleComparisonType = 3
 )
+
+// String returns the protobuf enum name for the comparison type.
+func (t SimpleComparisonType) String() string {
+	switch t {
+	case SimpleComparisonTypeUnspecified:
+		return "SIMPLE_COMPARISON_TYPE_UNSPECIFIED"
+	case SimpleComparisonTypeEq:
+		return "SIMPLE_COMPARISON_TYPE_EQ"
+	case SimpleComparisonTypeIsNotDistinctFrom:
+		return "SIMPLE_COMPARISON_TYPE_IS_NOT_DISTINCT_FROM"
+	case SimpleComparisonTypeMightEqual:
+		return "SIMPLE_COMPARISON_TYPE_MIGHT_EQUAL"
+	default:
+		return strconv.Itoa(int(t))
+	}
+}
 
 // JoinKeyComparison describes how the two sides of a ComparisonJoinKey are
 // compared. It is either a SimpleComparison or a CustomComparison. The
@@ -1845,7 +1862,7 @@ type SimpleComparison struct {
 
 func (c SimpleComparison) toProto() *proto.ComparisonJoinKey_ComparisonType {
 	return &proto.ComparisonJoinKey_ComparisonType{
-		InnerType: &proto.ComparisonJoinKey_ComparisonType_Simple{Simple: c.Type},
+		InnerType: &proto.ComparisonJoinKey_ComparisonType_Simple{Simple: proto.ComparisonJoinKey_SimpleComparisonType(c.Type)},
 	}
 }
 
@@ -1956,7 +1973,7 @@ func rightJoinKeys(keys []*ComparisonJoinKey) []*expr.FieldReference {
 func joinKeyComparisonFromProto(c *proto.ComparisonJoinKey_ComparisonType) (JoinKeyComparison, error) {
 	switch it := c.GetInnerType().(type) {
 	case *proto.ComparisonJoinKey_ComparisonType_Simple:
-		return SimpleComparison{Type: it.Simple}, nil
+		return SimpleComparison{Type: SimpleComparisonType(it.Simple)}, nil
 	case *proto.ComparisonJoinKey_ComparisonType_CustomFunctionReference:
 		return CustomComparison{FunctionReference: it.CustomFunctionReference}, nil
 	default:

--- a/plan/simple_comparison_type_test.go
+++ b/plan/simple_comparison_type_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package plan_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/substrait-io/substrait-go/v9/plan"
+	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
+)
+
+func TestSimpleComparisonTypeString(t *testing.T) {
+	for _, td := range []struct {
+		c        plan.SimpleComparisonType
+		expected string
+	}{
+		{plan.SimpleComparisonTypeUnspecified, "SIMPLE_COMPARISON_TYPE_UNSPECIFIED"},
+		{plan.SimpleComparisonTypeEq, "SIMPLE_COMPARISON_TYPE_EQ"},
+		{plan.SimpleComparisonTypeIsNotDistinctFrom, "SIMPLE_COMPARISON_TYPE_IS_NOT_DISTINCT_FROM"},
+		{plan.SimpleComparisonTypeMightEqual, "SIMPLE_COMPARISON_TYPE_MIGHT_EQUAL"},
+	} {
+		t.Run(td.expected, func(t *testing.T) {
+			assert.Equal(t, td.expected, td.c.String())
+			assert.Equal(t, td.expected, fmt.Sprintf("%v", td.c))
+		})
+	}
+}
+
+func TestSimpleComparisonTypeMatchesProto(t *testing.T) {
+	cases := []struct {
+		domain plan.SimpleComparisonType
+		pb     proto.ComparisonJoinKey_SimpleComparisonType
+	}{
+		{plan.SimpleComparisonTypeUnspecified, proto.ComparisonJoinKey_SIMPLE_COMPARISON_TYPE_UNSPECIFIED},
+		{plan.SimpleComparisonTypeEq, proto.ComparisonJoinKey_SIMPLE_COMPARISON_TYPE_EQ},
+		{plan.SimpleComparisonTypeIsNotDistinctFrom, proto.ComparisonJoinKey_SIMPLE_COMPARISON_TYPE_IS_NOT_DISTINCT_FROM},
+		{plan.SimpleComparisonTypeMightEqual, proto.ComparisonJoinKey_SIMPLE_COMPARISON_TYPE_MIGHT_EQUAL},
+	}
+	// fail if the spec adds a value we don't mirror
+	assert.Equal(t, proto.ComparisonJoinKey_SIMPLE_COMPARISON_TYPE_UNSPECIFIED.Descriptor().Values().Len(), len(cases),
+		"a proto simple comparison type value is not covered")
+	for _, td := range cases {
+		assert.EqualValues(t, td.pb, td.domain, "wire number for %s", td.pb)
+		assert.Equal(t, td.pb.String(), td.domain.String(), "enum name for %s", td.pb)
+	}
+}


### PR DESCRIPTION
`plan.SimpleComparisonType` was `= proto.ComparisonJoinKey_SimpleComparisonType`, so the generated enum was substrait-go's public API. It becomes substrait-go's own `int32` with the same constant names and the same wire numbers, so consumers still compile.

BREAKING CHANGE: `plan.SimpleComparisonType` is no longer an alias for `proto.ComparisonJoinKey_SimpleComparisonType`. Code that passes one where the other is expected needs a cast.

Part of #280.