### PR TITLE
feat(plan)!: make WriteOp and OutputMode domain enums

### DIFF
--- a/plan/output_mode_test.go
+++ b/plan/output_mode_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package plan_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/substrait-io/substrait-go/v9/plan"
+	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
+)
+
+func TestOutputModeString(t *testing.T) {
+	for _, td := range []struct {
+		m        plan.OutputMode
+		expected string
+	}{
+		{plan.OutputModeUnspecified, "OUTPUT_MODE_UNSPECIFIED"},
+		{plan.OutputModeNoOutput, "OUTPUT_MODE_NO_OUTPUT"},
+		{plan.OutputModeModifiedRecords, "OUTPUT_MODE_MODIFIED_RECORDS"},
+	} {
+		t.Run(td.expected, func(t *testing.T) {
+			assert.Equal(t, td.expected, td.m.String())
+			assert.Equal(t, td.expected, fmt.Sprintf("%v", td.m))
+		})
+	}
+}
+
+func TestOutputModeMatchesProto(t *testing.T) {
+	cases := []struct {
+		domain plan.OutputMode
+		pb     proto.WriteRel_OutputMode
+	}{
+		{plan.OutputModeUnspecified, proto.WriteRel_OUTPUT_MODE_UNSPECIFIED},
+		{plan.OutputModeNoOutput, proto.WriteRel_OUTPUT_MODE_NO_OUTPUT},
+		{plan.OutputModeModifiedRecords, proto.WriteRel_OUTPUT_MODE_MODIFIED_RECORDS},
+	}
+	// fail if the spec adds a value we don't mirror
+	assert.Equal(t, proto.WriteRel_OUTPUT_MODE_UNSPECIFIED.Descriptor().Values().Len(), len(cases),
+		"a proto output mode value is not covered")
+	for _, td := range cases {
+		assert.EqualValues(t, td.pb, td.domain, "wire number for %s", td.pb)
+		assert.Equal(t, td.pb.String(), td.domain.String(), "enum name for %s", td.pb)
+	}
+}

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -901,9 +901,9 @@ func RelFromProto(rel *proto.Rel, reg expr.ExtensionRegistry) (Rel, error) {
 		tableSchema := types.NewNamedStructFromProto(rel.Write.TableSchema)
 		out := &NamedTableWriteRel{
 			tableSchema: tableSchema,
-			op:          rel.Write.Op,
+			op:          WriteOp(rel.Write.Op),
 			input:       input,
-			outputMode:  rel.Write.Output,
+			outputMode:  OutputMode(rel.Write.Output),
 		}
 		if rel.Write.Common != nil {
 			out.fromProtoCommon(rel.Write.Common)

--- a/plan/relations.go
+++ b/plan/relations.go
@@ -2329,23 +2329,57 @@ func (mr *MergeJoinRel) Remap(mapping ...int32) (Rel, error) {
 	return RemapHelper(mr, mapping)
 }
 
-type WriteOp = proto.WriteRel_WriteOp
+// WriteOp describes the kind of write a NamedTableWriteRel performs.
+type WriteOp int32
 
 const (
-	WriteOpUnspecified = proto.WriteRel_WRITE_OP_UNSPECIFIED
-	WriteOpInsert      = proto.WriteRel_WRITE_OP_INSERT
-	WriteOpDelete      = proto.WriteRel_WRITE_OP_DELETE
-	WriteOpUpdate      = proto.WriteRel_WRITE_OP_UPDATE
-	WriteOpCTAS        = proto.WriteRel_WRITE_OP_CTAS
+	WriteOpUnspecified WriteOp = 0
+	WriteOpInsert      WriteOp = 1
+	WriteOpDelete      WriteOp = 2
+	WriteOpUpdate      WriteOp = 3
+	WriteOpCTAS        WriteOp = 4
 )
 
-type OutputMode = proto.WriteRel_OutputMode
+// String returns the protobuf enum name for the write operation.
+func (o WriteOp) String() string {
+	switch o {
+	case WriteOpUnspecified:
+		return "WRITE_OP_UNSPECIFIED"
+	case WriteOpInsert:
+		return "WRITE_OP_INSERT"
+	case WriteOpDelete:
+		return "WRITE_OP_DELETE"
+	case WriteOpUpdate:
+		return "WRITE_OP_UPDATE"
+	case WriteOpCTAS:
+		return "WRITE_OP_CTAS"
+	default:
+		return strconv.Itoa(int(o))
+	}
+}
+
+// OutputMode describes what records a NamedTableWriteRel returns.
+type OutputMode int32
 
 const (
-	OutputModeUnspecified     = proto.WriteRel_OUTPUT_MODE_UNSPECIFIED
-	OutputModeNoOutput        = proto.WriteRel_OUTPUT_MODE_NO_OUTPUT
-	OutputModeModifiedRecords = proto.WriteRel_OUTPUT_MODE_MODIFIED_RECORDS
+	OutputModeUnspecified     OutputMode = 0
+	OutputModeNoOutput        OutputMode = 1
+	OutputModeModifiedRecords OutputMode = 2
 )
+
+// String returns the protobuf enum name for the output mode.
+func (m OutputMode) String() string {
+	switch m {
+	case OutputModeUnspecified:
+		return "OUTPUT_MODE_UNSPECIFIED"
+	case OutputModeNoOutput:
+		return "OUTPUT_MODE_NO_OUTPUT"
+	case OutputModeModifiedRecords:
+		return "OUTPUT_MODE_MODIFIED_RECORDS"
+	default:
+		return strconv.Itoa(int(m))
+	}
+}
 
 // NamedTableWriteRel is a relational operator that writes data to a table. The list of strings
 // that make up the names are to represent namespacing (e.g. mydb.mytable).
@@ -2405,7 +2439,7 @@ func (wr *NamedTableWriteRel) ToProto() *proto.Rel {
 					},
 				},
 				TableSchema: wr.tableSchema.ToProto(),
-				Op:          wr.op,
+				Op:          proto.WriteRel_WriteOp(wr.op),
 				Input:       wr.input.ToProto(),
 			},
 		},

