### PR TITLE
feat(type)!: make BoundsType a domain enum

### DIFF
--- a/expr/expression.go
+++ b/expr/expression.go
@@ -134,7 +134,7 @@ func ExprFromProto(e *proto.Expression, baseSchema *types.RecordType, reg Extens
 			fn.Partitions = parts
 			fn.Sorts = sorts
 			fn.LowerBound = BoundFromProto(et.WindowFunction.LowerBound)
-			fn.BoundsType = et.WindowFunction.BoundsType
+			fn.BoundsType = types.BoundsType(et.WindowFunction.BoundsType)
 			fn.UpperBound = BoundFromProto(et.WindowFunction.UpperBound)
 			return fn, nil
 		}
@@ -149,7 +149,7 @@ func ExprFromProto(e *proto.Expression, baseSchema *types.RecordType, reg Extens
 			invocation:  et.WindowFunction.Invocation,
 			Partitions:  parts,
 			Sorts:       sorts,
-			BoundsType:  et.WindowFunction.BoundsType,
+			BoundsType:  types.BoundsType(et.WindowFunction.BoundsType),
 			LowerBound:  BoundFromProto(et.WindowFunction.LowerBound),
 			UpperBound:  BoundFromProto(et.WindowFunction.UpperBound),
 		}, nil

--- a/expr/functions.go
+++ b/expr/functions.go
@@ -719,7 +719,7 @@ func (w *WindowFunction) ToProto() *proto.Expression {
 				Sorts:             sorts,
 				Invocation:        w.invocation,
 				Partitions:        parts,
-				BoundsType:        w.BoundsType,
+				BoundsType:        proto.Expression_WindowFunction_BoundsType(w.BoundsType),
 				LowerBound:        lowerBound,
 				UpperBound:        upperBound,
 			},

--- a/types/bounds_type_test.go
+++ b/types/bounds_type_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package types_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/substrait-io/substrait-go/v9/types"
+	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
+)
+
+func TestBoundsTypeString(t *testing.T) {
+	for _, td := range []struct {
+		b        types.BoundsType
+		expected string
+	}{
+		{types.BoundsTypeUnspecified, "BOUNDS_TYPE_UNSPECIFIED"},
+		{types.BoundsTypeRows, "BOUNDS_TYPE_ROWS"},
+		{types.BoundsTypeRange, "BOUNDS_TYPE_RANGE"},
+		{types.BoundsType(99), "99"},
+	} {
+		t.Run(td.expected, func(t *testing.T) {
+			assert.Equal(t, td.expected, td.b.String())
+			assert.Equal(t, td.expected, fmt.Sprintf("%v", td.b))
+		})
+	}
+}
+
+func TestBoundsTypeMatchesProto(t *testing.T) {
+	cases := []struct {
+		domain types.BoundsType
+		pb     proto.Expression_WindowFunction_BoundsType
+	}{
+		{types.BoundsTypeUnspecified, proto.Expression_WindowFunction_BOUNDS_TYPE_UNSPECIFIED},
+		{types.BoundsTypeRows, proto.Expression_WindowFunction_BOUNDS_TYPE_ROWS},
+		{types.BoundsTypeRange, proto.Expression_WindowFunction_BOUNDS_TYPE_RANGE},
+	}
+	// fail if the spec adds a value we don't mirror
+	assert.Equal(t, proto.Expression_WindowFunction_BOUNDS_TYPE_UNSPECIFIED.Descriptor().Values().Len(), len(cases),
+		"a proto bounds type value is not covered")
+	for _, td := range cases {
+		assert.EqualValues(t, td.pb, td.domain, "wire number for %s", td.pb)
+		assert.Equal(t, td.pb.String(), td.domain.String(), "enum name for %s", td.pb)
+	}
+}

--- a/types/types.go
+++ b/types/types.go
@@ -221,13 +221,28 @@ const (
 	AggInvocationDistinct    = proto.AggregateFunction_AGGREGATION_INVOCATION_DISTINCT
 )
 
-type BoundsType = proto.Expression_WindowFunction_BoundsType
+// BoundsType indicates whether a window frame's bounds are measured in rows or in a range of values.
+type BoundsType int32
 
 const (
-	BoundsTypeUnspecified = proto.Expression_WindowFunction_BOUNDS_TYPE_UNSPECIFIED
-	BoundsTypeRows        = proto.Expression_WindowFunction_BOUNDS_TYPE_ROWS
-	BoundsTypeRange       = proto.Expression_WindowFunction_BOUNDS_TYPE_RANGE
+	BoundsTypeUnspecified BoundsType = 0
+	BoundsTypeRows        BoundsType = 1
+	BoundsTypeRange       BoundsType = 2
 )
+
+// String returns the protobuf enum name for the bounds type.
+func (b BoundsType) String() string {
+	switch b {
+	case BoundsTypeUnspecified:
+		return "BOUNDS_TYPE_UNSPECIFIED"
+	case BoundsTypeRows:
+		return "BOUNDS_TYPE_ROWS"
+	case BoundsTypeRange:
+		return "BOUNDS_TYPE_RANGE"
+	default:
+		return strconv.Itoa(int(b))
+	}
+}
 
 type SortDirection int32
 


### PR DESCRIPTION
`types.BoundsType` was `= proto.Expression_WindowFunction_BoundsType`, so the generated enum was substrait-go's public API. It becomes substrait-go's own `int32` with the same constant names and the same wire numbers plus a hand-written `String()`, casting at the proto boundaries, so consumers still compile.

BREAKING CHANGE: `types.BoundsType` is no longer an alias for `proto.Expression_WindowFunction_BoundsType`; its constants are now typed `BoundsType` values. Code that passes one where the other is expected needs a cast.

Part of #280.