### PR TITLE
fix(extensions): preserve imported anchor assignments

### DIFF
--- a/extensions/extension_anchor_test.go
+++ b/extensions/extension_anchor_test.go
@@ -145,3 +145,49 @@ func TestExtensionSetPreservesImportedURNAnchors(t *testing.T) {
 		})
 	}
 }
+
+func TestExtensionSetAllocatesAfterConsecutiveImportedAnchors(t *testing.T) {
+	c := extensions.GetDefaultCollectionWithNoError()
+	const urn = extensions.SubstraitDefaultURNPrefix + "functions_arithmetic"
+	ids := []extensions.FunctionID{
+		{URN: urn, Name: "add:i32_i32"},
+		{URN: urn, Name: "subtract:i32_i32"},
+		{URN: urn, Name: "multiply:i32_i32"},
+		{URN: urn, Name: "divide:i32_i32"},
+		{URN: urn, Name: "modulus:i32_i32"},
+	}
+	for _, firstAnchor := range []uint32{1, 3} {
+		t.Run(fmt.Sprint(firstAnchor), func(t *testing.T) {
+			plan := &proto.Plan{
+				ExtensionUrns: []*extensionspb.SimpleExtensionURN{{ExtensionUrnAnchor: 1, Urn: urn}},
+			}
+			for i, id := range ids[:2] {
+				plan.Extensions = append(plan.Extensions, &extensionspb.SimpleExtensionDeclaration{
+					MappingType: &extensionspb.SimpleExtensionDeclaration_ExtensionFunction_{
+						ExtensionFunction: &extensionspb.SimpleExtensionDeclaration_ExtensionFunction{
+							ExtensionUrnReference: 1, FunctionAnchor: firstAnchor + uint32(i), Name: id.Name,
+						},
+					},
+				})
+			}
+			s, err := extensions.GetExtensionSet(plan, c)
+			require.NoError(t, err)
+			for i := 2; i < 4; i++ {
+				assert.Equal(t, firstAnchor+uint32(i), s.GetFuncAnchor(ids[i]))
+			}
+
+			plan.ExtensionUrns, plan.Extensions = s.ToProto(c)
+			require.Len(t, plan.Extensions, 4)
+			s, err = extensions.GetExtensionSet(plan, c)
+			require.NoError(t, err)
+			assert.Equal(t, firstAnchor+4, s.GetFuncAnchor(ids[4]), "allocation must resume without replacing a round-tripped declaration")
+			for i, id := range ids {
+				anchor := firstAnchor + uint32(i)
+				assert.Equal(t, anchor, s.GetFuncAnchor(id))
+				decoded, ok := s.DecodeFunc(anchor)
+				assert.True(t, ok)
+				assert.Equal(t, id, decoded)
+			}
+		})
+	}
+}

