### PR TITLE
feat(type)!: make Decimal a domain struct

### DIFF
--- a/expr/literals.go
+++ b/expr/literals.go
@@ -499,8 +499,8 @@ func (t *ByteSliceLiteral[T]) WithType(newType types.Type) (Literal, error) {
 	return nil, fmt.Errorf("byte slice literal withType is not supported for %T ", newType)
 }
 
-// ProtoLiteral is a literal that is represented using its protobuf
-// message type such as a Decimal or UserDefinedType.
+// ProtoLiteral is a literal represented by a structured value such as a
+// decimal or user-defined value.
 type ProtoLiteral struct {
 	Value any
 	Type  types.Type

--- a/types/decimal_test.go
+++ b/types/decimal_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package types_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/substrait-io/substrait-go/v9/types"
+	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+func TestDecimalMatchesDescriptor(t *testing.T) {
+	want := map[protoreflect.Name]struct {
+		number protoreflect.FieldNumber
+		kind   protoreflect.Kind
+	}{
+		"value":     {1, protoreflect.BytesKind},
+		"precision": {2, protoreflect.Int32Kind},
+		"scale":     {3, protoreflect.Int32Kind},
+	}
+
+	fields := (&proto.Expression_Literal_Decimal{}).ProtoReflect().Descriptor().Fields()
+	require.Equal(t, len(want), fields.Len(), "spec decimal field set changed")
+	require.Equal(t, len(want), reflect.TypeOf(types.Decimal{}).NumField(), "types.Decimal field count drifted from the spec")
+
+	for i := 0; i < fields.Len(); i++ {
+		f := fields.Get(i)
+		w, ok := want[f.Name()]
+		require.Truef(t, ok, "unexpected spec field %q", f.Name())
+		assert.EqualValues(t, w.number, f.Number(), "%s wire number", f.Name())
+		assert.Equal(t, w.kind, f.Kind(), "%s kind", f.Name())
+	}
+}

--- a/types/types.go
+++ b/types/types.go
@@ -276,7 +276,6 @@ func (b CastFailBehavior) String() string {
 type (
 	IntervalYearToMonth  = proto.Expression_Literal_IntervalYearToMonth
 	IntervalDayToSecond  = proto.Expression_Literal_IntervalDayToSecond
-	Decimal              = proto.Expression_Literal_Decimal
 	UserDefinedLiteral   = proto.Expression_Literal_UserDefined
 	PrecisionTime        = proto.Expression_Literal_PrecisionTime
 	PrecisionTimestamp   = proto.Expression_Literal_PrecisionTimestamp_
@@ -288,6 +287,14 @@ type (
 type VarChar struct {
 	Value  string
 	Length uint32
+}
+
+// Decimal is a decimal literal: the value as a 16-byte little-endian two's-complement integer
+// (ignoring precision), together with the precision and scale.
+type Decimal struct {
+	Value     []byte
+	Precision int32
+	Scale     int32
 }
 
 // TypeFromProto returns the appropriate Type object from a protobuf


### PR DESCRIPTION
`types.Decimal` was `= proto.Expression_Literal_Decimal`, so the generated message was substrait-go's public API. It becomes substrait-go's own struct with the same field names and the same wire numbers.

BREAKING CHANGE: `types.Decimal` is no longer an alias for `proto.Expression_Literal_Decimal`.

Part of #280.