### PR TITLE
feat(type)!: make FunctionOption a domain struct

### DIFF
--- a/expr/expression.go
+++ b/expr/expression.go
@@ -82,14 +82,14 @@ func ExprFromProto(e *proto.Expression, baseSchema *types.RecordType, reg Extens
 
 		decl, ok := reg.LookupScalarFunction(et.ScalarFunction.FunctionReference)
 		if !ok {
-			return NewCustomScalarFunc(reg, extensions.NewScalarFuncVariant(id), types.TypeFromProto(et.ScalarFunction.OutputType), et.ScalarFunction.Options, args...)
+			return NewCustomScalarFunc(reg, extensions.NewScalarFuncVariant(id), types.TypeFromProto(et.ScalarFunction.OutputType), types.FunctionOptionsFromProto(et.ScalarFunction.Options), args...)
 		}
 
 		return &ScalarFunction{
 			funcRef:     et.ScalarFunction.FunctionReference,
 			declaration: decl,
 			args:        args,
-			options:     et.ScalarFunction.Options,
+			options:     types.FunctionOptionsFromProto(et.ScalarFunction.Options),
 			outputType:  types.TypeFromProto(et.ScalarFunction.OutputType),
 		}, nil
 	case *proto.Expression_WindowFunction_:
@@ -126,7 +126,7 @@ func ExprFromProto(e *proto.Expression, baseSchema *types.RecordType, reg Extens
 		decl, ok := reg.LookupWindowFunction(et.WindowFunction.FunctionReference)
 		if !ok {
 			fn, err := NewCustomWindowFunc(reg, extensions.NewWindowFuncVariant(id), types.TypeFromProto(et.WindowFunction.OutputType),
-				et.WindowFunction.Options, et.WindowFunction.Invocation, et.WindowFunction.Phase, args...)
+				types.FunctionOptionsFromProto(et.WindowFunction.Options), et.WindowFunction.Invocation, et.WindowFunction.Phase, args...)
 			if err != nil {
 				return nil, err
 			}
@@ -143,7 +143,7 @@ func ExprFromProto(e *proto.Expression, baseSchema *types.RecordType, reg Extens
 			funcRef:     et.WindowFunction.FunctionReference,
 			declaration: decl,
 			args:        args,
-			options:     et.WindowFunction.Options,
+			options:     types.FunctionOptionsFromProto(et.WindowFunction.Options),
 			outputType:  types.TypeFromProto(et.WindowFunction.OutputType),
 			phase:       et.WindowFunction.Phase,
 			invocation:  et.WindowFunction.Invocation,

--- a/expr/function_option_internal_test.go
+++ b/expr/function_option_internal_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package expr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/substrait-io/substrait-go/v9/types"
+)
+
+func opts(pref string) []*types.FunctionOption {
+	return []*types.FunctionOption{{Name: "overflow", Preference: []string{pref}}}
+}
+
+// TestScalarFunctionEqualsOptions checks that ScalarFunction.Equals compares
+// FunctionOptions by name and preference, treating nil elements as equal.
+func TestScalarFunctionEqualsOptions(t *testing.T) {
+	ot := &types.Int64Type{Nullability: types.NullabilityRequired}
+	base := &ScalarFunction{funcRef: 1, outputType: ot, options: opts("ERROR")}
+	same := &ScalarFunction{funcRef: 1, outputType: ot, options: opts("ERROR")}
+	diffPref := &ScalarFunction{funcRef: 1, outputType: ot, options: opts("SILENT")}
+	noOpts := &ScalarFunction{funcRef: 1, outputType: ot}
+
+	assert.True(t, base.Equals(same))
+	assert.False(t, base.Equals(diffPref))
+	assert.False(t, base.Equals(noOpts))
+
+	// nil option elements must compare equal without dereferencing.
+	nilA := &ScalarFunction{funcRef: 1, outputType: ot, options: []*types.FunctionOption{nil}}
+	nilB := &ScalarFunction{funcRef: 1, outputType: ot, options: []*types.FunctionOption{nil}}
+	assert.True(t, nilA.Equals(nilB))
+	assert.False(t, nilA.Equals(base))
+}
+
+// TestFunctionGetOption covers GetOption hit/miss on both scalar and aggregate.
+func TestFunctionGetOption(t *testing.T) {
+	o := opts("ERROR")
+	s := &ScalarFunction{options: o}
+	assert.Equal(t, []string{"ERROR"}, s.GetOption("overflow"))
+	assert.Nil(t, s.GetOption("missing"))
+
+	a := &AggregateFunction{options: o}
+	assert.Equal(t, []string{"ERROR"}, a.GetOption("overflow"))
+	assert.Nil(t, a.GetOption("missing"))
+}

--- a/expr/functions.go
+++ b/expr/functions.go
@@ -11,7 +11,6 @@ import (
 	"github.com/substrait-io/substrait-go/v9/extensions"
 	"github.com/substrait-io/substrait-go/v9/types"
 	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
-	pb "google.golang.org/protobuf/proto"
 )
 
 func FuncArgsEqual(a, b types.FuncArg) bool {
@@ -356,7 +355,7 @@ func (s *ScalarFunction) String() string {
 func (s *ScalarFunction) GetOption(name string) []string {
 	for _, o := range s.options {
 		if name == o.Name {
-			return o.GetPreference()
+			return o.Preference
 		}
 	}
 	return nil
@@ -402,7 +401,7 @@ func (s *ScalarFunction) ToProto() *proto.Expression {
 		RexType: &proto.Expression_ScalarFunction_{
 			ScalarFunction: &proto.Expression_ScalarFunction{
 				FunctionReference: s.funcRef,
-				Options:           s.options,
+				Options:           types.FunctionOptionsToProto(s.options),
 				OutputType:        types.TypeToProto(s.outputType),
 				Arguments:         args,
 			},
@@ -430,7 +429,10 @@ func (s *ScalarFunction) Equals(rhs Expression) bool {
 	}
 
 	return slices.EqualFunc(s.options, other.options, func(a, b *types.FunctionOption) bool {
-		return pb.Equal(a, b)
+		if a == nil || b == nil {
+			return a == b
+		}
+		return a.Name == b.Name && slices.Equal(a.Preference, b.Preference)
 	})
 }
 
@@ -713,7 +715,7 @@ func (w *WindowFunction) ToProto() *proto.Expression {
 			WindowFunction: &proto.Expression_WindowFunction{
 				FunctionReference: w.funcRef,
 				Arguments:         args,
-				Options:           w.options,
+				Options:           types.FunctionOptionsToProto(w.options),
 				OutputType:        types.TypeToProto(w.outputType),
 				Phase:             w.phase,
 				Sorts:             sorts,
@@ -853,14 +855,14 @@ func NewAggregateFunctionFromProto(
 	}
 	decl, ok := reg.LookupAggregateFunction(agg.FunctionReference)
 	if !ok {
-		return NewCustomAggregateFunc(reg, extensions.NewAggFuncVariant(id), types.TypeFromProto(agg.OutputType), agg.Options, agg.Invocation, agg.Phase, sorts, args...)
+		return NewCustomAggregateFunc(reg, extensions.NewAggFuncVariant(id), types.TypeFromProto(agg.OutputType), types.FunctionOptionsFromProto(agg.Options), agg.Invocation, agg.Phase, sorts, args...)
 	}
 
 	return &AggregateFunction{
 		funcRef:     agg.FunctionReference,
 		declaration: decl,
 		args:        args,
-		options:     agg.Options,
+		options:     types.FunctionOptionsFromProto(agg.Options),
 		outputType:  types.TypeFromProto(agg.OutputType),
 		phase:       agg.Phase,
 		invocation:  agg.Invocation,
@@ -931,7 +933,7 @@ func (a *AggregateFunction) String() string {
 func (a *AggregateFunction) GetOption(name string) []string {
 	for _, o := range a.options {
 		if name == o.Name {
-			return o.GetPreference()
+			return o.Preference
 		}
 	}
 	return nil
@@ -967,7 +969,7 @@ func (a *AggregateFunction) ToProto() *proto.AggregateFunction {
 	return &proto.AggregateFunction{
 		FunctionReference: a.funcRef,
 		Arguments:         args,
-		Options:           a.options,
+		Options:           types.FunctionOptionsToProto(a.options),
 		OutputType:        types.TypeToProto(a.outputType),
 		Phase:             a.phase,
 		Sorts:             sorts,

--- a/types/function_option_test.go
+++ b/types/function_option_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package types_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/substrait-io/substrait-go/v9/types"
+	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+func TestFunctionOptionMatchesDescriptor(t *testing.T) {
+	want := map[protoreflect.Name]struct {
+		number protoreflect.FieldNumber
+		kind   protoreflect.Kind
+	}{
+		"name":       {1, protoreflect.StringKind},
+		"preference": {2, protoreflect.StringKind},
+	}
+
+	fields := (&proto.FunctionOption{}).ProtoReflect().Descriptor().Fields()
+	require.Equal(t, len(want), fields.Len(), "spec function option field set changed")
+	require.Equal(t, len(want), reflect.TypeOf(types.FunctionOption{}).NumField(), "types.FunctionOption field count drifted from the spec")
+
+	for i := 0; i < fields.Len(); i++ {
+		f := fields.Get(i)
+		w, ok := want[f.Name()]
+		require.Truef(t, ok, "unexpected spec field %q", f.Name())
+		assert.EqualValues(t, w.number, f.Number(), "%s wire number", f.Name())
+		assert.Equal(t, w.kind, f.Kind(), "%s kind", f.Name())
+	}
+}
+
+func TestFunctionOptionsRoundTrip(t *testing.T) {
+	// a nil slice stays nil rather than becoming empty
+	assert.Nil(t, types.FunctionOptionsToProto(nil))
+	assert.Nil(t, types.FunctionOptionsFromProto(nil))
+
+	opts := []*types.FunctionOption{
+		{Name: "rounding", Preference: []string{"TIE_TO_EVEN", "TIE_AWAY_FROM_ZERO"}},
+		{Name: "overflow"},
+	}
+	pb := types.FunctionOptionsToProto(opts)
+	require.Len(t, pb, len(opts))
+	assert.Equal(t, "rounding", pb[0].Name)
+	assert.Equal(t, []string{"TIE_TO_EVEN", "TIE_AWAY_FROM_ZERO"}, pb[0].Preference)
+	assert.Equal(t, opts, types.FunctionOptionsFromProto(pb))
+}

--- a/types/types.go
+++ b/types/types.go
@@ -67,6 +67,43 @@ func VersionToProto(v Version) *proto.Version {
 	}
 }
 
+// FunctionOption is a named function behavior option: its name and the producer's ordered list of
+// acceptable preference values, mirroring the fields of the Substrait FunctionOption message.
+type FunctionOption struct {
+	Name       string
+	Preference []string
+}
+
+// FunctionOptionsFromProto converts protobuf function option messages to domain FunctionOptions.
+func FunctionOptionsFromProto(opts []*proto.FunctionOption) []*FunctionOption {
+	if opts == nil {
+		return nil
+	}
+	out := make([]*FunctionOption, len(opts))
+	for i, o := range opts {
+		if o == nil {
+			continue
+		}
+		out[i] = &FunctionOption{Name: o.Name, Preference: o.Preference}
+	}
+	return out
+}
+
+// FunctionOptionsToProto encodes domain FunctionOptions as their protobuf messages.
+func FunctionOptionsToProto(opts []*FunctionOption) []*proto.FunctionOption {
+	if opts == nil {
+		return nil
+	}
+	out := make([]*proto.FunctionOption, len(opts))
+	for i, o := range opts {
+		if o == nil {
+			continue
+		}
+		out[i] = &proto.FunctionOption{Name: o.Name, Preference: o.Preference}
+	}
+	return out
+}
+
 // Nullability indicates whether values of a Substrait type may be null.
 type Nullability int32
 
@@ -551,8 +588,6 @@ type (
 	FixedBinary []byte
 	UUID        []byte
 	Enum        string
-
-	FunctionOption = proto.FunctionOption
 
 	// FuncArg corresponds to the protobuf FunctionArgument. Anything
 	// which could be a function argument should meet this interface.


### PR DESCRIPTION
Replace the `proto.FunctionOption` alias with a substrait-go struct plus slice converters at the proto seam, so the core packages no longer expose a protobuf type here.

`ScalarFunction.Equals` previously compared options with `proto.Equal`; it now compares the domain fields directly (name + preferences), preserving the same semantics including nil handling.

BREAKING CHANGE: `types.FunctionOption` is now a substrait-go struct, not an alias of `proto.FunctionOption`.

Part of #280.
