### PR TITLE
feat(type)!: make IntervalYearToMonth a domain struct

### DIFF
--- a/expr/literals.go
+++ b/expr/literals.go
@@ -538,9 +538,9 @@ func (t *ProtoLiteral) ValueString() string {
 	case *types.DecimalType:
 		return decimalBytesToString([16]byte(t.Value.([]byte)), literalType.Scale)
 	case *types.IntervalYearType:
-		x, _ := t.Value.(*proto.Expression_Literal_IntervalYearToMonth)
+		x, _ := t.Value.(*types.IntervalYearToMonth)
 		// Validity is required by construction.
-		return fmt.Sprintf("%d years, %d months", x.GetYears(), x.GetMonths())
+		return fmt.Sprintf("%d years, %d months", x.Years, x.Months)
 	case *types.IntervalDayType:
 		x, _ := t.Value.(*proto.Expression_Literal_IntervalDayToSecond)
 		// Validity is required by construction.
@@ -562,9 +562,9 @@ func (t *ProtoLiteral) IsoValueString() string {
 		tm := types.TimestampTz(t.Value.(int64)).ToPrecisionTime(literalType.Precision)
 		return tm.UTC().Format("2006-01-02T15:04:05.000-07:00")
 	case *types.IntervalYearType:
-		x, _ := t.Value.(*proto.Expression_Literal_IntervalYearToMonth)
+		x, _ := t.Value.(*types.IntervalYearToMonth)
 		// Validity is required by construction.
-		return fmt.Sprintf("P%dY%dM", x.GetYears(), x.GetMonths())
+		return fmt.Sprintf("P%dY%dM", x.Years, x.Months)
 	case *types.IntervalDayType:
 		x, _ := t.Value.(*proto.Expression_Literal_IntervalDayToSecond)
 		// Validity is required by construction.
@@ -622,7 +622,10 @@ func (t *ProtoLiteral) ToProtoLiteral() *proto.Expression_Literal {
 	case *types.IntervalYearType:
 		v := t.Value.(*types.IntervalYearToMonth)
 		lit.LiteralType = &proto.Expression_Literal_IntervalYearToMonth_{
-			IntervalYearToMonth: v,
+			IntervalYearToMonth: &proto.Expression_Literal_IntervalYearToMonth{
+				Years:  v.Years,
+				Months: v.Months,
+			},
 		}
 	case *types.IntervalDayType:
 		v := t.Value.(*types.IntervalDayToSecond)
@@ -938,6 +941,9 @@ func NewLiteral[T allLiteralTypes](val T, nullable bool) (Literal, error) {
 	case MapLiteralValue:
 		return NewNestedLiteral(v, nullable), nil
 	case *types.IntervalYearToMonth:
+		if v == nil {
+			return nil, fmt.Errorf("interval year to month value must not be nil")
+		}
 		return &ProtoLiteral{
 			Value: v,
 			Type: &types.IntervalYearType{

--- a/expr/literals_test.go
+++ b/expr/literals_test.go
@@ -91,6 +91,20 @@ func TestNewLiteralWithIntervalDayToSecondPrecisionSet(t *testing.T) {
 	}
 }
 
+func TestNewLiteralWithIntervalYearToMonth(t *testing.T) {
+	_, err := expr.NewLiteral((*types.IntervalYearToMonth)(nil), false)
+	require.Error(t, err)
+
+	lit, err := expr.NewLiteral(&types.IntervalYearToMonth{Years: 1, Months: 2}, false)
+	require.NoError(t, err)
+	assert.Equal(t, "1 years, 2 months", lit.ValueString())
+	assert.Equal(t, "P1Y2M", lit.(types.IsoValuePrinter).IsoValueString())
+
+	pb := lit.ToProtoLiteral().GetIntervalYearToMonth()
+	assert.Equal(t, int32(1), pb.GetYears())
+	assert.Equal(t, int32(2), pb.GetMonths())
+}
+
 func TestNewFixedLenWithType(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/types/interval_year_to_month_literal_test.go
+++ b/types/interval_year_to_month_literal_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package types_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/substrait-io/substrait-go/v9/types"
+	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+func TestIntervalYearToMonthMatchesDescriptor(t *testing.T) {
+	want := map[protoreflect.Name]struct {
+		number protoreflect.FieldNumber
+		kind   protoreflect.Kind
+	}{
+		"years":  {1, protoreflect.Int32Kind},
+		"months": {2, protoreflect.Int32Kind},
+	}
+
+	fields := (&proto.Expression_Literal_IntervalYearToMonth{}).ProtoReflect().Descriptor().Fields()
+	require.Equal(t, len(want), fields.Len(), "spec interval_year_to_month field set changed")
+	require.Equal(t, len(want), reflect.TypeOf(types.IntervalYearToMonth{}).NumField(), "types.IntervalYearToMonth field count drifted from the spec")
+
+	for i := 0; i < fields.Len(); i++ {
+		f := fields.Get(i)
+		w, ok := want[f.Name()]
+		require.Truef(t, ok, "unexpected spec field %q", f.Name())
+		assert.EqualValues(t, w.number, f.Number(), "%s wire number", f.Name())
+		assert.Equal(t, w.kind, f.Kind(), "%s kind", f.Name())
+	}
+}

--- a/types/types.go
+++ b/types/types.go
@@ -292,7 +292,6 @@ func (b CastFailBehavior) String() string {
 }
 
 type (
-	IntervalYearToMonth  = proto.Expression_Literal_IntervalYearToMonth
 	IntervalDayToSecond  = proto.Expression_Literal_IntervalDayToSecond
 	UserDefinedLiteral   = proto.Expression_Literal_UserDefined
 	PrecisionTime        = proto.Expression_Literal_PrecisionTime
@@ -313,6 +312,13 @@ type Decimal struct {
 	Value     []byte
 	Precision int32
 	Scale     int32
+}
+
+// IntervalYearToMonth is an interval literal expressed in years and months, mirroring the
+// fields of the Substrait IntervalYearToMonth literal message.
+type IntervalYearToMonth struct {
+	Years  int32
+	Months int32
 }
 
 // TypeFromProto returns the appropriate Type object from a protobuf


### PR DESCRIPTION
`types.IntervalYearToMonth` was `= proto.Expression_Literal_IntervalYearToMonth`, so the generated protobuf message was substrait-go's public API. It becomes a small substrait-go struct with the same `Years`/`Months` fields, converting to and from the protobuf message at the boundaries, so consumers still compile.

BREAKING CHANGE: `types.IntervalYearToMonth` is no longer an alias for `proto.Expression_Literal_IntervalYearToMonth`; it is now a plain struct. Code that passed the protobuf message where the alias was expected needs to construct the struct instead.

Part of #280.