### PR TITLE
feat(type)!: make PrecisionTime, PrecisionTimestamp, PrecisionTimestampTz domain structs

### DIFF
--- a/expr/literals.go
+++ b/expr/literals.go
@@ -995,9 +995,9 @@ func NewLiteral[T allLiteralTypes](val T, nullable bool) (Literal, error) {
 	case *types.PrecisionTime:
 		return NewPrecisionTimeLiteral(v.Value, types.TimePrecision(v.Precision), getNullability(nullable)), nil
 	case *types.PrecisionTimestamp:
-		return NewPrecisionTimestampLiteral(v.PrecisionTimestamp.Value, types.TimePrecision(v.PrecisionTimestamp.Precision), getNullability(nullable)), nil
+		return NewPrecisionTimestampLiteral(v.Value, types.TimePrecision(v.Precision), getNullability(nullable)), nil
 	case *types.PrecisionTimestampTz:
-		return NewPrecisionTimestampTzLiteral(v.PrecisionTimestampTz.Value, types.TimePrecision(v.PrecisionTimestampTz.Precision), getNullability(nullable)), nil
+		return NewPrecisionTimestampTzLiteral(v.Value, types.TimePrecision(v.Precision), getNullability(nullable)), nil
 	}
 
 	return nil, substraitgo.ErrNotImplemented

