### PR TITLE
feat(plan)!: make SetOp a domain enum

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -731,7 +731,7 @@ func RelFromProto(rel *proto.Rel, reg expr.ExtensionRegistry) (Rel, error) {
 			}
 		}
 
-		if rel.Set.Op == SetOpUnspecified {
+		if SetOp(rel.Set.Op) == SetOpUnspecified {
 			return nil, fmt.Errorf("%w: set operation must not be unspecified", substraitgo.ErrInvalidRel)
 		}
 
@@ -746,7 +746,7 @@ func RelFromProto(rel *proto.Rel, reg expr.ExtensionRegistry) (Rel, error) {
 
 		out := &SetRel{
 			inputs:       inputs,
-			op:           rel.Set.Op,
+			op:           SetOp(rel.Set.Op),
 			advExtension: rel.Set.AdvancedExtension,
 		}
 		out.fromProtoCommon(rel.Set.Common)

--- a/plan/relations.go
+++ b/plan/relations.go
@@ -1522,17 +1522,46 @@ func (fr *FilterRel) Remap(mapping ...int32) (Rel, error) {
 	return RemapHelper(fr, mapping)
 }
 
-type SetOp = proto.SetRel_SetOp
+// SetOp identifies the relational set operator applied by a SetRel.
+type SetOp int32
 
 const (
-	SetOpUnspecified          = proto.SetRel_SET_OP_UNSPECIFIED
-	SetOpMinusPrimary         = proto.SetRel_SET_OP_MINUS_PRIMARY
-	SetOpMinusMultiset        = proto.SetRel_SET_OP_MINUS_MULTISET
-	SetOpIntersectionPrimary  = proto.SetRel_SET_OP_INTERSECTION_PRIMARY
-	SetOpIntersectionMultiset = proto.SetRel_SET_OP_INTERSECTION_MULTISET
-	SetOpUnionDistinct        = proto.SetRel_SET_OP_UNION_DISTINCT
-	SetOpUnionAll             = proto.SetRel_SET_OP_UNION_ALL
+	SetOpUnspecified             SetOp = 0
+	SetOpMinusPrimary            SetOp = 1
+	SetOpMinusMultiset           SetOp = 2
+	SetOpIntersectionPrimary     SetOp = 3
+	SetOpIntersectionMultiset    SetOp = 4
+	SetOpUnionDistinct           SetOp = 5
+	SetOpUnionAll                SetOp = 6
+	SetOpMinusPrimaryAll         SetOp = 7
+	SetOpIntersectionMultisetAll SetOp = 8
 )
+
+// String returns the protobuf enum name for the set operation.
+func (o SetOp) String() string {
+	switch o {
+	case SetOpUnspecified:
+		return "SET_OP_UNSPECIFIED"
+	case SetOpMinusPrimary:
+		return "SET_OP_MINUS_PRIMARY"
+	case SetOpMinusMultiset:
+		return "SET_OP_MINUS_MULTISET"
+	case SetOpIntersectionPrimary:
+		return "SET_OP_INTERSECTION_PRIMARY"
+	case SetOpIntersectionMultiset:
+		return "SET_OP_INTERSECTION_MULTISET"
+	case SetOpUnionDistinct:
+		return "SET_OP_UNION_DISTINCT"
+	case SetOpUnionAll:
+		return "SET_OP_UNION_ALL"
+	case SetOpMinusPrimaryAll:
+		return "SET_OP_MINUS_PRIMARY_ALL"
+	case SetOpIntersectionMultisetAll:
+		return "SET_OP_INTERSECTION_MULTISET_ALL"
+	default:
+		return strconv.Itoa(int(o))
+	}
+}
 
 // SetRel represents the relational set operators (intersection, union, etc.)
 type SetRel struct {
@@ -1568,7 +1597,7 @@ func (s *SetRel) ToProto() *proto.Rel {
 			Set: &proto.SetRel{
 				Common:            s.toProto(),
 				Inputs:            inputs,
-				Op:                s.op,
+				Op:                proto.SetRel_SetOp(s.op),
 				AdvancedExtension: s.advExtension,
 			},
 		},

--- a/plan/set_op_test.go
+++ b/plan/set_op_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package plan_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/substrait-io/substrait-go/v9/plan"
+	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
+)
+
+func TestSetOpString(t *testing.T) {
+	for _, td := range []struct {
+		o        plan.SetOp
+		expected string
+	}{
+		{plan.SetOpUnspecified, "SET_OP_UNSPECIFIED"},
+		{plan.SetOpMinusPrimary, "SET_OP_MINUS_PRIMARY"},
+		{plan.SetOpMinusMultiset, "SET_OP_MINUS_MULTISET"},
+		{plan.SetOpIntersectionPrimary, "SET_OP_INTERSECTION_PRIMARY"},
+		{plan.SetOpIntersectionMultiset, "SET_OP_INTERSECTION_MULTISET"},
+		{plan.SetOpUnionDistinct, "SET_OP_UNION_DISTINCT"},
+		{plan.SetOpUnionAll, "SET_OP_UNION_ALL"},
+		{plan.SetOpMinusPrimaryAll, "SET_OP_MINUS_PRIMARY_ALL"},
+		{plan.SetOpIntersectionMultisetAll, "SET_OP_INTERSECTION_MULTISET_ALL"},
+	} {
+		t.Run(td.expected, func(t *testing.T) {
+			assert.Equal(t, td.expected, td.o.String())
+			assert.Equal(t, td.expected, fmt.Sprintf("%v", td.o))
+		})
+	}
+}
+
+func TestSetOpMatchesProto(t *testing.T) {
+	cases := []struct {
+		domain plan.SetOp
+		pb     proto.SetRel_SetOp
+	}{
+		{plan.SetOpUnspecified, proto.SetRel_SET_OP_UNSPECIFIED},
+		{plan.SetOpMinusPrimary, proto.SetRel_SET_OP_MINUS_PRIMARY},
+		{plan.SetOpMinusMultiset, proto.SetRel_SET_OP_MINUS_MULTISET},
+		{plan.SetOpIntersectionPrimary, proto.SetRel_SET_OP_INTERSECTION_PRIMARY},
+		{plan.SetOpIntersectionMultiset, proto.SetRel_SET_OP_INTERSECTION_MULTISET},
+		{plan.SetOpUnionDistinct, proto.SetRel_SET_OP_UNION_DISTINCT},
+		{plan.SetOpUnionAll, proto.SetRel_SET_OP_UNION_ALL},
+		{plan.SetOpMinusPrimaryAll, proto.SetRel_SET_OP_MINUS_PRIMARY_ALL},
+		{plan.SetOpIntersectionMultisetAll, proto.SetRel_SET_OP_INTERSECTION_MULTISET_ALL},
+	}
+	// fail if the spec adds a value we don't mirror
+	assert.Equal(t, proto.SetRel_SET_OP_UNSPECIFIED.Descriptor().Values().Len(), len(cases),
+		"a proto set operation value is not covered")
+	for _, td := range cases {
+		assert.EqualValues(t, td.pb, td.domain, "wire number for %s", td.pb)
+		assert.Equal(t, td.pb.String(), td.domain.String(), "enum name for %s", td.pb)
+	}
+}


### PR DESCRIPTION
`plan.SetOp` was `= proto.SetRel_SetOp`, so the generated enum was substrait-go's public API. It becomes substrait-go's own `int32` with the same constant names and the same wire numbers plus a hand-written `String()`, casting at the proto boundaries, so consumers still compile. This also adds `SetOpMinusPrimaryAll` and `SetOpIntersectionMultisetAll`, which the alias's constant list omitted.

BREAKING CHANGE: `plan.SetOp` is no longer an alias for `proto.SetRel_SetOp`; its constants are now typed `SetOp` values. Code that passes one where the other is expected needs a cast.

Part of #280.