--- a/extensions/extension_anchor_test.go
+++ b/extensions/extension_anchor_test.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package extensions_test
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/substrait-io/substrait-go/v9/extensions"
+	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
+	extensionspb "github.com/substrait-io/substrait-protobuf/go/substraitpb/extensions"
+)
+
+func TestExtensionSetPreservesImportedAnchors(t *testing.T) {
+	c := extensions.GetDefaultCollectionWithNoError()
+	const arithmeticURN = extensions.SubstraitDefaultURNPrefix + "functions_arithmetic"
+	const variationURN = extensions.SubstraitDefaultURNPrefix + "type_variations"
+
+	t.Run("function", func(t *testing.T) {
+		testImportedAnchors(t, c, arithmeticURN,
+			extensions.FunctionID{URN: arithmeticURN, Name: "add:i32_i32"},
+			extensions.FunctionID{URN: arithmeticURN, Name: "subtract:i32_i32"},
+			extensions.Set.GetFuncAnchor, extensions.Set.DecodeFunc,
+			func(anchor uint32, id extensions.FunctionID) *extensionspb.SimpleExtensionDeclaration {
+				return &extensionspb.SimpleExtensionDeclaration{MappingType: &extensionspb.SimpleExtensionDeclaration_ExtensionFunction_{
+					ExtensionFunction: &extensionspb.SimpleExtensionDeclaration_ExtensionFunction{
+						ExtensionUrnReference: 1, FunctionAnchor: anchor, Name: id.Name,
+					},
+				}}
+			}, true)
+	})
+
+	t.Run("type", func(t *testing.T) {
+		var c extensions.Collection
+		require.NoError(t, c.Load(strings.NewReader(sampleYAML)))
+		const urn = "extension:test:sample"
+		testImportedAnchors(t, &c, urn,
+			extensions.TypeID{URN: urn, Name: "point"},
+			extensions.TypeID{URN: urn, Name: "line"},
+			extensions.Set.GetTypeAnchor, extensions.Set.DecodeType,
+			func(anchor uint32, id extensions.TypeID) *extensionspb.SimpleExtensionDeclaration {
+				return &extensionspb.SimpleExtensionDeclaration{MappingType: &extensionspb.SimpleExtensionDeclaration_ExtensionType_{
+					ExtensionType: &extensionspb.SimpleExtensionDeclaration_ExtensionType{
+						ExtensionUrnReference: 1, TypeAnchor: anchor, Name: id.Name,
+					},
+				}}
+			}, true)
+	})
+
+	t.Run("type variation", func(t *testing.T) {
+		testImportedAnchors(t, c, variationURN,
+			extensions.TypeVariationID{URN: variationURN, Name: "dict4"},
+			extensions.TypeVariationID{URN: variationURN, Name: "bigoffset"},
+			extensions.Set.GetTypeVariationAnchor, extensions.Set.DecodeTypeVariation,
+			func(anchor uint32, id extensions.TypeVariationID) *extensionspb.SimpleExtensionDeclaration {
+				return &extensionspb.SimpleExtensionDeclaration{MappingType: &extensionspb.SimpleExtensionDeclaration_ExtensionTypeVariation_{
+					ExtensionTypeVariation: &extensionspb.SimpleExtensionDeclaration_ExtensionTypeVariation{
+						ExtensionUrnReference: 1, TypeVariationAnchor: anchor, Name: id.Name,
+					},
+				}}
+			}, false)
+	})
+}
+
+func testImportedAnchors[T comparable](t *testing.T, c *extensions.Collection, urn string, importedID, newID T,
+	getAnchor func(extensions.Set, T) uint32, decode func(extensions.Set, uint32) (T, bool),
+	declaration func(uint32, T) *extensionspb.SimpleExtensionDeclaration, zeroAllowed bool) {
+	t.Helper()
+	anchors := []uint32{2, math.MaxUint32}
+	if zeroAllowed {
+		anchors = append(anchors, 0)
+	}
+	for _, importedAnchor := range anchors {
+		t.Run(fmt.Sprint(importedAnchor), func(t *testing.T) {
+			plan := &proto.Plan{
+				ExtensionUrns: []*extensionspb.SimpleExtensionURN{{ExtensionUrnAnchor: 1, Urn: urn}},
+				Extensions:    []*extensionspb.SimpleExtensionDeclaration{declaration(importedAnchor, importedID)},
+			}
+			s, err := extensions.GetExtensionSet(plan, c)
+			require.NoError(t, err)
+			newAnchor := getAnchor(s, newID)
+			assert.NotZero(t, newAnchor)
+			assert.NotEqual(t, importedAnchor, newAnchor)
+			assert.Equal(t, newAnchor, getAnchor(s, newID), "repeated lookup must reuse its anchor")
+			assert.Equal(t, importedAnchor, getAnchor(s, importedID), "imported anchors must remain stable")
+
+			check := func(s extensions.Set) {
+				id, ok := decode(s, importedAnchor)
+				assert.True(t, ok)
+				assert.Equal(t, importedID, id)
+				id, ok = decode(s, newAnchor)
+				assert.True(t, ok)
+				assert.Equal(t, newID, id)
+			}
+			check(s)
+			plan.ExtensionUrns, plan.Extensions = s.ToProto(c)
+			require.Len(t, plan.Extensions, 2)
+			s, err = extensions.GetExtensionSet(plan, c)
+			require.NoError(t, err)
+			check(s)
+		})
+	}
+}
+
+func TestExtensionSetPreservesImportedURNAnchors(t *testing.T) {
+	c := extensions.GetDefaultCollectionWithNoError()
+	importedID := extensions.FunctionID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Name: "add:i32_i32"}
+	newID := extensions.FunctionID{URN: extensions.SubstraitDefaultURNPrefix + "functions_boolean", Name: "and:bool_bool"}
+	for _, importedAnchor := range []uint32{0, 2, math.MaxUint32} {
+		t.Run(fmt.Sprint(importedAnchor), func(t *testing.T) {
+			plan := &proto.Plan{
+				ExtensionUrns: []*extensionspb.SimpleExtensionURN{{ExtensionUrnAnchor: importedAnchor, Urn: importedID.URN}},
+				Extensions: []*extensionspb.SimpleExtensionDeclaration{{MappingType: &extensionspb.SimpleExtensionDeclaration_ExtensionFunction_{
+					ExtensionFunction: &extensionspb.SimpleExtensionDeclaration_ExtensionFunction{
+						ExtensionUrnReference: importedAnchor, FunctionAnchor: 1, Name: importedID.Name,
+					},
+				}}},
+			}
+			s, err := extensions.GetExtensionSet(plan, c)
+			require.NoError(t, err)
+			var functionAnchor uint32
+			require.NotPanics(t, func() { functionAnchor = s.GetFuncAnchor(newID) })
+			newAnchor, ok := s.FindURN(newID.URN)
+			require.True(t, ok)
+			assert.NotZero(t, newAnchor)
+			assert.NotEqual(t, importedAnchor, newAnchor)
+			anchor, ok := s.FindURN(importedID.URN)
+			require.True(t, ok)
+			assert.Equal(t, importedAnchor, anchor)
+
+			plan.ExtensionUrns, plan.Extensions = s.ToProto(c)
+			require.Len(t, plan.ExtensionUrns, 2)
+			s, err = extensions.GetExtensionSet(plan, c)
+			require.NoError(t, err)
+			id, ok := s.DecodeFunc(1)
+			require.True(t, ok)
+			assert.Equal(t, importedID, id)
+			id, ok = s.DecodeFunc(functionAnchor)
+			require.True(t, ok)
+			assert.Equal(t, newID, id)
+		})
+	}
+}

