### PR TITLE
fix(expr): guard nil FunctionOption in WindowFunction.Equals

### DIFF
--- a/expr/functions.go
+++ b/expr/functions.go
@@ -654,6 +654,9 @@ func (w *WindowFunction) Equals(other Expression) bool {
 	case w.LowerBound != rhs.LowerBound || w.UpperBound != rhs.UpperBound:
 		return false
 	case !slices.EqualFunc(w.options, rhs.options, func(l, r *types.FunctionOption) bool {
+		if l == nil || r == nil {
+			return l == r
+		}
 		return l.Name == r.Name && slices.Equal(l.Preference, r.Preference)
 	}):
 		return false

--- a/expr/window_function_equals_test.go
+++ b/expr/window_function_equals_test.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package expr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/substrait-io/substrait-go/v9/types"
+)
+
+// TestWindowFunctionEqualsNilOption checks that WindowFunction.Equals treats a nil
+// FunctionOption element as equal without dereferencing it.
+func TestWindowFunctionEqualsNilOption(t *testing.T) {
+	ot := &types.Int64Type{Nullability: types.NullabilityRequired}
+	a := &WindowFunction{funcRef: 1, outputType: ot, options: []*types.FunctionOption{nil}}
+	b := &WindowFunction{funcRef: 1, outputType: ot, options: []*types.FunctionOption{nil}}
+
+	assert.True(t, a.Equals(b))
+}


### PR DESCRIPTION
WindowFunction.Equals compares function options by reading `l.Name`/`r.Name` directly, so comparing a WindowFunction whose options slice contains a nil element panics with a nil-pointer dereference.

ScalarFunction.Equals does not have this problem because it compares options via `proto.Equal`, which is nil-safe. This brings WindowFunction into line by treating a nil option element as equal only to another nil, then comparing fields as before.

Added a regression test that panics without the guard.