### PR TITLE
feat(plan)!: make JoinType a domain enum

### DIFF
--- a/plan/join_type_test.go
+++ b/plan/join_type_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package plan_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/substrait-io/substrait-go/v9/plan"
+	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
+)
+
+func TestJoinTypeString(t *testing.T) {
+	for _, td := range []struct {
+		j        plan.JoinType
+		expected string
+	}{
+		{plan.JoinTypeUnspecified, "JOIN_TYPE_UNSPECIFIED"},
+		{plan.JoinTypeInner, "JOIN_TYPE_INNER"},
+		{plan.JoinTypeOuter, "JOIN_TYPE_OUTER"},
+		{plan.JoinTypeLeft, "JOIN_TYPE_LEFT"},
+		{plan.JoinTypeRight, "JOIN_TYPE_RIGHT"},
+		{plan.JoinTypeLeftSemi, "JOIN_TYPE_LEFT_SEMI"},
+		{plan.JoinTypeLeftAnti, "JOIN_TYPE_LEFT_ANTI"},
+		{plan.JoinTypeLeftSingle, "JOIN_TYPE_LEFT_SINGLE"},
+		{plan.JoinTypeRightSemi, "JOIN_TYPE_RIGHT_SEMI"},
+		{plan.JoinTypeRightAnti, "JOIN_TYPE_RIGHT_ANTI"},
+		{plan.JoinTypeRightSingle, "JOIN_TYPE_RIGHT_SINGLE"},
+		{plan.JoinTypeLeftMark, "JOIN_TYPE_LEFT_MARK"},
+		{plan.JoinTypeRightMark, "JOIN_TYPE_RIGHT_MARK"},
+	} {
+		t.Run(td.expected, func(t *testing.T) {
+			assert.Equal(t, td.expected, td.j.String())
+			assert.Equal(t, td.expected, fmt.Sprintf("%v", td.j))
+		})
+	}
+}
+
+func TestJoinTypeMatchesProto(t *testing.T) {
+	cases := []struct {
+		domain plan.JoinType
+		pb     proto.JoinRel_JoinType
+	}{
+		{plan.JoinTypeUnspecified, proto.JoinRel_JOIN_TYPE_UNSPECIFIED},
+		{plan.JoinTypeInner, proto.JoinRel_JOIN_TYPE_INNER},
+		{plan.JoinTypeOuter, proto.JoinRel_JOIN_TYPE_OUTER},
+		{plan.JoinTypeLeft, proto.JoinRel_JOIN_TYPE_LEFT},
+		{plan.JoinTypeRight, proto.JoinRel_JOIN_TYPE_RIGHT},
+		{plan.JoinTypeLeftSemi, proto.JoinRel_JOIN_TYPE_LEFT_SEMI},
+		{plan.JoinTypeLeftAnti, proto.JoinRel_JOIN_TYPE_LEFT_ANTI},
+		{plan.JoinTypeLeftSingle, proto.JoinRel_JOIN_TYPE_LEFT_SINGLE},
+		{plan.JoinTypeRightSemi, proto.JoinRel_JOIN_TYPE_RIGHT_SEMI},
+		{plan.JoinTypeRightAnti, proto.JoinRel_JOIN_TYPE_RIGHT_ANTI},
+		{plan.JoinTypeRightSingle, proto.JoinRel_JOIN_TYPE_RIGHT_SINGLE},
+		{plan.JoinTypeLeftMark, proto.JoinRel_JOIN_TYPE_LEFT_MARK},
+		{plan.JoinTypeRightMark, proto.JoinRel_JOIN_TYPE_RIGHT_MARK},
+	}
+	// fail if the spec adds a value we don't mirror
+	assert.Equal(t, proto.JoinRel_JOIN_TYPE_UNSPECIFIED.Descriptor().Values().Len(), len(cases),
+		"a proto join type value is not covered")
+	for _, td := range cases {
+		assert.EqualValues(t, td.pb, td.domain, "wire number for %s", td.pb)
+		assert.Equal(t, td.pb.String(), td.domain.String(), "enum name for %s", td.pb)
+	}
+}

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -651,7 +651,7 @@ func RelFromProto(rel *proto.Rel, reg expr.ExtensionRegistry) (Rel, error) {
 		out.fromProtoCommon(rel.Sort.Common)
 		return out, nil
 	case *proto.Rel_Join:
-		if rel.Join.Type == JoinTypeUnspecified {
+		if JoinType(rel.Join.Type) == JoinTypeUnspecified {
 			return nil, fmt.Errorf("%w: JoinRel must not have unspecified join type", substraitgo.ErrInvalidRel)
 		}
 
@@ -668,7 +668,7 @@ func RelFromProto(rel *proto.Rel, reg expr.ExtensionRegistry) (Rel, error) {
 		out := &JoinRel{
 			left:         left,
 			right:        right,
-			joinType:     rel.Join.Type,
+			joinType:     JoinType(rel.Join.Type),
 			advExtension: rel.Join.AdvancedExtension,
 		}
 		out.fromProtoCommon(rel.Join.Common)

--- a/plan/relations.go
+++ b/plan/relations.go
@@ -793,21 +793,58 @@ func (p *ProjectRel) Remap(mapping ...int32) (Rel, error) {
 
 var defFilter = expr.NewPrimitiveLiteral(true, false)
 
-type JoinType = proto.JoinRel_JoinType
+// JoinType indicates the semantics of a JoinRel (inner, outer, semi, etc.).
+type JoinType int32
 
 const (
-	JoinTypeUnspecified = proto.JoinRel_JOIN_TYPE_UNSPECIFIED
-	JoinTypeInner       = proto.JoinRel_JOIN_TYPE_INNER
-	JoinTypeOuter       = proto.JoinRel_JOIN_TYPE_OUTER
-	JoinTypeLeft        = proto.JoinRel_JOIN_TYPE_LEFT
-	JoinTypeRight       = proto.JoinRel_JOIN_TYPE_RIGHT
-	JoinTypeLeftSemi    = proto.JoinRel_JOIN_TYPE_LEFT_SEMI
-	JoinTypeLeftAnti    = proto.JoinRel_JOIN_TYPE_LEFT_ANTI
-	JoinTypeLeftSingle  = proto.JoinRel_JOIN_TYPE_LEFT_SINGLE
-	JoinTypeRightSemi   = proto.JoinRel_JOIN_TYPE_RIGHT_SEMI
-	JoinTypeRightAnti   = proto.JoinRel_JOIN_TYPE_RIGHT_ANTI
-	JoinTypeRightSingle = proto.JoinRel_JOIN_TYPE_RIGHT_SINGLE
+	JoinTypeUnspecified JoinType = 0
+	JoinTypeInner       JoinType = 1
+	JoinTypeOuter       JoinType = 2
+	JoinTypeLeft        JoinType = 3
+	JoinTypeRight       JoinType = 4
+	JoinTypeLeftSemi    JoinType = 5
+	JoinTypeLeftAnti    JoinType = 6
+	JoinTypeLeftSingle  JoinType = 7
+	JoinTypeRightSemi   JoinType = 8
+	JoinTypeRightAnti   JoinType = 9
+	JoinTypeRightSingle JoinType = 10
+	JoinTypeLeftMark    JoinType = 11
+	JoinTypeRightMark   JoinType = 12
 )
+
+// String returns the protobuf enum name for the join type.
+func (j JoinType) String() string {
+	switch j {
+	case JoinTypeUnspecified:
+		return "JOIN_TYPE_UNSPECIFIED"
+	case JoinTypeInner:
+		return "JOIN_TYPE_INNER"
+	case JoinTypeOuter:
+		return "JOIN_TYPE_OUTER"
+	case JoinTypeLeft:
+		return "JOIN_TYPE_LEFT"
+	case JoinTypeRight:
+		return "JOIN_TYPE_RIGHT"
+	case JoinTypeLeftSemi:
+		return "JOIN_TYPE_LEFT_SEMI"
+	case JoinTypeLeftAnti:
+		return "JOIN_TYPE_LEFT_ANTI"
+	case JoinTypeLeftSingle:
+		return "JOIN_TYPE_LEFT_SINGLE"
+	case JoinTypeRightSemi:
+		return "JOIN_TYPE_RIGHT_SEMI"
+	case JoinTypeRightAnti:
+		return "JOIN_TYPE_RIGHT_ANTI"
+	case JoinTypeRightSingle:
+		return "JOIN_TYPE_RIGHT_SINGLE"
+	case JoinTypeLeftMark:
+		return "JOIN_TYPE_LEFT_MARK"
+	case JoinTypeRightMark:
+		return "JOIN_TYPE_RIGHT_MARK"
+	default:
+		return strconv.Itoa(int(j))
+	}
+}
 
 // JoinRel is a binary Join relational operator representing left-join-right,
 // including various join types, a join condition and a post join filter expr.
@@ -891,7 +928,7 @@ func (j *JoinRel) ToProto() *proto.Rel {
 		Left:              j.left.ToProto(),
 		Right:             j.right.ToProto(),
 		Expression:        j.expr.ToProto(),
-		Type:              j.joinType,
+		Type:              proto.JoinRel_JoinType(j.joinType),
 		AdvancedExtension: j.advExtension,
 	}
 


### PR DESCRIPTION
`plan.JoinType` was `= proto.JoinRel_JoinType`, so the generated enum was substrait-go's public API. It becomes substrait-go's own `int32` with the same constant names and the same wire numbers and a hand-written `String()`, casting at the proto boundaries, so consumers still compile.

BREAKING CHANGE: `plan.JoinType` is no longer an alias for `proto.JoinRel_JoinType`; its constants are now typed `JoinType` values. Code that passes one where the other is expected needs a cast.

Part of #280.