--- a/extensions/extension_mgr.go
+++ b/extensions/extension_mgr.go
@@ -363,16 +363,20 @@ func NewSet() Set {
 }
 
 type set struct {
-	urns map[uint32]string
+	urns          map[uint32]string
+	nextURNAnchor uint32
 
-	typesMap map[uint32]TypeID
-	types    map[TypeID]uint32
+	typesMap       map[uint32]TypeID
+	types          map[TypeID]uint32
+	nextTypeAnchor uint32
 
-	typeVariationMap map[uint32]TypeVariationID
-	typeVariations   map[TypeVariationID]uint32
+	typeVariationMap        map[uint32]TypeVariationID
+	typeVariations          map[TypeVariationID]uint32
+	nextTypeVariationAnchor uint32
 
-	funcMap map[uint32]FunctionID
-	funcs   map[FunctionID]uint32
+	funcMap        map[uint32]FunctionID
+	funcs          map[FunctionID]uint32
+	nextFuncAnchor uint32
 }
 
 func (e *set) ToProto(c *Collection) ([]*extensions.SimpleExtensionURN, []*extensions.SimpleExtensionDeclaration) {
@@ -512,7 +516,7 @@ func (e *set) GetTypeAnchor(id TypeID) uint32 {
 	a, ok := e.types[id]
 	if !ok {
 		e.addOrGetURN(id.URN)
-		a = unusedAnchor(e.typesMap)
+		a = unusedAnchor(e.typesMap, &e.nextTypeAnchor)
 		e.encodeType(a, id)
 	}
 	return a
@@ -522,7 +526,7 @@ func (e *set) GetFuncAnchor(id FunctionID) uint32 {
 	a, ok := e.funcs[id]
 	if !ok {
 		e.addOrGetURN(id.URN)
-		a = unusedAnchor(e.funcMap)
+		a = unusedAnchor(e.funcMap, &e.nextFuncAnchor)
 		e.encodeFunc(a, id)
 	}
 	return a
@@ -532,7 +536,7 @@ func (e *set) GetTypeVariationAnchor(id TypeVariationID) uint32 {
 	a, ok := e.typeVariations[id]
 	if !ok {
 		e.addOrGetURN(id.URN)
-		a = unusedAnchor(e.typeVariationMap)
+		a = unusedAnchor(e.typeVariationMap, &e.nextTypeVariationAnchor)
 		e.encodeTypeVariation(a, id)
 	}
 	return a
@@ -564,12 +568,20 @@ func (e *set) FindURN(urn string) (uint32, bool) {
 
 // unusedAnchor preserves the dense allocation sequence while avoiding collisions
 // with imported anchors. Zero is reserved for the system-preferred type variation.
-func unusedAnchor[T any](anchors map[uint32]T) uint32 {
-	for anchor := uint32(len(anchors)) + 1; ; anchor++ {
+// The cursor skips previously scanned ranges on subsequent allocations.
+func unusedAnchor[T any](anchors map[uint32]T, next *uint32) uint32 {
+	if *next == 0 {
+		*next = uint32(len(anchors)) + 1
+	}
+	for anchor := *next; ; anchor++ {
 		if anchor == 0 {
 			continue
 		}
 		if _, exists := anchors[anchor]; !exists {
+			*next = anchor + 1
+			if *next == 0 {
+				*next = 1
+			}
 			return anchor
 		}
 	}
@@ -581,7 +593,7 @@ func (e *set) addOrGetURN(urn string) uint32 {
 			return k
 		}
 	}
-	anchor := unusedAnchor(e.urns)
+	anchor := unusedAnchor(e.urns, &e.nextURNAnchor)
 	e.urns[anchor] = urn
 	return anchor
 }

--- a/extensions/extension_mgr.go
+++ b/extensions/extension_mgr.go
@@ -511,11 +511,8 @@ func (e *set) DecodeType(anchor uint32) (id TypeID, ok bool) {
 func (e *set) GetTypeAnchor(id TypeID) uint32 {
 	a, ok := e.types[id]
 	if !ok {
-		_, err := e.addOrGetURN(id.URN)
-		if err != nil {
-			panic(err)
-		}
-		a = uint32(len(e.types)) + 1
+		e.addOrGetURN(id.URN)
+		a = unusedAnchor(e.typesMap)
 		e.encodeType(a, id)
 	}
 	return a
@@ -524,11 +521,8 @@ func (e *set) GetTypeAnchor(id TypeID) uint32 {
 func (e *set) GetFuncAnchor(id FunctionID) uint32 {
 	a, ok := e.funcs[id]
 	if !ok {
-		_, err := e.addOrGetURN(id.URN)
-		if err != nil {
-			panic(err)
-		}
-		a = uint32(len(e.funcs)) + 1
+		e.addOrGetURN(id.URN)
+		a = unusedAnchor(e.funcMap)
 		e.encodeFunc(a, id)
 	}
 	return a
@@ -537,14 +531,8 @@ func (e *set) GetFuncAnchor(id FunctionID) uint32 {
 func (e *set) GetTypeVariationAnchor(id TypeVariationID) uint32 {
 	a, ok := e.typeVariations[id]
 	if !ok {
-		_, err := e.addOrGetURN(id.URN)
-		if err != nil {
-			panic(err)
-		}
-		// add 1 to the length to avoid an anchor of 0
-		// so that it's easier to tell when there is no
-		// type variation.
-		a = uint32(len(e.typeVariations)) + 1
+		e.addOrGetURN(id.URN)
+		a = unusedAnchor(e.typeVariationMap)
 		e.encodeTypeVariation(a, id)
 	}
 	return a
@@ -574,19 +562,28 @@ func (e *set) FindURN(urn string) (uint32, bool) {
 	return 0, false
 }
 
-func (e *set) addOrGetURN(urn string) (uint32, error) {
-	for k, v := range e.urns {
-		if v == urn {
-			return k, nil
+// unusedAnchor preserves the dense allocation sequence while avoiding collisions
+// with imported anchors. Zero is reserved for the system-preferred type variation.
+func unusedAnchor[T any](anchors map[uint32]T) uint32 {
+	for anchor := uint32(len(anchors)) + 1; ; anchor++ {
+		if anchor == 0 {
+			continue
+		}
+		if _, exists := anchors[anchor]; !exists {
+			return anchor
 		}
 	}
-	sz := uint32(len(e.urns)) + 1
-	if _, ok := e.urns[sz]; ok {
-		return 0, fmt.Errorf("%w: URN anchor %d already exists", substraitgo.ErrKeyExists, sz)
-	}
+}
 
-	e.urns[sz] = urn
-	return sz, nil
+func (e *set) addOrGetURN(urn string) uint32 {
+	for k, v := range e.urns {
+		if v == urn {
+			return k
+		}
+	}
+	anchor := unusedAnchor(e.urns)
+	e.urns[anchor] = urn
+	return anchor
 }
 
 type TopLevel interface {


### PR DESCRIPTION
Importing a plan whose only function anchor is `2`, then registering another function, previously reused anchor `2`. This overwrote the original lookup and serialized two functions with the same anchor. Types and type variations had the same issue, while a sparse URN anchor could cause a panic.

Allocate an unused nonzero anchor in each namespace while preserving imported assignments and the existing dense allocation sequence. Each namespace keeps an allocation cursor so consecutive additions do not repeatedly scan the same occupied range. Regression tests cover import, allocation, serialization, and reimport with sparse anchors, consecutive occupied ranges, zero where permitted, and `MaxUint32`.

## Validation

The regression tests fail on the base commit and pass with this change:

```sh
go test ./extensions -run TestExtensionSetPreservesImported -count=1
```

Also verified `go test ./...`, `go build ./...`, and `golangci-lint run` with CI's version 2.1.6.

## Downsides

The first allocation after a sparse import may probe several occupied anchors. Subsequent allocations resume after the previous result. The usual dense allocation path still requires one availability check.
