### PR TITLE
fix(plan): correct aggregate grouping schemas

### DIFF
--- a/plan/aggregate_schema_test.go
+++ b/plan/aggregate_schema_test.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package plan_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/substrait-io/substrait-go/v9/expr"
+	"github.com/substrait-io/substrait-go/v9/extensions"
+	"github.com/substrait-io/substrait-go/v9/plan"
+	"github.com/substrait-io/substrait-go/v9/types"
+	substraitproto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestAggregateGroupingSchema(t *testing.T) {
+	stringType := &types.StringType{Nullability: types.NullabilityRequired}
+	boolType := &types.BooleanType{Nullability: types.NullabilityRequired}
+	floatType := &types.Float64Type{Nullability: types.NullabilityNullable}
+	countType := &types.Int64Type{Nullability: types.NullabilityRequired}
+	groupingIndexType := &types.Int32Type{Nullability: types.NullabilityRequired}
+
+	for _, tc := range []struct {
+		name       string
+		groups     [][]uint32
+		keyCount   int
+		noMeasures bool
+		want       []types.Type
+	}{
+		{
+			name: "permuted references preserve declaration order", groups: [][]uint32{{2, 0, 1}}, keyCount: 3,
+			want: []types.Type{stringType, boolType, floatType, countType, floatType},
+		},
+		{
+			name: "overlapping sets share columns", groups: [][]uint32{{2, 0}, {0, 1}}, keyCount: 3,
+			want: []types.Type{stringType, &types.BooleanType{Nullability: types.NullabilityNullable}, floatType, countType, floatType, groupingIndexType},
+		},
+		{
+			name: "grand total makes keys nullable", groups: [][]uint32{{0, 1, 2}, {}}, keyCount: 3,
+			want: []types.Type{&types.StringType{Nullability: types.NullabilityNullable}, &types.BooleanType{Nullability: types.NullabilityNullable}, floatType, countType, floatType, groupingIndexType},
+		},
+		{
+			name: "identical sets retain required keys", groups: [][]uint32{{0, 1, 2}, {2, 1, 0}}, keyCount: 3,
+			want: []types.Type{stringType, boolType, floatType, countType, floatType, groupingIndexType},
+		},
+		{
+			name: "single empty grouping set", groups: [][]uint32{{}},
+			want: []types.Type{countType, floatType},
+		},
+		{
+			name: "no grouping sets",
+			want: []types.Type{countType, floatType},
+		},
+		{
+			name: "grouping sets without measures", groups: [][]uint32{{0}, {}}, keyCount: 1, noMeasures: true,
+			want: []types.Type{&types.StringType{Nullability: types.NullabilityNullable}, groupingIndexType},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b := plan.NewBuilderDefault()
+			scan := b.NamedScan([]string{"test"}, types.NamedStruct{
+				Names: []string{"a", "b", "c"},
+				Struct: types.StructType{Nullability: types.NullabilityRequired,
+					Types: []types.Type{stringType, boolType, floatType}},
+			})
+			var measures []plan.AggRelMeasure
+			if !tc.noMeasures {
+				count, err := b.AggregateFn(extensions.SubstraitDefaultURNPrefix+"functions_aggregate_generic", "count", nil)
+				require.NoError(t, err)
+				value, err := b.RootFieldRef(scan, 2)
+				require.NoError(t, err)
+				avg, err := b.AggregateFn(extensions.SubstraitDefaultURNPrefix+"functions_arithmetic", "avg", nil, value)
+				require.NoError(t, err)
+				measures = []plan.AggRelMeasure{b.Measure(count, nil), b.Measure(avg, nil)}
+			}
+			arb := b.GetRelBuilder().AggregateRel(scan, measures)
+			for i := 0; i < tc.keyCount; i++ {
+				key, err := b.RootFieldRef(scan, int32(i))
+				require.NoError(t, err)
+				arb.AddExpression(key)
+			}
+			for _, group := range tc.groups {
+				arb.AddGroupingSet(group)
+			}
+			aggregate, err := arb.Build()
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, aggregate.RecordType().Types())
+
+			// Valid root names must be accepted for the specified output schema,
+			// including after serializing and decoding the entire plan.
+			names := []string{"a", "b", "c", "d", "e", "f"}[:len(tc.want)]
+			p, err := b.Plan(aggregate, names)
+			require.NoError(t, err)
+			serialized, err := p.ToProto()
+			require.NoError(t, err)
+			wire, err := proto.Marshal(serialized)
+			require.NoError(t, err)
+			decoded := &substraitproto.Plan{}
+			require.NoError(t, proto.Unmarshal(wire, decoded))
+			roundTrip, err := plan.FromProto(decoded, extensions.GetDefaultCollectionWithNoError())
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, roundTrip.GetRoots()[0].Input().RecordType().Types())
+		})
+	}
+}
+
+func TestAggregateGroupingSchemaEmit(t *testing.T) {
+	b := plan.NewBuilderDefault()
+	scan := b.NamedScan([]string{"test"}, baseSchema)
+	count, err := b.AggregateFn(extensions.SubstraitDefaultURNPrefix+"functions_aggregate_generic", "count", nil)
+	require.NoError(t, err)
+	key, err := b.RootFieldRef(scan, 0)
+	require.NoError(t, err)
+	aggregate, err := b.AggregateExprs(scan, []plan.AggRelMeasure{b.Measure(count, nil)}, []expr.Expression{key}, []expr.Expression{})
+	require.NoError(t, err)
+	remapped, err := aggregate.Remap(2, 1, 0)
+	require.NoError(t, err)
+	want := []types.Type{
+		&types.Int32Type{Nullability: types.NullabilityRequired},
+		&types.Int64Type{Nullability: types.NullabilityRequired},
+		&types.StringType{Nullability: types.NullabilityNullable},
+	}
+	assert.Equal(t, want, remapped.RecordType().Types())
+	p, err := b.Plan(remapped, []string{"grouping", "count", "key"})
+	require.NoError(t, err)
+	serialized, err := p.ToProto()
+	require.NoError(t, err)
+	assert.Equal(t, []int32{2, 1, 0}, serialized.Relations[0].GetRoot().Input.GetAggregate().Common.GetEmit().OutputMapping)
+	roundTrip, err := plan.FromProto(serialized, extensions.GetDefaultCollectionWithNoError())
+	require.NoError(t, err)
+	assert.Equal(t, want, roundTrip.GetRoots()[0].Input().RecordType().Types())
+}
+
+func TestAggregateGroupingSchemaPreservesInputTypes(t *testing.T) {
+	for _, inputType := range []types.Type{
+		&types.StringType{Nullability: types.NullabilityRequired, TypeVariationRef: 7},
+		&types.IntervalDayType{Precision: types.PrecisionMicroSeconds, Nullability: types.NullabilityRequired, TypeVariationRef: 7},
+		&types.PrecisionTimestampType{Precision: types.PrecisionNanoSeconds, Nullability: types.NullabilityRequired, TypeVariationRef: 7},
+	} {
+		t.Run(inputType.String(), func(t *testing.T) {
+			b := plan.NewBuilderDefault()
+			scan := b.NamedScan([]string{"test"}, types.NamedStruct{
+				Names:  []string{"key"},
+				Struct: types.StructType{Nullability: types.NullabilityRequired, Types: []types.Type{inputType}},
+			})
+			key, err := b.RootFieldRef(scan, 0)
+			require.NoError(t, err)
+			aggregate, err := b.AggregateExprs(scan, nil, []expr.Expression{key}, []expr.Expression{})
+			require.NoError(t, err)
+			before := proto.Clone(types.TypeToProto(inputType))
+			for i := 0; i < 2; i++ {
+				output := aggregate.RecordType().Types()[0]
+				assert.Equal(t, types.NullabilityNullable, output.GetNullability())
+				assert.Equal(t, uint32(7), output.GetTypeVariationReference())
+				assert.Equal(t, inputType.GetParameters(), output.GetParameters())
+				assert.True(t, proto.Equal(before, types.TypeToProto(inputType)), "computing the aggregate schema must not mutate the input type")
+				assert.Equal(t, types.NullabilityRequired, key.GetType().GetNullability())
+			}
+		})
+	}
+}

