### PR TITLE
feat(type)!: make IntervalDayToSecond a domain type

### DIFF
--- a/expr/literals.go
+++ b/expr/literals.go
@@ -750,7 +750,7 @@ func newPrecisionTimestampTzWithType(literal *ProtoLiteral, ptstzType *types.Pre
 func newIntervalDayWithType(literal *ProtoLiteral, intervalDayType *types.IntervalDayType) (Literal, error) {
 	if _, ok := literal.GetType().(*types.IntervalDayType); ok {
 		intervalValue := literal.Value.(*types.IntervalDayToSecond)
-		precisionDiff := intervalValue.GetPrecision() - intervalDayType.Precision.ToProtoVal()
+		precisionDiff := intervalValue.Precision.ToProtoVal() - intervalDayType.Precision.ToProtoVal()
 		ss := intervalValue.Subseconds
 		if precisionDiff != 0 {
 			factor := int64(math.Pow10(int(math.Abs(float64(precisionDiff)))))
@@ -956,7 +956,7 @@ func NewLiteral[T allLiteralTypes](val T, nullable bool) (Literal, error) {
 			Value: v,
 			Type: &types.IntervalDayType{
 				Nullability: getNullability(nullable),
-				Precision:   types.TimePrecision(v.GetPrecision()),
+				Precision:   v.Precision,
 			},
 		}, nil
 	case *types.Decimal:
@@ -1096,7 +1096,7 @@ func LiteralFromProto(l *proto.Expression_Literal) Literal {
 			}}
 	case *proto.Expression_Literal_IntervalDayToSecond_:
 		value := types.IntervalDayToSecondFromProto(lit.IntervalDayToSecond)
-		precision, err := types.ProtoToTimePrecision(value.GetPrecision())
+		precision, err := types.ProtoToTimePrecision(value.GetPrecisionProtoVal())
 		if err != nil {
 			return nil
 		}

--- a/expr/literals.go
+++ b/expr/literals.go
@@ -542,9 +542,9 @@ func (t *ProtoLiteral) ValueString() string {
 		// Validity is required by construction.
 		return fmt.Sprintf("%d years, %d months", x.Years, x.Months)
 	case *types.IntervalDayType:
-		x, _ := t.Value.(*proto.Expression_Literal_IntervalDayToSecond)
+		x, _ := t.Value.(*types.IntervalDayToSecond)
 		// Validity is required by construction.
-		return fmt.Sprintf("%d days, %d seconds, %d subseconds", x.GetDays(), x.GetSeconds(), x.GetSubseconds())
+		return fmt.Sprintf("%d days, %d seconds, %d subseconds", x.Days, x.Seconds, x.Subseconds)
 	}
 	return fmt.Sprintf("%s", t.Value)
 }
@@ -566,17 +566,17 @@ func (t *ProtoLiteral) IsoValueString() string {
 		// Validity is required by construction.
 		return fmt.Sprintf("P%dY%dM", x.Years, x.Months)
 	case *types.IntervalDayType:
-		x, _ := t.Value.(*proto.Expression_Literal_IntervalDayToSecond)
+		x, _ := t.Value.(*types.IntervalDayToSecond)
 		// Validity is required by construction.
 		sb := strings.Builder{}
 		sb.WriteString("P")
-		if x.GetDays() > 0 {
-			sb.WriteString(fmt.Sprintf("%dD", x.GetDays()))
+		if x.Days > 0 {
+			sb.WriteString(fmt.Sprintf("%dD", x.Days))
 		}
-		if x.GetSeconds() > 0 || x.GetSubseconds() > 0 {
+		if x.Seconds > 0 || x.Subseconds > 0 {
 			sb.WriteString("T")
-			duration := time.Duration(x.GetSeconds()) * time.Second
-			duration += types.SubSecondsToDuration(x.GetSubseconds(), literalType.Precision)
+			duration := time.Duration(x.Seconds) * time.Second
+			duration += types.SubSecondsToDuration(x.Subseconds, literalType.Precision)
 			sb.WriteString(strings.ToUpper(duration.String()))
 		}
 		return sb.String()
@@ -630,7 +630,7 @@ func (t *ProtoLiteral) ToProtoLiteral() *proto.Expression_Literal {
 	case *types.IntervalDayType:
 		v := t.Value.(*types.IntervalDayToSecond)
 		lit.LiteralType = &proto.Expression_Literal_IntervalDayToSecond_{
-			IntervalDayToSecond: v,
+			IntervalDayToSecond: types.IntervalDayToSecondToProto(v),
 		}
 	case *types.VarCharType:
 		v := t.Value.(string)
@@ -749,9 +749,9 @@ func newPrecisionTimestampTzWithType(literal *ProtoLiteral, ptstzType *types.Pre
 
 func newIntervalDayWithType(literal *ProtoLiteral, intervalDayType *types.IntervalDayType) (Literal, error) {
 	if _, ok := literal.GetType().(*types.IntervalDayType); ok {
-		intervalValue := literal.Value.(*proto.Expression_Literal_IntervalDayToSecond)
+		intervalValue := literal.Value.(*types.IntervalDayToSecond)
 		precisionDiff := intervalValue.GetPrecision() - intervalDayType.Precision.ToProtoVal()
-		ss := intervalValue.GetSubseconds()
+		ss := intervalValue.Subseconds
 		if precisionDiff != 0 {
 			factor := int64(math.Pow10(int(math.Abs(float64(precisionDiff)))))
 			if precisionDiff > 0 {
@@ -762,12 +762,10 @@ func newIntervalDayWithType(literal *ProtoLiteral, intervalDayType *types.Interv
 		}
 		return &ProtoLiteral{
 			Value: &types.IntervalDayToSecond{
-				Days:       intervalValue.GetDays(),
-				Seconds:    intervalValue.GetSeconds(),
-				Subseconds: ss,
-				PrecisionMode: &proto.Expression_Literal_IntervalDayToSecond_Precision{
-					Precision: intervalDayType.Precision.ToProtoVal(),
-				},
+				Days:          intervalValue.Days,
+				Seconds:       intervalValue.Seconds,
+				Subseconds:    ss,
+				PrecisionMode: types.IntervalDayToSecondPrecision(intervalDayType.Precision.ToProtoVal()),
 			}, Type: intervalDayType,
 		}, nil
 	}
@@ -951,6 +949,9 @@ func NewLiteral[T allLiteralTypes](val T, nullable bool) (Literal, error) {
 			},
 		}, nil
 	case *types.IntervalDayToSecond:
+		if v == nil {
+			return nil, fmt.Errorf("interval day to second value must not be nil")
+		}
 		return &ProtoLiteral{
 			Value: v,
 			Type: &types.IntervalDayType{
@@ -1104,7 +1105,7 @@ func LiteralFromProto(l *proto.Expression_Literal) Literal {
 			}
 		}
 		return &ProtoLiteral{
-			Value: lit.IntervalDayToSecond,
+			Value: types.IntervalDayToSecondFromProto(lit.IntervalDayToSecond),
 			Type: &types.IntervalDayType{
 				Precision:        precision,
 				Nullability:      nullability,

--- a/expr/literals.go
+++ b/expr/literals.go
@@ -1095,17 +1095,13 @@ func LiteralFromProto(l *proto.Expression_Literal) Literal {
 				Nullability:      nullability,
 			}}
 	case *proto.Expression_Literal_IntervalDayToSecond_:
-		precision := types.PrecisionMicroSeconds
-		switch lit.IntervalDayToSecond.PrecisionMode.(type) {
-		case *proto.Expression_Literal_IntervalDayToSecond_Precision:
-			var err error
-			precision, err = types.ProtoToTimePrecision(lit.IntervalDayToSecond.GetPrecision())
-			if err != nil {
-				return nil
-			}
+		value := types.IntervalDayToSecondFromProto(lit.IntervalDayToSecond)
+		precision, err := types.ProtoToTimePrecision(value.GetPrecision())
+		if err != nil {
+			return nil
 		}
 		return &ProtoLiteral{
-			Value: types.IntervalDayToSecondFromProto(lit.IntervalDayToSecond),
+			Value: value,
 			Type: &types.IntervalDayType{
 				Precision:        precision,
 				Nullability:      nullability,

--- a/expr/literals.go
+++ b/expr/literals.go
@@ -762,10 +762,10 @@ func newIntervalDayWithType(literal *ProtoLiteral, intervalDayType *types.Interv
 		}
 		return &ProtoLiteral{
 			Value: &types.IntervalDayToSecond{
-				Days:          intervalValue.Days,
-				Seconds:       intervalValue.Seconds,
-				Subseconds:    ss,
-				PrecisionMode: types.IntervalDayToSecondPrecision(intervalDayType.Precision.ToProtoVal()),
+				Days:       intervalValue.Days,
+				Seconds:    intervalValue.Seconds,
+				Subseconds: ss,
+				Precision:  intervalDayType.Precision,
 			}, Type: intervalDayType,
 		}, nil
 	}

--- a/expr/literals_test.go
+++ b/expr/literals_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/substrait-io/substrait-go/v9/expr"
 	"github.com/substrait-io/substrait-go/v9/literal"
 	"github.com/substrait-io/substrait-go/v9/types"
-	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
 )
 
 func TestNewDecimalWithType(t *testing.T) {
@@ -103,6 +102,23 @@ func TestNewLiteralWithIntervalYearToMonth(t *testing.T) {
 	pb := lit.ToProtoLiteral().GetIntervalYearToMonth()
 	assert.Equal(t, int32(1), pb.GetYears())
 	assert.Equal(t, int32(2), pb.GetMonths())
+}
+
+func TestNewLiteralWithIntervalDayToSecond(t *testing.T) {
+	_, err := expr.NewLiteral((*types.IntervalDayToSecond)(nil), false)
+	require.Error(t, err)
+
+	v := &types.IntervalDayToSecond{Days: 1, Seconds: 2, Subseconds: 3, PrecisionMode: types.IntervalDayToSecondPrecision(6)}
+	lit, err := expr.NewLiteral(v, false)
+	require.NoError(t, err)
+	assert.Equal(t, "1 days, 2 seconds, 3 subseconds", lit.ValueString())
+	assert.Equal(t, "P1DT2.000003S", lit.(types.IsoValuePrinter).IsoValueString())
+
+	pb := lit.ToProtoLiteral().GetIntervalDayToSecond()
+	assert.Equal(t, int32(1), pb.GetDays())
+	assert.Equal(t, int32(2), pb.GetSeconds())
+	assert.Equal(t, int64(3), pb.GetSubseconds())
+	assert.Equal(t, int32(6), pb.GetPrecision())
 }
 
 func TestNewFixedLenWithType(t *testing.T) {
@@ -235,9 +251,9 @@ func TestNewIntervalDayWithType(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tt.inputType, got.GetType())
 			assert.Equal(t, tt.expLiteralString, got.(types.IsoValuePrinter).IsoValueString())
-			iday := got.(*expr.ProtoLiteral).Value.(*proto.Expression_Literal_IntervalDayToSecond)
+			iday := got.(*expr.ProtoLiteral).Value.(*types.IntervalDayToSecond)
 			assert.Equal(t, tt.inputType.Precision.ToProtoVal(), iday.GetPrecision())
-			assert.Equal(t, tt.expSubSeconds, iday.GetSubseconds())
+			assert.Equal(t, tt.expSubSeconds, iday.Subseconds)
 		})
 	}
 }

--- a/expr/literals_test.go
+++ b/expr/literals_test.go
@@ -252,7 +252,7 @@ func TestNewIntervalDayWithType(t *testing.T) {
 			assert.Equal(t, tt.inputType, got.GetType())
 			assert.Equal(t, tt.expLiteralString, got.(types.IsoValuePrinter).IsoValueString())
 			iday := got.(*expr.ProtoLiteral).Value.(*types.IntervalDayToSecond)
-			assert.Equal(t, tt.inputType.Precision.ToProtoVal(), iday.GetPrecision())
+			assert.Equal(t, tt.inputType.Precision.ToProtoVal(), iday.GetPrecisionProtoVal())
 			assert.Equal(t, tt.expSubSeconds, iday.Subseconds)
 		})
 	}

--- a/expr/literals_test.go
+++ b/expr/literals_test.go
@@ -108,7 +108,7 @@ func TestNewLiteralWithIntervalDayToSecond(t *testing.T) {
 	_, err := expr.NewLiteral((*types.IntervalDayToSecond)(nil), false)
 	require.Error(t, err)
 
-	v := &types.IntervalDayToSecond{Days: 1, Seconds: 2, Subseconds: 3, PrecisionMode: types.IntervalDayToSecondPrecision(6)}
+	v := &types.IntervalDayToSecond{Days: 1, Seconds: 2, Subseconds: 3, Precision: types.PrecisionMicroSeconds}
 	lit, err := expr.NewLiteral(v, false)
 	require.NoError(t, err)
 	assert.Equal(t, "1 days, 2 seconds, 3 subseconds", lit.ValueString())

--- a/expr/proto_literals_test.go
+++ b/expr/proto_literals_test.go
@@ -95,7 +95,7 @@ func TestLiteralFromProtoLiteral(t *testing.T) {
 		},
 		{"IntervalDayType",
 			&proto.Expression_Literal{LiteralType: &proto.Expression_Literal_IntervalDayToSecond_{IntervalDayToSecond: intDayToSecVal}, Nullable: true},
-			&ProtoLiteral{Value: &types.IntervalDayToSecond{Days: 1, Seconds: 2, PrecisionMode: types.IntervalDayToSecondPrecision(5)}, Type: &types.IntervalDayType{Precision: types.PrecisionEMinus5Seconds, Nullability: types.NullabilityNullable}},
+			&ProtoLiteral{Value: &types.IntervalDayToSecond{Days: 1, Seconds: 2, Precision: types.PrecisionEMinus5Seconds}, Type: &types.IntervalDayType{Precision: types.PrecisionEMinus5Seconds, Nullability: types.NullabilityNullable}},
 		},
 		{"IntervalYearToMonthType",
 			&proto.Expression_Literal{LiteralType: &proto.Expression_Literal_IntervalYearToMonth_{IntervalYearToMonth: &proto.Expression_Literal_IntervalYearToMonth{Years: 1234, Months: 5}}, Nullable: true},

--- a/expr/proto_literals_test.go
+++ b/expr/proto_literals_test.go
@@ -95,7 +95,7 @@ func TestLiteralFromProtoLiteral(t *testing.T) {
 		},
 		{"IntervalDayType",
 			&proto.Expression_Literal{LiteralType: &proto.Expression_Literal_IntervalDayToSecond_{IntervalDayToSecond: intDayToSecVal}, Nullable: true},
-			&ProtoLiteral{Value: intDayToSecVal, Type: &types.IntervalDayType{Precision: types.PrecisionEMinus5Seconds, Nullability: types.NullabilityNullable}},
+			&ProtoLiteral{Value: &types.IntervalDayToSecond{Days: 1, Seconds: 2, PrecisionMode: types.IntervalDayToSecondPrecision(5)}, Type: &types.IntervalDayType{Precision: types.PrecisionEMinus5Seconds, Nullability: types.NullabilityNullable}},
 		},
 		{"IntervalYearToMonthType",
 			&proto.Expression_Literal{LiteralType: &proto.Expression_Literal_IntervalYearToMonth_{IntervalYearToMonth: &proto.Expression_Literal_IntervalYearToMonth{Years: 1234, Months: 5}}, Nullable: true},

--- a/literal/utils.go
+++ b/literal/utils.go
@@ -195,10 +195,10 @@ func NewIntervalDaysToSecondFromString(daysToSecond string, nullable bool) (expr
 		return nil, err
 	}
 	return expr.NewLiteral(&types.IntervalDayToSecond{
-		Days:          days,
-		Seconds:       seconds,
-		PrecisionMode: types.IntervalDayToSecondPrecision(precision),
-		Subseconds:    subSeconds,
+		Days:       days,
+		Seconds:    seconds,
+		Precision:  types.TimePrecision(precision),
+		Subseconds: subSeconds,
 	}, nullable)
 }
 
@@ -263,10 +263,10 @@ func parseIntervalDaysToSecond(interval string) (int32, int32, int64, int32, err
 
 func NewIntervalDaysToSecond(days, seconds int32, micros int64, nullable bool) (expr.Literal, error) {
 	return expr.NewLiteral(&types.IntervalDayToSecond{
-		Days:          days,
-		Seconds:       seconds,
-		PrecisionMode: types.IntervalDayToSecondPrecision(int32(types.PrecisionMicroSeconds)),
-		Subseconds:    micros,
+		Days:       days,
+		Seconds:    seconds,
+		Precision:  types.PrecisionMicroSeconds,
+		Subseconds: micros,
 	}, nullable)
 }
 

--- a/literal/utils.go
+++ b/literal/utils.go
@@ -195,12 +195,10 @@ func NewIntervalDaysToSecondFromString(daysToSecond string, nullable bool) (expr
 		return nil, err
 	}
 	return expr.NewLiteral(&types.IntervalDayToSecond{
-		Days:    days,
-		Seconds: seconds,
-		PrecisionMode: &proto.Expression_Literal_IntervalDayToSecond_Precision{
-			Precision: precision,
-		},
-		Subseconds: subSeconds,
+		Days:          days,
+		Seconds:       seconds,
+		PrecisionMode: types.IntervalDayToSecondPrecision(precision),
+		Subseconds:    subSeconds,
 	}, nullable)
 }
 
@@ -265,12 +263,10 @@ func parseIntervalDaysToSecond(interval string) (int32, int32, int64, int32, err
 
 func NewIntervalDaysToSecond(days, seconds int32, micros int64, nullable bool) (expr.Literal, error) {
 	return expr.NewLiteral(&types.IntervalDayToSecond{
-		Days:    days,
-		Seconds: seconds,
-		PrecisionMode: &proto.Expression_Literal_IntervalDayToSecond_Precision{
-			Precision: int32(types.PrecisionMicroSeconds),
-		},
-		Subseconds: micros,
+		Days:          days,
+		Seconds:       seconds,
+		PrecisionMode: types.IntervalDayToSecondPrecision(int32(types.PrecisionMicroSeconds)),
+		Subseconds:    micros,
 	}, nullable)
 }
 

--- a/literal/utils_test.go
+++ b/literal/utils_test.go
@@ -368,10 +368,10 @@ func TestNewIntervalDaysToSecond(t *testing.T) {
 func createIntervalDaysLiteral(days, seconds int32, micros int64) *expr.ProtoLiteral {
 	return &expr.ProtoLiteral{
 		Value: &types.IntervalDayToSecond{
-			Days:          days,
-			Seconds:       seconds,
-			Subseconds:    micros,
-			PrecisionMode: types.IntervalDayToSecondPrecision(int32(types.PrecisionMicroSeconds)),
+			Days:       days,
+			Seconds:    seconds,
+			Subseconds: micros,
+			Precision:  types.PrecisionMicroSeconds,
 		},
 		Type: &types.IntervalDayType{
 			Nullability: types.NullabilityRequired,
@@ -383,10 +383,10 @@ func createIntervalDaysLiteral(days, seconds int32, micros int64) *expr.ProtoLit
 func createIntervalDaysLiteralWithNanos(days, seconds int32, nanos int64) *expr.ProtoLiteral {
 	return &expr.ProtoLiteral{
 		Value: &types.IntervalDayToSecond{
-			Days:          days,
-			Seconds:       seconds,
-			Subseconds:    nanos,
-			PrecisionMode: types.IntervalDayToSecondPrecision(int32(types.PrecisionNanoSeconds)),
+			Days:       days,
+			Seconds:    seconds,
+			Subseconds: nanos,
+			Precision:  types.PrecisionNanoSeconds,
 		},
 		Type: &types.IntervalDayType{
 			Nullability: types.NullabilityRequired,

--- a/literal/utils_test.go
+++ b/literal/utils_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/substrait-io/substrait-go/v9/expr"
 	"github.com/substrait-io/substrait-go/v9/types"
-	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
 )
 
 func TestNewBool(t *testing.T) {
@@ -369,12 +368,10 @@ func TestNewIntervalDaysToSecond(t *testing.T) {
 func createIntervalDaysLiteral(days, seconds int32, micros int64) *expr.ProtoLiteral {
 	return &expr.ProtoLiteral{
 		Value: &types.IntervalDayToSecond{
-			Days:       days,
-			Seconds:    seconds,
-			Subseconds: micros,
-			PrecisionMode: &proto.Expression_Literal_IntervalDayToSecond_Precision{
-				Precision: int32(types.PrecisionMicroSeconds),
-			},
+			Days:          days,
+			Seconds:       seconds,
+			Subseconds:    micros,
+			PrecisionMode: types.IntervalDayToSecondPrecision(int32(types.PrecisionMicroSeconds)),
 		},
 		Type: &types.IntervalDayType{
 			Nullability: types.NullabilityRequired,
@@ -386,12 +383,10 @@ func createIntervalDaysLiteral(days, seconds int32, micros int64) *expr.ProtoLit
 func createIntervalDaysLiteralWithNanos(days, seconds int32, nanos int64) *expr.ProtoLiteral {
 	return &expr.ProtoLiteral{
 		Value: &types.IntervalDayToSecond{
-			Days:       days,
-			Seconds:    seconds,
-			Subseconds: nanos,
-			PrecisionMode: &proto.Expression_Literal_IntervalDayToSecond_Precision{
-				Precision: int32(types.PrecisionNanoSeconds),
-			},
+			Days:          days,
+			Seconds:       seconds,
+			Subseconds:    nanos,
+			PrecisionMode: types.IntervalDayToSecondPrecision(int32(types.PrecisionNanoSeconds)),
 		},
 		Type: &types.IntervalDayType{
 			Nullability: types.NullabilityRequired,

--- a/types/interval_day_to_second_test.go
+++ b/types/interval_day_to_second_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package types_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/substrait-io/substrait-go/v9/types"
+	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+func TestIntervalDayToSecondMatchesDescriptor(t *testing.T) {
+	// Scalar fields are pinned by wire number and kind; the precision_mode oneof is pinned
+	// separately since the domain type collapses its two arms into a single PrecisionMode field.
+	wantScalars := map[protoreflect.Name]struct {
+		number protoreflect.FieldNumber
+		kind   protoreflect.Kind
+	}{
+		"days":       {1, protoreflect.Int32Kind},
+		"seconds":    {2, protoreflect.Int32Kind},
+		"subseconds": {5, protoreflect.Int64Kind},
+	}
+	wantOneof := map[protoreflect.Name]struct {
+		number protoreflect.FieldNumber
+		kind   protoreflect.Kind
+	}{
+		"microseconds": {3, protoreflect.Int32Kind},
+		"precision":    {4, protoreflect.Int32Kind},
+	}
+
+	desc := (&proto.Expression_Literal_IntervalDayToSecond{}).ProtoReflect().Descriptor()
+	fields := desc.Fields()
+	require.Equal(t, len(wantScalars)+len(wantOneof), fields.Len(), "spec interval_day_to_second field set changed")
+
+	// 3 scalars + 1 PrecisionMode field standing in for the 2-arm oneof.
+	require.Equal(t, len(wantScalars)+1, reflect.TypeOf(types.IntervalDayToSecond{}).NumField(),
+		"types.IntervalDayToSecond field count drifted from the spec")
+
+	for i := 0; i < fields.Len(); i++ {
+		f := fields.Get(i)
+		if f.ContainingOneof() != nil {
+			assert.Equal(t, protoreflect.Name("precision_mode"), f.ContainingOneof().Name(), "%s oneof", f.Name())
+			w, ok := wantOneof[f.Name()]
+			require.Truef(t, ok, "unexpected oneof spec field %q", f.Name())
+			assert.EqualValues(t, w.number, f.Number(), "%s wire number", f.Name())
+			assert.Equal(t, w.kind, f.Kind(), "%s kind", f.Name())
+			continue
+		}
+		w, ok := wantScalars[f.Name()]
+		require.Truef(t, ok, "unexpected spec field %q", f.Name())
+		assert.EqualValues(t, w.number, f.Number(), "%s wire number", f.Name())
+		assert.Equal(t, w.kind, f.Kind(), "%s kind", f.Name())
+	}
+}
+
+// Round-trip both precision_mode arms domain->proto->domain, asserting each arm maps to the
+// correct proto oneof field so a swapped or dropped arm fails here.
+func TestIntervalDayToSecondRoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		in      *types.IntervalDayToSecond
+		checkPB func(t *testing.T, p *proto.Expression_Literal_IntervalDayToSecond)
+	}{
+		{
+			name: "precision arm",
+			in:   &types.IntervalDayToSecond{Days: 1, Seconds: 2, Subseconds: 3, PrecisionMode: types.IntervalDayToSecondPrecision(9)},
+			checkPB: func(t *testing.T, p *proto.Expression_Literal_IntervalDayToSecond) {
+				require.IsType(t, &proto.Expression_Literal_IntervalDayToSecond_Precision{}, p.PrecisionMode)
+				assert.EqualValues(t, 9, p.GetPrecision())
+			},
+		},
+		{
+			name: "microseconds arm",
+			in:   &types.IntervalDayToSecond{Days: 4, Seconds: 5, PrecisionMode: types.IntervalDayToSecondMicroseconds(7)},
+			checkPB: func(t *testing.T, p *proto.Expression_Literal_IntervalDayToSecond) {
+				require.IsType(t, &proto.Expression_Literal_IntervalDayToSecond_Microseconds{}, p.PrecisionMode)
+				assert.EqualValues(t, 7, p.GetMicroseconds())
+			},
+		},
+		{
+			name: "no precision mode",
+			in:   &types.IntervalDayToSecond{Days: 1, Seconds: 2, Subseconds: 3},
+			checkPB: func(t *testing.T, p *proto.Expression_Literal_IntervalDayToSecond) {
+				assert.Nil(t, p.PrecisionMode)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := types.IntervalDayToSecondToProto(tc.in)
+			tc.checkPB(t, p)
+			assert.Equal(t, tc.in, types.IntervalDayToSecondFromProto(p))
+		})
+	}
+
+	assert.Nil(t, types.IntervalDayToSecondToProto(nil))
+	assert.Nil(t, types.IntervalDayToSecondFromProto(nil))
+
+	// GetPrecision is nil-safe and yields the exponent only for the Precision arm.
+	assert.Zero(t, (*types.IntervalDayToSecond)(nil).GetPrecision())
+	assert.EqualValues(t, 9, (&types.IntervalDayToSecond{PrecisionMode: types.IntervalDayToSecondPrecision(9)}).GetPrecision())
+	assert.Zero(t, (&types.IntervalDayToSecond{PrecisionMode: types.IntervalDayToSecondMicroseconds(7)}).GetPrecision())
+}

--- a/types/interval_day_to_second_test.go
+++ b/types/interval_day_to_second_test.go
@@ -104,7 +104,7 @@ func TestIntervalDayToSecondRoundTrip(t *testing.T) {
 	assert.Nil(t, types.IntervalDayToSecondToProto(nil))
 	assert.Nil(t, types.IntervalDayToSecondFromProto(nil))
 
-	// GetPrecision is nil-safe and yields the precision's protobuf value.
-	assert.Zero(t, (*types.IntervalDayToSecond)(nil).GetPrecision())
-	assert.EqualValues(t, 9, (&types.IntervalDayToSecond{Precision: types.PrecisionNanoSeconds}).GetPrecision())
+	// GetPrecisionProtoVal is nil-safe and yields the precision's protobuf value.
+	assert.Zero(t, (*types.IntervalDayToSecond)(nil).GetPrecisionProtoVal())
+	assert.EqualValues(t, 9, (&types.IntervalDayToSecond{Precision: types.PrecisionNanoSeconds}).GetPrecisionProtoVal())
 }

--- a/types/interval_day_to_second_test.go
+++ b/types/interval_day_to_second_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestIntervalDayToSecondMatchesDescriptor(t *testing.T) {
 	// Scalar fields are pinned by wire number and kind; the precision_mode oneof is pinned
-	// separately since the domain type collapses its two arms into a single PrecisionMode field.
+	// separately since the domain type collapses its two arms into a single Precision field.
 	wantScalars := map[protoreflect.Name]struct {
 		number protoreflect.FieldNumber
 		kind   protoreflect.Kind
@@ -36,7 +36,7 @@ func TestIntervalDayToSecondMatchesDescriptor(t *testing.T) {
 	fields := desc.Fields()
 	require.Equal(t, len(wantScalars)+len(wantOneof), fields.Len(), "spec interval_day_to_second field set changed")
 
-	// 3 scalars + 1 PrecisionMode field standing in for the 2-arm oneof.
+	// 3 scalars + 1 Precision field standing in for the 2-arm oneof.
 	require.Equal(t, len(wantScalars)+1, reflect.TypeOf(types.IntervalDayToSecond{}).NumField(),
 		"types.IntervalDayToSecond field count drifted from the spec")
 
@@ -57,50 +57,54 @@ func TestIntervalDayToSecondMatchesDescriptor(t *testing.T) {
 	}
 }
 
-// Round-trip both precision_mode arms domain->proto->domain, asserting each arm maps to the
-// correct proto oneof field so a swapped or dropped arm fails here.
+// Round-trip domain->proto->domain always uses the non-deprecated precision arm, so a swapped or
+// dropped field fails here.
 func TestIntervalDayToSecondRoundTrip(t *testing.T) {
 	for _, tc := range []struct {
-		name    string
-		in      *types.IntervalDayToSecond
-		checkPB func(t *testing.T, p *proto.Expression_Literal_IntervalDayToSecond)
+		name string
+		in   *types.IntervalDayToSecond
 	}{
 		{
-			name: "precision arm",
-			in:   &types.IntervalDayToSecond{Days: 1, Seconds: 2, Subseconds: 3, PrecisionMode: types.IntervalDayToSecondPrecision(9)},
-			checkPB: func(t *testing.T, p *proto.Expression_Literal_IntervalDayToSecond) {
-				require.IsType(t, &proto.Expression_Literal_IntervalDayToSecond_Precision{}, p.PrecisionMode)
-				assert.EqualValues(t, 9, p.GetPrecision())
-			},
+			name: "nanosecond precision",
+			in:   &types.IntervalDayToSecond{Days: 1, Seconds: 2, Subseconds: 3, Precision: types.PrecisionNanoSeconds},
 		},
 		{
-			name: "microseconds arm",
-			in:   &types.IntervalDayToSecond{Days: 4, Seconds: 5, PrecisionMode: types.IntervalDayToSecondMicroseconds(7)},
-			checkPB: func(t *testing.T, p *proto.Expression_Literal_IntervalDayToSecond) {
-				require.IsType(t, &proto.Expression_Literal_IntervalDayToSecond_Microseconds{}, p.PrecisionMode)
-				assert.EqualValues(t, 7, p.GetMicroseconds())
-			},
-		},
-		{
-			name: "no precision mode",
-			in:   &types.IntervalDayToSecond{Days: 1, Seconds: 2, Subseconds: 3},
-			checkPB: func(t *testing.T, p *proto.Expression_Literal_IntervalDayToSecond) {
-				assert.Nil(t, p.PrecisionMode)
-			},
+			name: "second precision",
+			in:   &types.IntervalDayToSecond{Days: 4, Seconds: 5, Precision: types.PrecisionSeconds},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			p := types.IntervalDayToSecondToProto(tc.in)
-			tc.checkPB(t, p)
+			require.IsType(t, &proto.Expression_Literal_IntervalDayToSecond_Precision{}, p.PrecisionMode)
 			assert.Equal(t, tc.in, types.IntervalDayToSecondFromProto(p))
 		})
 	}
 
+	// The deprecated microseconds precision_mode arm is normalized to microsecond precision on decode.
+	t.Run("deprecated microseconds normalized", func(t *testing.T) {
+		p := &proto.Expression_Literal_IntervalDayToSecond{
+			Days:          4,
+			Seconds:       5,
+			PrecisionMode: &proto.Expression_Literal_IntervalDayToSecond_Microseconds{Microseconds: 7},
+		}
+		assert.Equal(t,
+			&types.IntervalDayToSecond{Days: 4, Seconds: 5, Subseconds: 7, Precision: types.PrecisionMicroSeconds},
+			types.IntervalDayToSecondFromProto(p))
+	})
+
+	// An absent precision_mode is the legacy encoding and decodes as microsecond precision,
+	// matching IntervalDayType's default.
+	t.Run("absent precision_mode defaults to microseconds", func(t *testing.T) {
+		p := &proto.Expression_Literal_IntervalDayToSecond{Days: 1, Seconds: 2, Subseconds: 3}
+		assert.Equal(t,
+			&types.IntervalDayToSecond{Days: 1, Seconds: 2, Subseconds: 3, Precision: types.PrecisionMicroSeconds},
+			types.IntervalDayToSecondFromProto(p))
+	})
+
 	assert.Nil(t, types.IntervalDayToSecondToProto(nil))
 	assert.Nil(t, types.IntervalDayToSecondFromProto(nil))
 
-	// GetPrecision is nil-safe and yields the exponent only for the Precision arm.
+	// GetPrecision is nil-safe and yields the precision's protobuf value.
 	assert.Zero(t, (*types.IntervalDayToSecond)(nil).GetPrecision())
-	assert.EqualValues(t, 9, (&types.IntervalDayToSecond{PrecisionMode: types.IntervalDayToSecondPrecision(9)}).GetPrecision())
-	assert.Zero(t, (&types.IntervalDayToSecond{PrecisionMode: types.IntervalDayToSecondMicroseconds(7)}).GetPrecision())
+	assert.EqualValues(t, 9, (&types.IntervalDayToSecond{Precision: types.PrecisionNanoSeconds}).GetPrecision())
 }

--- a/types/types.go
+++ b/types/types.go
@@ -336,63 +336,43 @@ type IntervalYearToMonth struct {
 }
 
 // IntervalDayToSecond is an interval literal spanning days down to sub-seconds, mirroring the
-// fields of the Substrait IntervalDayToSecond literal message. Its sub-second precision is carried
-// by the PrecisionMode oneof.
+// fields of the Substrait IntervalDayToSecond literal message. Its sub-second value is Subseconds
+// interpreted at Precision fractional-second digits.
 type IntervalDayToSecond struct {
-	Days          int32
-	Seconds       int32
-	Subseconds    int64
-	PrecisionMode IntervalDayToSecondPrecisionMode
+	Days       int32
+	Seconds    int32
+	Subseconds int64
+	Precision  TimePrecision
 }
 
-// IntervalDayToSecondPrecisionMode models the precision_mode oneof of the IntervalDayToSecond
-// literal message: either a deprecated Microseconds count or a Precision exponent.
-type IntervalDayToSecondPrecisionMode interface {
-	isIntervalDayToSecondPrecisionMode()
-}
-
-// IntervalDayToSecondMicroseconds is the deprecated microseconds arm of the precision_mode oneof.
-type IntervalDayToSecondMicroseconds int32
-
-func (IntervalDayToSecondMicroseconds) isIntervalDayToSecondPrecisionMode() {}
-
-// IntervalDayToSecondPrecision is the sub-second precision exponent arm of the precision_mode oneof.
-type IntervalDayToSecondPrecision int32
-
-func (IntervalDayToSecondPrecision) isIntervalDayToSecondPrecisionMode() {}
-
-// GetPrecision returns the sub-second precision exponent when the precision_mode oneof carries a
-// Precision arm, and 0 otherwise, mirroring the proto getter.
+// GetPrecision returns the sub-second precision as its protobuf value, and 0 for a nil receiver.
 func (i *IntervalDayToSecond) GetPrecision() int32 {
 	if i == nil {
 		return 0
 	}
-	if p, ok := i.PrecisionMode.(IntervalDayToSecondPrecision); ok {
-		return int32(p)
-	}
-	return 0
+	return i.Precision.ToProtoVal()
 }
 
-// IntervalDayToSecondToProto encodes the domain interval as its protobuf literal message.
+// IntervalDayToSecondToProto encodes the domain interval as its protobuf literal message. It always
+// writes the precision precision_mode arm; the deprecated microseconds arm is never emitted.
 func IntervalDayToSecondToProto(v *IntervalDayToSecond) *proto.Expression_Literal_IntervalDayToSecond {
 	if v == nil {
 		return nil
 	}
-	p := &proto.Expression_Literal_IntervalDayToSecond{
+	return &proto.Expression_Literal_IntervalDayToSecond{
 		Days:       v.Days,
 		Seconds:    v.Seconds,
 		Subseconds: v.Subseconds,
+		PrecisionMode: &proto.Expression_Literal_IntervalDayToSecond_Precision{
+			Precision: v.Precision.ToProtoVal(),
+		},
 	}
-	switch m := v.PrecisionMode.(type) {
-	case IntervalDayToSecondMicroseconds:
-		p.PrecisionMode = &proto.Expression_Literal_IntervalDayToSecond_Microseconds{Microseconds: int32(m)}
-	case IntervalDayToSecondPrecision:
-		p.PrecisionMode = &proto.Expression_Literal_IntervalDayToSecond_Precision{Precision: int32(m)}
-	}
-	return p
 }
 
 // IntervalDayToSecondFromProto decodes a protobuf interval literal message into the domain type.
+// The deprecated microseconds precision_mode arm, and an absent precision_mode (the legacy
+// encoding), are both normalized to microsecond precision, matching IntervalDayType so the domain
+// type never carries the deprecated representation.
 func IntervalDayToSecondFromProto(p *proto.Expression_Literal_IntervalDayToSecond) *IntervalDayToSecond {
 	if p == nil {
 		return nil
@@ -403,10 +383,13 @@ func IntervalDayToSecondFromProto(p *proto.Expression_Literal_IntervalDayToSecon
 		Subseconds: p.GetSubseconds(),
 	}
 	switch m := p.PrecisionMode.(type) {
-	case *proto.Expression_Literal_IntervalDayToSecond_Microseconds:
-		v.PrecisionMode = IntervalDayToSecondMicroseconds(m.Microseconds)
 	case *proto.Expression_Literal_IntervalDayToSecond_Precision:
-		v.PrecisionMode = IntervalDayToSecondPrecision(m.Precision)
+		v.Precision = TimePrecision(m.Precision)
+	case *proto.Expression_Literal_IntervalDayToSecond_Microseconds:
+		v.Subseconds = int64(m.Microseconds)
+		v.Precision = PrecisionMicroSeconds
+	default:
+		v.Precision = PrecisionMicroSeconds
 	}
 	return v
 }

--- a/types/types.go
+++ b/types/types.go
@@ -307,7 +307,6 @@ func (b CastFailBehavior) String() string {
 }
 
 type (
-	IntervalDayToSecond  = proto.Expression_Literal_IntervalDayToSecond
 	UserDefinedLiteral   = proto.Expression_Literal_UserDefined
 	PrecisionTime        = proto.Expression_Literal_PrecisionTime
 	PrecisionTimestamp   = proto.Expression_Literal_PrecisionTimestamp_
@@ -334,6 +333,82 @@ type Decimal struct {
 type IntervalYearToMonth struct {
 	Years  int32
 	Months int32
+}
+
+// IntervalDayToSecond is an interval literal spanning days down to sub-seconds, mirroring the
+// fields of the Substrait IntervalDayToSecond literal message. Its sub-second precision is carried
+// by the PrecisionMode oneof.
+type IntervalDayToSecond struct {
+	Days          int32
+	Seconds       int32
+	Subseconds    int64
+	PrecisionMode IntervalDayToSecondPrecisionMode
+}
+
+// IntervalDayToSecondPrecisionMode models the precision_mode oneof of the IntervalDayToSecond
+// literal message: either a deprecated Microseconds count or a Precision exponent.
+type IntervalDayToSecondPrecisionMode interface {
+	isIntervalDayToSecondPrecisionMode()
+}
+
+// IntervalDayToSecondMicroseconds is the deprecated microseconds arm of the precision_mode oneof.
+type IntervalDayToSecondMicroseconds int32
+
+func (IntervalDayToSecondMicroseconds) isIntervalDayToSecondPrecisionMode() {}
+
+// IntervalDayToSecondPrecision is the sub-second precision exponent arm of the precision_mode oneof.
+type IntervalDayToSecondPrecision int32
+
+func (IntervalDayToSecondPrecision) isIntervalDayToSecondPrecisionMode() {}
+
+// GetPrecision returns the sub-second precision exponent when the precision_mode oneof carries a
+// Precision arm, and 0 otherwise, mirroring the proto getter.
+func (i *IntervalDayToSecond) GetPrecision() int32 {
+	if i == nil {
+		return 0
+	}
+	if p, ok := i.PrecisionMode.(IntervalDayToSecondPrecision); ok {
+		return int32(p)
+	}
+	return 0
+}
+
+// IntervalDayToSecondToProto encodes the domain interval as its protobuf literal message.
+func IntervalDayToSecondToProto(v *IntervalDayToSecond) *proto.Expression_Literal_IntervalDayToSecond {
+	if v == nil {
+		return nil
+	}
+	p := &proto.Expression_Literal_IntervalDayToSecond{
+		Days:       v.Days,
+		Seconds:    v.Seconds,
+		Subseconds: v.Subseconds,
+	}
+	switch m := v.PrecisionMode.(type) {
+	case IntervalDayToSecondMicroseconds:
+		p.PrecisionMode = &proto.Expression_Literal_IntervalDayToSecond_Microseconds{Microseconds: int32(m)}
+	case IntervalDayToSecondPrecision:
+		p.PrecisionMode = &proto.Expression_Literal_IntervalDayToSecond_Precision{Precision: int32(m)}
+	}
+	return p
+}
+
+// IntervalDayToSecondFromProto decodes a protobuf interval literal message into the domain type.
+func IntervalDayToSecondFromProto(p *proto.Expression_Literal_IntervalDayToSecond) *IntervalDayToSecond {
+	if p == nil {
+		return nil
+	}
+	v := &IntervalDayToSecond{
+		Days:       p.GetDays(),
+		Seconds:    p.GetSeconds(),
+		Subseconds: p.GetSubseconds(),
+	}
+	switch m := p.PrecisionMode.(type) {
+	case *proto.Expression_Literal_IntervalDayToSecond_Microseconds:
+		v.PrecisionMode = IntervalDayToSecondMicroseconds(m.Microseconds)
+	case *proto.Expression_Literal_IntervalDayToSecond_Precision:
+		v.PrecisionMode = IntervalDayToSecondPrecision(m.Precision)
+	}
+	return v
 }
 
 // TypeFromProto returns the appropriate Type object from a protobuf

--- a/types/types.go
+++ b/types/types.go
@@ -345,8 +345,9 @@ type IntervalDayToSecond struct {
 	Precision  TimePrecision
 }
 
-// GetPrecision returns the sub-second precision as its protobuf value, and 0 for a nil receiver.
-func (i *IntervalDayToSecond) GetPrecision() int32 {
+// GetPrecisionProtoVal returns the sub-second precision as its protobuf value, and 0 for a nil
+// receiver.
+func (i *IntervalDayToSecond) GetPrecisionProtoVal() int32 {
 	if i == nil {
 		return 0
 	}


### PR DESCRIPTION
`types.IntervalDayToSecond` was `= proto.Expression_Literal_IntervalDayToSecond`, so the generated protobuf message was substrait-go's public API. It becomes a substrait-go struct with the same fields, and its `precision_mode` oneof becomes a small `IntervalDayToSecondPrecisionMode` interface (Microseconds / Precision arms). Conversion to and from the protobuf message lives in `IntervalDayToSecondToProto` / `IntervalDayToSecondFromProto`, so consumers still compile.

BREAKING CHANGE: `types.IntervalDayToSecond` is no longer an alias for `proto.Expression_Literal_IntervalDayToSecond`; it is a plain struct whose sub-second precision is carried by the `PrecisionMode` oneof interface. Code that used the protobuf message directly must construct the struct.

Part of #280.