--- a/literal/utils.go
+++ b/literal/utils.go
@@ -362,10 +362,8 @@ func NewPrecisionTimestampFromTime(precision types.TimePrecision, tm time.Time, 
 // NewPrecisionTimestamp creates a new PrecisionTimestamp literal with given precision and value.
 func NewPrecisionTimestamp(precision types.TimePrecision, value int64, nullable bool) (expr.Literal, error) {
 	return expr.NewLiteral(&types.PrecisionTimestamp{
-		PrecisionTimestamp: &proto.Expression_Literal_PrecisionTimestamp{
-			Precision: int32(precision),
-			Value:     value,
-		},
+		Precision: int32(precision),
+		Value:     value,
 	}, nullable)
 }
 
@@ -385,10 +383,8 @@ func NewPrecisionTimestampTzFromTime(precision types.TimePrecision, tm time.Time
 // NewPrecisionTimestampTz creates a new PrecisionTimestampTz literal with given precision and value.
 func NewPrecisionTimestampTz(precision types.TimePrecision, value int64, nullable bool) (expr.Literal, error) {
 	return expr.NewLiteral(&types.PrecisionTimestampTz{
-		PrecisionTimestampTz: &proto.Expression_Literal_PrecisionTimestamp{
-			Precision: int32(precision),
-			Value:     value,
-		},
+		Precision: int32(precision),
+		Value:     value,
 	}, nullable)
 }
 

--- a/types/precision_time_test.go
+++ b/types/precision_time_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package types_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/substrait-io/substrait-go/v9/types"
+	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+func TestPrecisionTimeMatchesDescriptor(t *testing.T) {
+	want := map[protoreflect.Name]struct {
+		number protoreflect.FieldNumber
+		kind   protoreflect.Kind
+	}{
+		"precision": {1, protoreflect.Int32Kind},
+		"value":     {2, protoreflect.Int64Kind},
+	}
+
+	fields := (&proto.Expression_Literal_PrecisionTime{}).ProtoReflect().Descriptor().Fields()
+	require.Equal(t, len(want), fields.Len(), "spec precision_time field set changed")
+	require.Equal(t, len(want), reflect.TypeOf(types.PrecisionTime{}).NumField(), "types.PrecisionTime field count drifted from the spec")
+
+	for i := 0; i < fields.Len(); i++ {
+		f := fields.Get(i)
+		w, ok := want[f.Name()]
+		require.Truef(t, ok, "unexpected spec field %q", f.Name())
+		assert.EqualValues(t, w.number, f.Number(), "%s wire number", f.Name())
+		assert.Equal(t, w.kind, f.Kind(), "%s kind", f.Name())
+	}
+}
+
+func TestPrecisionTimestampMatchesDescriptor(t *testing.T) {
+	want := map[protoreflect.Name]struct {
+		number protoreflect.FieldNumber
+		kind   protoreflect.Kind
+	}{
+		"precision": {1, protoreflect.Int32Kind},
+		"value":     {2, protoreflect.Int64Kind},
+	}
+
+	fields := (&proto.Expression_Literal_PrecisionTimestamp{}).ProtoReflect().Descriptor().Fields()
+	require.Equal(t, len(want), fields.Len(), "spec precision_timestamp field set changed")
+	require.Equal(t, len(want), reflect.TypeOf(types.PrecisionTimestamp{}).NumField(), "types.PrecisionTimestamp field count drifted from the spec")
+
+	for i := 0; i < fields.Len(); i++ {
+		f := fields.Get(i)
+		w, ok := want[f.Name()]
+		require.Truef(t, ok, "unexpected spec field %q", f.Name())
+		assert.EqualValues(t, w.number, f.Number(), "%s wire number", f.Name())
+		assert.Equal(t, w.kind, f.Kind(), "%s kind", f.Name())
+	}
+}
+
+func TestPrecisionTimestampTzMatchesDescriptor(t *testing.T) {
+	want := map[protoreflect.Name]struct {
+		number protoreflect.FieldNumber
+		kind   protoreflect.Kind
+	}{
+		"precision": {1, protoreflect.Int32Kind},
+		"value":     {2, protoreflect.Int64Kind},
+	}
+
+	fields := (&proto.Expression_Literal_PrecisionTimestamp{}).ProtoReflect().Descriptor().Fields()
+	require.Equal(t, len(want), fields.Len(), "spec precision_timestamp_tz field set changed")
+	require.Equal(t, len(want), reflect.TypeOf(types.PrecisionTimestampTz{}).NumField(), "types.PrecisionTimestampTz field count drifted from the spec")
+
+	for i := 0; i < fields.Len(); i++ {
+		f := fields.Get(i)
+		w, ok := want[f.Name()]
+		require.Truef(t, ok, "unexpected spec field %q", f.Name())
+		assert.EqualValues(t, w.number, f.Number(), "%s wire number", f.Name())
+		assert.Equal(t, w.kind, f.Kind(), "%s kind", f.Name())
+	}
+}

--- a/types/types.go
+++ b/types/types.go
@@ -307,11 +307,8 @@ func (b CastFailBehavior) String() string {
 }
 
 type (
-	IntervalDayToSecond  = proto.Expression_Literal_IntervalDayToSecond
-	UserDefinedLiteral   = proto.Expression_Literal_UserDefined
-	PrecisionTime        = proto.Expression_Literal_PrecisionTime
-	PrecisionTimestamp   = proto.Expression_Literal_PrecisionTimestamp_
-	PrecisionTimestampTz = proto.Expression_Literal_PrecisionTimestampTz
+	IntervalDayToSecond = proto.Expression_Literal_IntervalDayToSecond
+	UserDefinedLiteral  = proto.Expression_Literal_UserDefined
 )
 
 // VarChar is a variable-length character literal: its value and length, mirroring the fields of
@@ -334,6 +331,29 @@ type Decimal struct {
 type IntervalYearToMonth struct {
 	Years  int32
 	Months int32
+}
+
+// PrecisionTime is a time-of-day literal: the number of precision units past
+// midnight, mirroring the fields of the Substrait PrecisionTime literal message.
+type PrecisionTime struct {
+	Precision int32
+	Value     int64
+}
+
+// PrecisionTimestamp is a timestamp literal in an unspecified time zone: the
+// number of precision units since the UNIX epoch, mirroring the fields of the
+// Substrait PrecisionTimestamp literal message.
+type PrecisionTimestamp struct {
+	Precision int32
+	Value     int64
+}
+
+// PrecisionTimestampTz is a UTC timestamp literal: the number of precision units
+// since the UNIX epoch, mirroring the fields of the Substrait PrecisionTimestamp
+// literal message that backs the precision_timestamp_tz field.
+type PrecisionTimestampTz struct {
+	Precision int32
+	Value     int64
 }
 
 // TypeFromProto returns the appropriate Type object from a protobuf


### PR DESCRIPTION
Replace the `proto.Expression_Literal_PrecisionTime` /
`PrecisionTimestamp` / `PrecisionTimestampTz` aliases with substrait-go structs
holding `Precision`/`Value`, flattening the oneof-wrapper aliases at the
construction and read seams so the core packages no longer expose protobuf types
here.

**BREAKING CHANGE:** `types.PrecisionTime`, `types.PrecisionTimestamp`, and
`types.PrecisionTimestampTz` are now substrait-go structs, not aliases of their
protobuf literal messages / oneof wrappers.

Part of #280.