--- a/plan/relations_test.go
+++ b/plan/relations_test.go
@@ -767,7 +767,7 @@ func TestNamedTableWriteRecordType(t *testing.T) {
 	var rel NamedTableWriteRel
 	rel.input = &fakeRel{outputType: *types.NewRecordTypeFromTypes(
 		[]types.Type{&types.Int64Type{}, &types.StringType{}})}
-	rel.outputMode = proto.WriteRel_OUTPUT_MODE_MODIFIED_RECORDS
+	rel.outputMode = OutputModeModifiedRecords
 
 	expected := *types.NewRecordTypeFromTypes(nil)
 	result := rel.RecordType()

--- a/plan/write_op_test.go
+++ b/plan/write_op_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package plan_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/substrait-io/substrait-go/v9/plan"
+	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
+)
+
+func TestWriteOpString(t *testing.T) {
+	for _, td := range []struct {
+		o        plan.WriteOp
+		expected string
+	}{
+		{plan.WriteOpUnspecified, "WRITE_OP_UNSPECIFIED"},
+		{plan.WriteOpInsert, "WRITE_OP_INSERT"},
+		{plan.WriteOpDelete, "WRITE_OP_DELETE"},
+		{plan.WriteOpUpdate, "WRITE_OP_UPDATE"},
+		{plan.WriteOpCTAS, "WRITE_OP_CTAS"},
+	} {
+		t.Run(td.expected, func(t *testing.T) {
+			assert.Equal(t, td.expected, td.o.String())
+			assert.Equal(t, td.expected, fmt.Sprintf("%v", td.o))
+		})
+	}
+}
+
+func TestWriteOpMatchesProto(t *testing.T) {
+	cases := []struct {
+		domain plan.WriteOp
+		pb     proto.WriteRel_WriteOp
+	}{
+		{plan.WriteOpUnspecified, proto.WriteRel_WRITE_OP_UNSPECIFIED},
+		{plan.WriteOpInsert, proto.WriteRel_WRITE_OP_INSERT},
+		{plan.WriteOpDelete, proto.WriteRel_WRITE_OP_DELETE},
+		{plan.WriteOpUpdate, proto.WriteRel_WRITE_OP_UPDATE},
+		{plan.WriteOpCTAS, proto.WriteRel_WRITE_OP_CTAS},
+	}
+	// fail if the spec adds a value we don't mirror
+	assert.Equal(t, proto.WriteRel_WRITE_OP_UNSPECIFIED.Descriptor().Values().Len(), len(cases),
+		"a proto write op value is not covered")
+	for _, td := range cases {
+		assert.EqualValues(t, td.pb, td.domain, "wire number for %s", td.pb)
+		assert.Equal(t, td.pb.String(), td.domain.String(), "enum name for %s", td.pb)
+	}
+}


### PR DESCRIPTION
`plan.WriteOp` and `plan.OutputMode` were `= proto.WriteRel_WriteOp` / `= proto.WriteRel_OutputMode`, so the generated enums were substrait-go's public API. They become substrait-go's own `int32` enums with the same constant names and wire numbers plus a hand-written `String()`, casting at the proto boundaries, so consumers still compile.

BREAKING CHANGE: `plan.WriteOp` and `plan.OutputMode` are no longer aliases for the protobuf enums; their constants are now typed values. Code that passes one where the other is expected needs a cast.

Part of #280.