### PR TITLE
feat(type)!: make SortDirection a domain enum

### DIFF
--- a/types/sort_direction_test.go
+++ b/types/sort_direction_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package types_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/substrait-io/substrait-go/v9/types"
+	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
+)
+
+func TestSortDirectionString(t *testing.T) {
+	for _, td := range []struct {
+		d        types.SortDirection
+		expected string
+	}{
+		{types.SortUnspecified, "SORT_DIRECTION_UNSPECIFIED"},
+		{types.SortAscNullsFirst, "SORT_DIRECTION_ASC_NULLS_FIRST"},
+		{types.SortAscNullsLast, "SORT_DIRECTION_ASC_NULLS_LAST"},
+		{types.SortDescNullsFirst, "SORT_DIRECTION_DESC_NULLS_FIRST"},
+		{types.SortDescNullsLast, "SORT_DIRECTION_DESC_NULLS_LAST"},
+		{types.SortClustered, "SORT_DIRECTION_CLUSTERED"},
+	} {
+		t.Run(td.expected, func(t *testing.T) {
+			assert.Equal(t, td.expected, td.d.String())
+			assert.Equal(t, td.expected, fmt.Sprintf("%v", td.d))
+		})
+	}
+}
+
+func TestSortDirectionMatchesProto(t *testing.T) {
+	cases := []struct {
+		domain types.SortDirection
+		pb     proto.SortField_SortDirection
+	}{
+		{types.SortUnspecified, proto.SortField_SORT_DIRECTION_UNSPECIFIED},
+		{types.SortAscNullsFirst, proto.SortField_SORT_DIRECTION_ASC_NULLS_FIRST},
+		{types.SortAscNullsLast, proto.SortField_SORT_DIRECTION_ASC_NULLS_LAST},
+		{types.SortDescNullsFirst, proto.SortField_SORT_DIRECTION_DESC_NULLS_FIRST},
+		{types.SortDescNullsLast, proto.SortField_SORT_DIRECTION_DESC_NULLS_LAST},
+		{types.SortClustered, proto.SortField_SORT_DIRECTION_CLUSTERED},
+	}
+	// fail if the spec adds a value we don't mirror
+	assert.Equal(t, proto.SortField_SORT_DIRECTION_UNSPECIFIED.Descriptor().Values().Len(), len(cases),
+		"a proto sort direction value is not covered")
+	for _, td := range cases {
+		assert.EqualValues(t, td.pb, td.domain, "wire number for %s", td.pb)
+		assert.Equal(t, td.pb.String(), td.domain.String(), "enum name for %s", td.pb)
+	}
+}

--- a/types/types.go
+++ b/types/types.go
@@ -229,18 +229,36 @@ const (
 	BoundsTypeRange       = proto.Expression_WindowFunction_BOUNDS_TYPE_RANGE
 )
 
-type SortDirection proto.SortField_SortDirection
+type SortDirection int32
 
 const (
-	SortUnspecified    = SortDirection(proto.SortField_SORT_DIRECTION_UNSPECIFIED)
-	SortAscNullsFirst  = SortDirection(proto.SortField_SORT_DIRECTION_ASC_NULLS_FIRST)
-	SortAscNullsLast   = SortDirection(proto.SortField_SORT_DIRECTION_ASC_NULLS_LAST)
-	SortDescNullsFirst = SortDirection(proto.SortField_SORT_DIRECTION_DESC_NULLS_FIRST)
-	SortDescNullsLast  = SortDirection(proto.SortField_SORT_DIRECTION_DESC_NULLS_LAST)
-	SortClustered      = SortDirection(proto.SortField_SORT_DIRECTION_CLUSTERED)
+	SortUnspecified    SortDirection = 0
+	SortAscNullsFirst  SortDirection = 1
+	SortAscNullsLast   SortDirection = 2
+	SortDescNullsFirst SortDirection = 3
+	SortDescNullsLast  SortDirection = 4
+	SortClustered      SortDirection = 5
 )
 
-func (s SortDirection) String() string { return proto.SortField_SortDirection(s).String() }
+// String returns the protobuf enum name for the sort direction.
+func (s SortDirection) String() string {
+	switch s {
+	case SortUnspecified:
+		return "SORT_DIRECTION_UNSPECIFIED"
+	case SortAscNullsFirst:
+		return "SORT_DIRECTION_ASC_NULLS_FIRST"
+	case SortAscNullsLast:
+		return "SORT_DIRECTION_ASC_NULLS_LAST"
+	case SortDescNullsFirst:
+		return "SORT_DIRECTION_DESC_NULLS_FIRST"
+	case SortDescNullsLast:
+		return "SORT_DIRECTION_DESC_NULLS_LAST"
+	case SortClustered:
+		return "SORT_DIRECTION_CLUSTERED"
+	default:
+		return strconv.Itoa(int(s))
+	}
+}
 
 func (SortDirection) isSortKind() {}
 


### PR DESCRIPTION
`types.SortDirection` was already its own named type, but declared over `proto.SortField_SortDirection`, so the generated enum was still its underlying type and public surface. It becomes substrait-go's own `int32` with the same constant names and the same wire numbers, plus a hand-written `String()`, so consumers still compile.

BREAKING CHANGE: `types.SortDirection`'s underlying type changes from `proto.SortField_SortDirection` to `int32`. Code that passes one where the other is expected needs a cast.

Part of #280.
