### PR TITLE
feat(type)!: make VarChar a domain struct

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -276,13 +276,19 @@ func (b CastFailBehavior) String() string {
 type (
 	IntervalYearToMonth  = proto.Expression_Literal_IntervalYearToMonth
 	IntervalDayToSecond  = proto.Expression_Literal_IntervalDayToSecond
-	VarChar              = proto.Expression_Literal_VarChar
 	Decimal              = proto.Expression_Literal_Decimal
 	UserDefinedLiteral   = proto.Expression_Literal_UserDefined
 	PrecisionTime        = proto.Expression_Literal_PrecisionTime
 	PrecisionTimestamp   = proto.Expression_Literal_PrecisionTimestamp_
 	PrecisionTimestampTz = proto.Expression_Literal_PrecisionTimestampTz
 )
+
+// VarChar is a variable-length character literal: its value and length, mirroring the fields of
+// the Substrait VarChar literal message.
+type VarChar struct {
+	Value  string
+	Length uint32
+}
 
 // TypeFromProto returns the appropriate Type object from a protobuf
 // type message.

--- a/types/var_char_test.go
+++ b/types/var_char_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package types_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/substrait-io/substrait-go/v9/types"
+	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+func TestVarCharMatchesDescriptor(t *testing.T) {
+	want := map[protoreflect.Name]struct {
+		number protoreflect.FieldNumber
+		kind   protoreflect.Kind
+	}{
+		"value":  {1, protoreflect.StringKind},
+		"length": {2, protoreflect.Uint32Kind},
+	}
+
+	fields := (&proto.Expression_Literal_VarChar{}).ProtoReflect().Descriptor().Fields()
+	require.Equal(t, len(want), fields.Len(), "spec varchar field set changed")
+	require.Equal(t, len(want), reflect.TypeOf(types.VarChar{}).NumField(), "types.VarChar field count drifted from the spec")
+
+	for i := 0; i < fields.Len(); i++ {
+		f := fields.Get(i)
+		w, ok := want[f.Name()]
+		require.Truef(t, ok, "unexpected spec field %q", f.Name())
+		assert.EqualValues(t, w.number, f.Number(), "%s wire number", f.Name())
+		assert.Equal(t, w.kind, f.Kind(), "%s kind", f.Name())
+	}
+}


### PR DESCRIPTION
`types.VarChar` was `= proto.Expression_Literal_VarChar`, so the generated message was substrait-go's public API. It becomes substrait-go's own struct with the same field names and the same wire numbers.

BREAKING CHANGE: `types.VarChar` is no longer an alias for `proto.Expression_Literal_VarChar`.

Part of #280.