--- a/plan/relations.go
+++ b/plan/relations.go
@@ -1173,16 +1173,26 @@ type AggregateRel struct {
 }
 
 func (ar *AggregateRel) directOutputSchema() types.RecordType {
-	groupTypes := make([]types.Type, 0, len(ar.groupingReferences)+len(ar.measures))
-	for _, g := range ar.groupingReferences {
-		for _, e := range g {
-			expression := ar.groupingExpressions[e]
-			groupTypes = append(groupTypes, expression.GetType())
+	groupTypes := make([]types.Type, 0, len(ar.groupingExpressions)+len(ar.measures)+1)
+	// Each declared grouping expression contributes one column, regardless of
+	// its position or occurrence in the grouping sets.
+	for i, expression := range ar.groupingExpressions {
+		typ := expression.GetType()
+		for _, group := range ar.groupingReferences {
+			if !slices.Contains(group, uint32(i)) {
+				// Rows from this grouping set contain null for this column.
+				typ = typ.WithNullability(types.NullabilityNullable)
+				break
+			}
 		}
+		groupTypes = append(groupTypes, typ)
 	}
 
 	for _, m := range ar.measures {
 		groupTypes = append(groupTypes, m.measure.GetType())
+	}
+	if len(ar.groupingReferences) > 1 {
+		groupTypes = append(groupTypes, &types.Int32Type{Nullability: types.NullabilityRequired})
 	}
 
 	return *types.NewRecordTypeFromTypes(groupTypes)

--- a/types/interval_day_nullability_test.go
+++ b/types/interval_day_nullability_test.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIntervalDayWithNullabilityCopiesType(t *testing.T) {
+	original := &IntervalDayType{
+		Precision: PrecisionMicroSeconds, Nullability: NullabilityRequired, TypeVariationRef: 7,
+	}
+	got := original.WithNullability(NullabilityNullable)
+	assert.NotSame(t, original, got)
+	assert.Equal(t, NullabilityRequired, original.Nullability)
+	assert.Equal(t, &IntervalDayType{
+		Precision: PrecisionMicroSeconds, Nullability: NullabilityNullable, TypeVariationRef: 7,
+	}, got)
+}

--- a/types/interval_day_type.go
+++ b/types/interval_day_type.go
@@ -19,8 +19,9 @@ func (m *IntervalDayType) GetPrecisionProtoVal() int32 {
 
 func (*IntervalDayType) isRootRef() {}
 func (m *IntervalDayType) WithNullability(n Nullability) Type {
-	m.Nullability = n
-	return m
+	out := *m
+	out.Nullability = n
+	return &out
 }
 
 func (m *IntervalDayType) GetType() Type                     { return m }


### PR DESCRIPTION
Aggregate output schemas previously concatenated each grouping set's references. This reordered or duplicated grouping columns, left nullable grouping keys marked required, and omitted the grouping-set index. Valid root names and emit mappings could consequently be rejected or refer to the wrong types.

Emit grouping expressions once in declaration order, followed by measures and a required `i32` grouping-set index when multiple sets exist. Keys absent from any set become nullable. For example, declared keys `[a:i64, b:string]` with sets `[[0], [1]]` now have schema `[i64?, string?, i32]`.

Also make `IntervalDayType.WithNullability` return a copy, so deriving the aggregate schema cannot mutate its input type. Tests cover ordering, overlapping sets, grand totals, measure positions, emit mapping, full plan serialization, and preservation of input types and variations.

This follows the [Aggregate Operation specification](https://github.com/substrait-io/substrait/blob/v0.87.0/site/docs/relations/logical_relations.md#aggregate-operation).

## Validation

The regression tests fail on the base commit and pass with this change:

```sh
go test ./plan ./types -run 'TestAggregateGroupingSchema|TestIntervalDayWithNullabilityCopiesType' -count=1
```

Also verified `go test ./...`, `go build ./...`, and `golangci-lint run` with CI's version 2.1.6.

## Downsides

Callers that compensated for the old grouping-column order or count will need to use the specification's output positions. The serialized grouping declarations themselves do not change.
