### PR TITLE
feat(expr)!: make MaskListElement and MaskListSlice domain structs

### DIFF
--- a/expr/field_reference.go
+++ b/expr/field_reference.go
@@ -368,9 +368,9 @@ func maskSelectFromProto(p *proto.Expression_MaskExpression_Select) MaskSelect {
 		for i, sel := range s.List.Selection {
 			switch s := sel.Type.(type) {
 			case *proto.Expression_MaskExpression_ListSelect_ListSelectItem_Item:
-				selection[i] = (*MaskListElement)(s.Item)
+				selection[i] = &MaskListElement{Field: s.Item.Field}
 			case *proto.Expression_MaskExpression_ListSelect_ListSelectItem_Slice:
-				selection[i] = (*MaskListSlice)(s.Slice)
+				selection[i] = &MaskListSlice{Start: s.Slice.Start, End: s.Slice.End}
 			}
 		}
 		return &MaskListSelect{
@@ -469,7 +469,11 @@ type MaskListSelectItem interface {
 	ToProto() *proto.Expression_MaskExpression_ListSelect_ListSelectItem
 }
 
-type MaskListElement proto.Expression_MaskExpression_ListSelect_ListSelectItem_ListElement
+// MaskListElement selects a single element of a list by its field index, mirroring the fields of
+// the Substrait mask expression ListElement message.
+type MaskListElement struct {
+	Field int32
+}
 
 func (m *MaskListElement) GetField() int32 {
 	return m.Field
@@ -478,12 +482,19 @@ func (m *MaskListElement) GetField() int32 {
 func (m *MaskListElement) ToProto() *proto.Expression_MaskExpression_ListSelect_ListSelectItem {
 	return &proto.Expression_MaskExpression_ListSelect_ListSelectItem{
 		Type: &proto.Expression_MaskExpression_ListSelect_ListSelectItem_Item{
-			Item: (*proto.Expression_MaskExpression_ListSelect_ListSelectItem_ListElement)(m),
+			Item: &proto.Expression_MaskExpression_ListSelect_ListSelectItem_ListElement{
+				Field: m.Field,
+			},
 		},
 	}
 }
 
-type MaskListSlice proto.Expression_MaskExpression_ListSelect_ListSelectItem_ListSlice
+// MaskListSlice selects a contiguous range of list elements by start and end bounds, mirroring the
+// fields of the Substrait mask expression ListSlice message.
+type MaskListSlice struct {
+	Start int32
+	End   int32
+}
 
 func (m *MaskListSlice) GetBounds() (start, end int32) {
 	return m.Start, m.End
@@ -492,7 +503,10 @@ func (m *MaskListSlice) GetBounds() (start, end int32) {
 func (m *MaskListSlice) ToProto() *proto.Expression_MaskExpression_ListSelect_ListSelectItem {
 	return &proto.Expression_MaskExpression_ListSelect_ListSelectItem{
 		Type: &proto.Expression_MaskExpression_ListSelect_ListSelectItem_Slice{
-			Slice: (*proto.Expression_MaskExpression_ListSelect_ListSelectItem_ListSlice)(m),
+			Slice: &proto.Expression_MaskExpression_ListSelect_ListSelectItem_ListSlice{
+				Start: m.Start,
+				End:   m.End,
+			},
 		},
 	}
 }

--- a/expr/mask_list_test.go
+++ b/expr/mask_list_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package expr_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/substrait-io/substrait-go/v9/expr"
+	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
+	pbproto "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+func TestMaskListElementMatchesDescriptor(t *testing.T) {
+	want := map[protoreflect.Name]struct {
+		number protoreflect.FieldNumber
+		kind   protoreflect.Kind
+	}{
+		"field": {1, protoreflect.Int32Kind},
+	}
+
+	fields := (&proto.Expression_MaskExpression_ListSelect_ListSelectItem_ListElement{}).ProtoReflect().Descriptor().Fields()
+	require.Equal(t, len(want), fields.Len(), "spec mask list element field set changed")
+	require.Equal(t, len(want), reflect.TypeOf(expr.MaskListElement{}).NumField(), "expr.MaskListElement field count drifted from the spec")
+
+	for i := 0; i < fields.Len(); i++ {
+		f := fields.Get(i)
+		w, ok := want[f.Name()]
+		require.Truef(t, ok, "unexpected spec field %q", f.Name())
+		assert.EqualValues(t, w.number, f.Number(), "%s wire number", f.Name())
+		assert.Equal(t, w.kind, f.Kind(), "%s kind", f.Name())
+	}
+}
+
+func TestMaskListSliceMatchesDescriptor(t *testing.T) {
+	want := map[protoreflect.Name]struct {
+		number protoreflect.FieldNumber
+		kind   protoreflect.Kind
+	}{
+		"start": {1, protoreflect.Int32Kind},
+		"end":   {2, protoreflect.Int32Kind},
+	}
+
+	fields := (&proto.Expression_MaskExpression_ListSelect_ListSelectItem_ListSlice{}).ProtoReflect().Descriptor().Fields()
+	require.Equal(t, len(want), fields.Len(), "spec mask list slice field set changed")
+	require.Equal(t, len(want), reflect.TypeOf(expr.MaskListSlice{}).NumField(), "expr.MaskListSlice field count drifted from the spec")
+
+	for i := 0; i < fields.Len(); i++ {
+		f := fields.Get(i)
+		w, ok := want[f.Name()]
+		require.Truef(t, ok, "unexpected spec field %q", f.Name())
+		assert.EqualValues(t, w.number, f.Number(), "%s wire number", f.Name())
+		assert.Equal(t, w.kind, f.Kind(), "%s kind", f.Name())
+	}
+}
+
+func TestMaskListSelectRoundTrip(t *testing.T) {
+	// Direct accessors + per-item ToProto.
+	elem := &expr.MaskListElement{Field: 2}
+	assert.EqualValues(t, 2, elem.GetField())
+	assert.EqualValues(t, 2, elem.ToProto().GetItem().GetField())
+
+	slice := &expr.MaskListSlice{Start: 1, End: 3}
+	start, end := slice.GetBounds()
+	assert.EqualValues(t, 1, start)
+	assert.EqualValues(t, 3, end)
+	assert.EqualValues(t, 1, slice.ToProto().GetSlice().GetStart())
+	assert.EqualValues(t, 3, slice.ToProto().GetSlice().GetEnd())
+
+	// A list select (element + slice) reached through the public MaskExpression
+	// entry, exercising maskSelectFromProto and the domain -> proto round-trip.
+	pb := &proto.Expression_MaskExpression{
+		Select: &proto.Expression_MaskExpression_StructSelect{
+			StructItems: []*proto.Expression_MaskExpression_StructItem{{
+				Field: 0,
+				Child: &proto.Expression_MaskExpression_Select{
+					Type: &proto.Expression_MaskExpression_Select_List{
+						List: &proto.Expression_MaskExpression_ListSelect{
+							Selection: []*proto.Expression_MaskExpression_ListSelect_ListSelectItem{
+								{Type: &proto.Expression_MaskExpression_ListSelect_ListSelectItem_Item{
+									Item: &proto.Expression_MaskExpression_ListSelect_ListSelectItem_ListElement{Field: 2},
+								}},
+								{Type: &proto.Expression_MaskExpression_ListSelect_ListSelectItem_Slice{
+									Slice: &proto.Expression_MaskExpression_ListSelect_ListSelectItem_ListSlice{Start: 1, End: 3},
+								}},
+							},
+							Child: &proto.Expression_MaskExpression_Select{
+								Type: &proto.Expression_MaskExpression_Select_Struct{
+									Struct: &proto.Expression_MaskExpression_StructSelect{},
+								},
+							},
+						},
+					},
+				},
+			}},
+		},
+	}
+
+	got := expr.MaskExpressionFromProto(pb).ToProto()
+	assert.Truef(t, pbproto.Equal(pb, got), "mask expression round-trip mismatch:\nwant: %v\ngot:  %v", pb, got)
+}


### PR DESCRIPTION
`expr.MaskListElement` and `expr.MaskListSlice` were type definitions over the generated protobuf messages, so those messages were substrait-go's public API. They become substrait-go structs with the same fields, converting to and from the protobuf messages by explicit field construction instead of the previous unchecked pointer casts, so consumers still compile.

BREAKING CHANGE: `expr.MaskListElement` and `expr.MaskListSlice` are no longer defined over the protobuf messages; they are plain structs. Code relying on the old proto-typed layout must use the struct fields.

Part of #280.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of mask-list expressions when loading and saving serialized data.
  - Field selections and range selections now preserve their values more reliably during conversion.
  - Improved support for nested mask expressions and round-trip serialization, reducing the risk of lost or altered selections.
  - Mask-list ranges now retain their start and end positions consistently across serialization cycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->