### PR TITLE
fix(plan): apply read projections to output schemas

### DIFF
--- a/expr/field_reference.go
+++ b/expr/field_reference.go
@@ -353,6 +353,9 @@ func MaskExpressionFromProto(p *proto.Expression_MaskExpression) *MaskExpression
 }
 
 func maskSelectFromProto(p *proto.Expression_MaskExpression_Select) MaskSelect {
+	if p == nil {
+		return nil
+	}
 	switch s := p.Type.(type) {
 	case *proto.Expression_MaskExpression_Select_Struct:
 		items := make(MaskStructSelect, len(s.Struct.StructItems))
@@ -445,6 +448,10 @@ type MaskListSelect struct {
 }
 
 func (m *MaskListSelect) ToProto() *proto.Expression_MaskExpression_Select {
+	var childProto *proto.Expression_MaskExpression_Select
+	if m.child != nil {
+		childProto = m.child.ToProto()
+	}
 	selection := make([]*proto.Expression_MaskExpression_ListSelect_ListSelectItem, len(m.selection))
 	for i, s := range m.selection {
 		selection[i] = s.ToProto()
@@ -454,7 +461,7 @@ func (m *MaskListSelect) ToProto() *proto.Expression_MaskExpression_Select {
 		Type: &proto.Expression_MaskExpression_Select_List{
 			List: &proto.Expression_MaskExpression_ListSelect{
 				Selection: selection,
-				Child:     m.child.ToProto(),
+				Child:     childProto,
 			},
 		},
 	}
@@ -518,9 +525,13 @@ func (m *MaskMapSelect) Child() MaskSelect {
 }
 
 func (m *MaskMapSelect) ToProto() *proto.Expression_MaskExpression_Select {
+	var childProto *proto.Expression_MaskExpression_Select
+	if m.child != nil {
+		childProto = m.child.ToProto()
+	}
 	ret := &proto.Expression_MaskExpression_Select_Map{
 		Map: &proto.Expression_MaskExpression_MapSelect{
-			Child: m.child.ToProto(),
+			Child: childProto,
 		},
 	}
 

--- a/expr/field_reference.go
+++ b/expr/field_reference.go
@@ -381,7 +381,7 @@ func maskSelectFromProto(p *proto.Expression_MaskExpression_Select) MaskSelect {
 			child:     maskSelectFromProto(s.List.Child),
 		}
 	case *proto.Expression_MaskExpression_Select_Map:
-		var ret MaskMapSelect
+		ret := MaskMapSelect{kind: MapSelectAll}
 		if s.Map.Child != nil {
 			ret.child = maskSelectFromProto(s.Map.Child)
 		}
@@ -509,6 +509,8 @@ type MapSelectKind int8
 const (
 	MapSelectKey MapSelectKind = iota
 	MapSelectExpr
+	// MapSelectAll preserves every key when the map select discriminator is absent.
+	MapSelectAll
 )
 
 type MaskMapSelect struct {
@@ -535,13 +537,14 @@ func (m *MaskMapSelect) ToProto() *proto.Expression_MaskExpression_Select {
 		},
 	}
 
-	if m.kind == MapSelectKey {
+	switch m.kind {
+	case MapSelectKey:
 		ret.Map.Select = &proto.Expression_MaskExpression_MapSelect_Key{
 			Key: &proto.Expression_MaskExpression_MapSelect_MapKey{
 				MapKey: m.key,
 			},
 		}
-	} else {
+	case MapSelectExpr:
 		ret.Map.Select = &proto.Expression_MaskExpression_MapSelect_Expression{
 			Expression: &proto.Expression_MaskExpression_MapSelect_MapKeyExpression{
 				MapKeyExpression: m.key,

--- a/expr/field_reference_test.go
+++ b/expr/field_reference_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package expr_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/substrait-io/substrait-go/v9/expr"
+	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
+	protobuf "google.golang.org/protobuf/proto"
+)
+
+func TestMaskExpressionOptionalCollectionChildRoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		selectChild func(*proto.Expression_MaskExpression_Select) *proto.Expression_MaskExpression_Select
+	}{
+		{"list", func(child *proto.Expression_MaskExpression_Select) *proto.Expression_MaskExpression_Select {
+			return &proto.Expression_MaskExpression_Select{Type: &proto.Expression_MaskExpression_Select_List{List: &proto.Expression_MaskExpression_ListSelect{
+				Child: child,
+				Selection: []*proto.Expression_MaskExpression_ListSelect_ListSelectItem{
+					{Type: &proto.Expression_MaskExpression_ListSelect_ListSelectItem_Item{Item: &proto.Expression_MaskExpression_ListSelect_ListSelectItem_ListElement{Field: 1}}},
+					{Type: &proto.Expression_MaskExpression_ListSelect_ListSelectItem_Slice{Slice: &proto.Expression_MaskExpression_ListSelect_ListSelectItem_ListSlice{Start: 3, End: 5}}},
+				},
+			}}}
+		}},
+		{"map key", func(child *proto.Expression_MaskExpression_Select) *proto.Expression_MaskExpression_Select {
+			return &proto.Expression_MaskExpression_Select{Type: &proto.Expression_MaskExpression_Select_Map{Map: &proto.Expression_MaskExpression_MapSelect{
+				Child: child, Select: &proto.Expression_MaskExpression_MapSelect_Key{Key: &proto.Expression_MaskExpression_MapSelect_MapKey{MapKey: "name"}},
+			}}}
+		}},
+		{"map expression", func(child *proto.Expression_MaskExpression_Select) *proto.Expression_MaskExpression_Select {
+			return &proto.Expression_MaskExpression_Select{Type: &proto.Expression_MaskExpression_Select_Map{Map: &proto.Expression_MaskExpression_MapSelect{
+				Child: child, Select: &proto.Expression_MaskExpression_MapSelect_Expression{Expression: &proto.Expression_MaskExpression_MapSelect_MapKeyExpression{MapKeyExpression: "a.*"}},
+			}}}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, withChild := range []bool{false, true} {
+				t.Run(map[bool]string{false: "without child", true: "with child"}[withChild], func(t *testing.T) {
+					var child *proto.Expression_MaskExpression_Select
+					if withChild {
+						child = &proto.Expression_MaskExpression_Select{Type: &proto.Expression_MaskExpression_Select_Struct{Struct: &proto.Expression_MaskExpression_StructSelect{
+							StructItems: []*proto.Expression_MaskExpression_StructItem{{Field: 1}},
+						}}}
+					}
+					original := &proto.Expression_MaskExpression{
+						MaintainSingularStruct: true,
+						Select: &proto.Expression_MaskExpression_StructSelect{StructItems: []*proto.Expression_MaskExpression_StructItem{
+							{Field: 2, Child: tc.selectChild(child)},
+						}},
+					}
+					wire, err := protobuf.Marshal(original)
+					require.NoError(t, err)
+					decoded := &proto.Expression_MaskExpression{}
+					require.NoError(t, protobuf.Unmarshal(wire, decoded))
+					mask := expr.MaskExpressionFromProto(decoded)
+					selection := mask.Select()
+					require.Len(t, selection, 1)
+					collection := selection[0].Child().(interface{ Child() expr.MaskSelect })
+					if withChild {
+						assert.NotNil(t, collection.Child())
+					} else {
+						assert.Nil(t, collection.Child(), "an absent child selects the whole element or value")
+					}
+					assert.True(t, protobuf.Equal(original, mask.ToProto()), "mask must preserve its collection selection and optional child")
+				})
+			}
+		})
+	}
+}

--- a/expr/field_reference_test.go
+++ b/expr/field_reference_test.go
@@ -31,6 +31,16 @@ func TestMaskExpressionOptionalCollectionChildRoundTrip(t *testing.T) {
 				Child: child, Select: &proto.Expression_MaskExpression_MapSelect_Key{Key: &proto.Expression_MaskExpression_MapSelect_MapKey{MapKey: "name"}},
 			}}}
 		}},
+		{"map empty key", func(child *proto.Expression_MaskExpression_Select) *proto.Expression_MaskExpression_Select {
+			return &proto.Expression_MaskExpression_Select{Type: &proto.Expression_MaskExpression_Select_Map{Map: &proto.Expression_MaskExpression_MapSelect{
+				Child: child, Select: &proto.Expression_MaskExpression_MapSelect_Key{Key: &proto.Expression_MaskExpression_MapSelect_MapKey{MapKey: ""}},
+			}}}
+		}},
+		{"map all keys", func(child *proto.Expression_MaskExpression_Select) *proto.Expression_MaskExpression_Select {
+			return &proto.Expression_MaskExpression_Select{Type: &proto.Expression_MaskExpression_Select_Map{Map: &proto.Expression_MaskExpression_MapSelect{
+				Child: child,
+			}}}
+		}},
 		{"map expression", func(child *proto.Expression_MaskExpression_Select) *proto.Expression_MaskExpression_Select {
 			return &proto.Expression_MaskExpression_Select{Type: &proto.Expression_MaskExpression_Select_Map{Map: &proto.Expression_MaskExpression_MapSelect{
 				Child: child, Select: &proto.Expression_MaskExpression_MapSelect_Expression{Expression: &proto.Expression_MaskExpression_MapSelect_MapKeyExpression{MapKeyExpression: "a.*"}},

--- a/plan/ctas_plan_test.go
+++ b/plan/ctas_plan_test.go
@@ -127,7 +127,7 @@ func getProjectionForTest2(t *testing.T, b plan.Builder) plan.Rel {
 	// column 0 from the output of namedScanRel is role
 	// Build the filter with condition `role LIKE 'Engineer'`
 	l := literal.NewString("Engineer", false)
-	roleLikeEngineer := makeConditionExprForLike(t, b, namedScanRel, 1, l)
+	roleLikeEngineer := makeConditionExprForLike(t, b, namedScanRel, 0, l)
 	filterRel := makeFilterRel(t, b, namedScanRel, roleLikeEngineer)
 
 	// projectRel output employee_id, name, department_id, salary, role

--- a/plan/read_projection.go
+++ b/plan/read_projection.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package plan
+
+import (
+	"fmt"
+
+	substraitgo "github.com/substrait-io/substrait-go/v9"
+	"github.com/substrait-io/substrait-go/v9/expr"
+	"github.com/substrait-io/substrait-go/v9/types"
+)
+
+// A read projection removes fields before emit remapping. Preserve the row
+// struct and nested containers; maintain_singular_struct only controls the
+// outer result of a general mask expression, and a read always returns a row.
+func projectReadStruct(input types.StructType, selection expr.MaskStructSelect) (types.StructType, error) {
+	output := input
+	output.Types = make([]types.Type, len(selection))
+	for i, item := range selection {
+		field := item.Field()
+		if field < 0 || int(field) >= len(input.Types) {
+			return types.StructType{}, fmt.Errorf("%w: read projection field %d out of range for struct with %d fields", substraitgo.ErrInvalidRel, field, len(input.Types))
+		}
+		projected, err := projectReadType(input.Types[field], item.Child())
+		if err != nil {
+			return types.StructType{}, err
+		}
+		output.Types[i] = projected
+	}
+	return output, nil
+}
+
+func projectReadType(input types.Type, selection expr.MaskSelect) (types.Type, error) {
+	if selection == nil {
+		return input, nil
+	}
+	// Copy containers before replacing children so the base schema, nullability
+	// and type variations remain intact, including on repeated RecordType calls.
+	switch selection := selection.(type) {
+	case expr.MaskStructSelect:
+		if input, ok := input.(*types.StructType); ok {
+			output, err := projectReadStruct(*input, selection)
+			if err != nil {
+				return nil, err
+			}
+			return &output, nil
+		}
+	case *expr.MaskListSelect:
+		if input, ok := input.(*types.ListType); ok {
+			output := *input
+			var err error
+			output.Type, err = projectReadType(input.Type, selection.Child())
+			if err != nil {
+				return nil, err
+			}
+			return &output, nil
+		}
+	case *expr.MaskMapSelect:
+		if input, ok := input.(*types.MapType); ok {
+			output := *input
+			var err error
+			output.Value, err = projectReadType(input.Value, selection.Child())
+			if err != nil {
+				return nil, err
+			}
+			return &output, nil
+		}
+	}
+	return nil, fmt.Errorf("%w: read projection %T cannot select from %s", substraitgo.ErrInvalidRel, selection, input)
+}

--- a/plan/read_projection_test.go
+++ b/plan/read_projection_test.go
@@ -168,3 +168,30 @@ func TestReadProjectionInvalidField(t *testing.T) {
 		assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
 	}
 }
+
+func TestReadProjectionInvalidNestedSelection(t *testing.T) {
+	inner := &types.StructType{Types: []types.Type{&types.Int64Type{}}}
+	invalidField := &proto.Expression_MaskExpression_Select{Type: &proto.Expression_MaskExpression_Select_Struct{Struct: projectionStruct(1)}}
+	for _, tc := range []struct {
+		name      string
+		input     types.Type
+		selection *proto.Expression_MaskExpression_Select
+		message   string
+	}{
+		{"struct field", inner, invalidField, "field 1 out of range"},
+		{"list element field", &types.ListType{Type: inner}, &proto.Expression_MaskExpression_Select{Type: &proto.Expression_MaskExpression_Select_List{List: &proto.Expression_MaskExpression_ListSelect{Child: invalidField}}}, "field 1 out of range"},
+		{"map value field", &types.MapType{Key: &types.StringType{}, Value: inner}, &proto.Expression_MaskExpression_Select{Type: &proto.Expression_MaskExpression_Select_Map{Map: &proto.Expression_MaskExpression_MapSelect{
+			Child: invalidField, Select: &proto.Expression_MaskExpression_MapSelect_Key{Key: &proto.Expression_MaskExpression_MapSelect_MapKey{MapKey: "name"}},
+		}}}, "field 1 out of range"},
+		{"struct mask on scalar", &types.Int64Type{}, invalidField, "cannot select from i64"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			schema := types.NamedStruct{Struct: types.StructType{Types: []types.Type{tc.input}}}
+			projection := &proto.Expression_MaskExpression{MaintainSingularStruct: true, Select: &proto.Expression_MaskExpression_StructSelect{StructItems: []*proto.Expression_MaskExpression_StructItem{{Field: 0, Child: tc.selection}}}}
+			r, err := RelFromProto(projectionRead(schema, projection), expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError()))
+			assert.Nil(t, r)
+			assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
+			assert.ErrorContains(t, err, tc.message)
+		})
+	}
+}

--- a/plan/read_projection_test.go
+++ b/plan/read_projection_test.go
@@ -126,10 +126,14 @@ func TestReadProjectionNestedMasks(t *testing.T) {
 			&proto.Expression_MaskExpression_Select{Type: &proto.Expression_MaskExpression_Select_List{List: &proto.Expression_MaskExpression_ListSelect{Selection: listSelection, Child: structMask}}}},
 		{"map child", mapType, &types.MapType{Nullability: mapType.Nullability, TypeVariationRef: mapType.TypeVariationRef, Key: str, Value: &projected},
 			&proto.Expression_MaskExpression_Select{Type: &proto.Expression_MaskExpression_Select_Map{Map: &proto.Expression_MaskExpression_MapSelect{Child: structMask, Select: &proto.Expression_MaskExpression_MapSelect_Expression{Expression: &proto.Expression_MaskExpression_MapSelect_MapKeyExpression{MapKeyExpression: "a.*"}}}}}},
+		{"map all keys with child", mapType, &types.MapType{Nullability: mapType.Nullability, TypeVariationRef: mapType.TypeVariationRef, Key: str, Value: &projected},
+			&proto.Expression_MaskExpression_Select{Type: &proto.Expression_MaskExpression_Select_Map{Map: &proto.Expression_MaskExpression_MapSelect{Child: structMask}}}},
 		{"list without child", list, list,
 			&proto.Expression_MaskExpression_Select{Type: &proto.Expression_MaskExpression_Select_List{List: &proto.Expression_MaskExpression_ListSelect{Selection: listSelection}}}},
 		{"map without child", mapType, mapType,
 			&proto.Expression_MaskExpression_Select{Type: &proto.Expression_MaskExpression_Select_Map{Map: &proto.Expression_MaskExpression_MapSelect{Select: &proto.Expression_MaskExpression_MapSelect_Key{Key: &proto.Expression_MaskExpression_MapSelect_MapKey{MapKey: "a"}}}}}},
+		{"map all keys without child", mapType, mapType,
+			&proto.Expression_MaskExpression_Select{Type: &proto.Expression_MaskExpression_Select_Map{Map: &proto.Expression_MaskExpression_MapSelect{}}}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			schema := types.NamedStruct{Struct: types.StructType{Types: []types.Type{integer, tc.input}}}

--- a/plan/read_projection_test.go
+++ b/plan/read_projection_test.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package plan
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	substraitgo "github.com/substrait-io/substrait-go/v9"
+	"github.com/substrait-io/substrait-go/v9/expr"
+	"github.com/substrait-io/substrait-go/v9/extensions"
+	"github.com/substrait-io/substrait-go/v9/types"
+	proto "github.com/substrait-io/substrait-protobuf/go/substraitpb"
+	protobuf "google.golang.org/protobuf/proto"
+)
+
+func projectionStruct(fields ...int32) *proto.Expression_MaskExpression_StructSelect {
+	items := make([]*proto.Expression_MaskExpression_StructItem, len(fields))
+	for i, field := range fields {
+		items[i] = &proto.Expression_MaskExpression_StructItem{Field: field}
+	}
+	return &proto.Expression_MaskExpression_StructSelect{StructItems: items}
+}
+
+func projectionRead(schema types.NamedStruct, projection *proto.Expression_MaskExpression) *proto.Rel {
+	return &proto.Rel{RelType: &proto.Rel_Read{Read: &proto.ReadRel{
+		Common:     &proto.RelCommon{EmitKind: &proto.RelCommon_Direct_{Direct: &proto.RelCommon_Direct{}}},
+		BaseSchema: schema.ToProto(),
+		Projection: projection,
+		ReadType:   &proto.ReadRel_NamedTable_{NamedTable: &proto.ReadRel_NamedTable{Names: []string{"table"}}},
+	}}}
+}
+
+func projectionField(field int32) *proto.Expression {
+	return &proto.Expression{RexType: &proto.Expression_Selection{Selection: &proto.Expression_FieldReference{
+		RootType: &proto.Expression_FieldReference_RootReference_{RootReference: &proto.Expression_FieldReference_RootReference{}},
+		ReferenceType: &proto.Expression_FieldReference_DirectReference{DirectReference: &proto.Expression_ReferenceSegment{
+			ReferenceType: &proto.Expression_ReferenceSegment_StructField_{StructField: &proto.Expression_ReferenceSegment_StructField{Field: field}},
+		}},
+	}}}
+}
+
+func TestReadProjectionPlanRoundTrip(t *testing.T) {
+	schema := types.NamedStruct{
+		Names: []string{"id", "included", "label"},
+		Struct: types.StructType{Nullability: types.NullabilityRequired, Types: []types.Type{
+			&types.Int64Type{Nullability: types.NullabilityRequired},
+			&types.BooleanType{Nullability: types.NullabilityRequired},
+			&types.StringType{Nullability: types.NullabilityNullable},
+		}},
+	}
+	read := projectionRead(schema, &proto.Expression_MaskExpression{Select: projectionStruct(2), MaintainSingularStruct: true})
+	// Read filters still reference the base schema, including fields removed by projection.
+	read.GetRead().Filter = projectionField(1)
+	read.GetRead().BestEffortFilter = projectionField(1)
+	project := &proto.Rel{RelType: &proto.Rel_Project{Project: &proto.ProjectRel{
+		Common:      &proto.RelCommon{EmitKind: &proto.RelCommon_Direct_{Direct: &proto.RelCommon_Direct{}}},
+		Input:       read,
+		Expressions: []*proto.Expression{projectionField(0)},
+	}}}
+	original := &proto.Plan{Version: &proto.Version{MinorNumber: 85}, Relations: []*proto.PlanRel{{
+		RelType: &proto.PlanRel_Root{Root: &proto.RelRoot{Input: project, Names: []string{"label", "copy"}}},
+	}}}
+	wire, err := protobuf.Marshal(original)
+	require.NoError(t, err)
+	decoded := &proto.Plan{}
+	require.NoError(t, protobuf.Unmarshal(wire, decoded))
+	p, err := FromProto(decoded, extensions.GetDefaultCollectionWithNoError())
+	require.NoError(t, err)
+	parent := p.GetRoots()[0].Input().(*ProjectRel)
+	assert.Equal(t, schema.Struct.Types[2], parent.Expressions()[0].GetType())
+	assert.Equal(t, []types.Type{schema.Struct.Types[2], schema.Struct.Types[2]}, parent.RecordType().Types())
+	scan := parent.Input().(*NamedTableReadRel)
+	assert.Equal(t, schema, scan.BaseSchema())
+	assert.Equal(t, schema.Struct.Types[1], scan.Filter().GetType())
+	assert.Equal(t, schema.Struct.Types[1], scan.BestEffortFilter().GetType())
+	roundTripped, err := p.ToProto()
+	require.NoError(t, err)
+	assert.True(t, protobuf.Equal(original, roundTripped), "original: %s\nround trip: %s", original, roundTripped)
+}
+
+func TestReadProjectionBeforeEmit(t *testing.T) {
+	schema := types.NamedStruct{Struct: types.StructType{Types: []types.Type{&types.Int64Type{}, &types.StringType{}, &types.BooleanType{}}}}
+	read := projectionRead(schema, &proto.Expression_MaskExpression{Select: projectionStruct(1, 2), MaintainSingularStruct: true})
+	read.GetRead().Common = &proto.RelCommon{EmitKind: &proto.RelCommon_Emit_{Emit: &proto.RelCommon_Emit{OutputMapping: []int32{1, 0, 1}}}}
+	r, err := RelFromProto(read, expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError()))
+	require.NoError(t, err)
+	assert.Equal(t, []types.Type{schema.Struct.Types[2], schema.Struct.Types[1], schema.Struct.Types[2]}, r.RecordType().Types())
+	r, err = r.Remap(1)
+	require.NoError(t, err)
+	assert.Equal(t, []types.Type{schema.Struct.Types[1]}, r.RecordType().Types())
+}
+
+func TestReadProjectionSetAndClear(t *testing.T) {
+	schema := types.NamedStruct{Struct: types.StructType{Types: []types.Type{&types.Int64Type{}, &types.StringType{}}}}
+	r := NewBuilderDefault().NamedScan([]string{"table"}, schema)
+	r.SetProjection(expr.MaskExpressionFromProto(&proto.Expression_MaskExpression{Select: projectionStruct(1), MaintainSingularStruct: true}))
+	assert.Equal(t, []types.Type{schema.Struct.Types[1]}, r.RecordType().Types())
+	r.SetProjection(expr.MaskExpressionFromProto(&proto.Expression_MaskExpression{Select: projectionStruct()}))
+	assert.Zero(t, r.RecordType().FieldCount())
+	r.SetProjection(nil)
+	assert.Equal(t, schema.Struct.Types, r.RecordType().Types())
+}
+
+func TestReadProjectionNestedMasks(t *testing.T) {
+	integer := &types.Int64Type{Nullability: types.NullabilityRequired}
+	str := &types.StringType{Nullability: types.NullabilityRequired, TypeVariationRef: 7}
+	boolean := &types.BooleanType{Nullability: types.NullabilityNullable}
+	inner := &types.StructType{Nullability: types.NullabilityNullable, TypeVariationRef: 11, Types: []types.Type{integer, str, boolean}}
+	projected := *inner
+	projected.Types = []types.Type{str, boolean}
+	list := &types.ListType{Nullability: types.NullabilityNullable, TypeVariationRef: 12, Type: inner}
+	mapType := &types.MapType{Nullability: types.NullabilityRequired, TypeVariationRef: 13, Key: str, Value: inner}
+	structMask := &proto.Expression_MaskExpression_Select{Type: &proto.Expression_MaskExpression_Select_Struct{Struct: projectionStruct(1, 2)}}
+	listSelection := []*proto.Expression_MaskExpression_ListSelect_ListSelectItem{{Type: &proto.Expression_MaskExpression_ListSelect_ListSelectItem_Slice{
+		Slice: &proto.Expression_MaskExpression_ListSelect_ListSelectItem_ListSlice{Start: 0, End: 5},
+	}}}
+	for _, tc := range []struct {
+		name        string
+		input, want types.Type
+		mask        *proto.Expression_MaskExpression_Select
+	}{
+		{"struct", inner, &projected, structMask},
+		{"list child", list, &types.ListType{Nullability: list.Nullability, TypeVariationRef: list.TypeVariationRef, Type: &projected},
+			&proto.Expression_MaskExpression_Select{Type: &proto.Expression_MaskExpression_Select_List{List: &proto.Expression_MaskExpression_ListSelect{Selection: listSelection, Child: structMask}}}},
+		{"map child", mapType, &types.MapType{Nullability: mapType.Nullability, TypeVariationRef: mapType.TypeVariationRef, Key: str, Value: &projected},
+			&proto.Expression_MaskExpression_Select{Type: &proto.Expression_MaskExpression_Select_Map{Map: &proto.Expression_MaskExpression_MapSelect{Child: structMask, Select: &proto.Expression_MaskExpression_MapSelect_Expression{Expression: &proto.Expression_MaskExpression_MapSelect_MapKeyExpression{MapKeyExpression: "a.*"}}}}}},
+		{"list without child", list, list,
+			&proto.Expression_MaskExpression_Select{Type: &proto.Expression_MaskExpression_Select_List{List: &proto.Expression_MaskExpression_ListSelect{Selection: listSelection}}}},
+		{"map without child", mapType, mapType,
+			&proto.Expression_MaskExpression_Select{Type: &proto.Expression_MaskExpression_Select_Map{Map: &proto.Expression_MaskExpression_MapSelect{Select: &proto.Expression_MaskExpression_MapSelect_Key{Key: &proto.Expression_MaskExpression_MapSelect_MapKey{MapKey: "a"}}}}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			schema := types.NamedStruct{Struct: types.StructType{Types: []types.Type{integer, tc.input}}}
+			mask := &proto.Expression_MaskExpression{MaintainSingularStruct: true, Select: &proto.Expression_MaskExpression_StructSelect{StructItems: []*proto.Expression_MaskExpression_StructItem{{Field: 1, Child: tc.mask}}}}
+			original := projectionRead(schema, mask)
+			saved := protobuf.Clone(original)
+			r, err := RelFromProto(original, expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError()))
+			require.NoError(t, err)
+			assert.Equal(t, []types.Type{tc.want}, r.RecordType().Types())
+			assert.True(t, protobuf.Equal(saved, r.ToProto()), "read, base schema and mask must round trip unchanged")
+			assert.Equal(t, schema, r.(ReadRel).BaseSchema())
+		})
+	}
+}
+
+func TestReadProjectionSingularStruct(t *testing.T) {
+	leaf := &types.StringType{Nullability: types.NullabilityRequired, TypeVariationRef: 7}
+	inner := &types.StructType{Nullability: types.NullabilityNullable, TypeVariationRef: 11, Types: []types.Type{&types.Int64Type{}, leaf}}
+	for _, maintain := range []bool{false, true} {
+		t.Run(map[bool]string{false: "default", true: "maintain"}[maintain], func(t *testing.T) {
+			schema := types.NamedStruct{Struct: types.StructType{Types: []types.Type{&types.Int64Type{}, inner}}}
+			mask := &proto.Expression_MaskExpression{MaintainSingularStruct: maintain, Select: &proto.Expression_MaskExpression_StructSelect{StructItems: []*proto.Expression_MaskExpression_StructItem{{Field: 0}, {Field: 1, Child: &proto.Expression_MaskExpression_Select{Type: &proto.Expression_MaskExpression_Select_Struct{Struct: projectionStruct(1)}}}}}}
+			r, err := RelFromProto(projectionRead(schema, mask), expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError()))
+			require.NoError(t, err)
+			want := &types.StructType{Nullability: inner.Nullability, TypeVariationRef: inner.TypeVariationRef, Types: []types.Type{leaf}}
+			assert.Equal(t, []types.Type{schema.Struct.Types[0], want}, r.RecordType().Types())
+			assert.Equal(t, schema, r.(ReadRel).BaseSchema())
+		})
+	}
+}
+
+func TestReadProjectionInvalidField(t *testing.T) {
+	schema := types.NamedStruct{Struct: types.StructType{Types: []types.Type{&types.Int64Type{}}}}
+	for _, field := range []int32{-1, 1} {
+		_, err := RelFromProto(projectionRead(schema, &proto.Expression_MaskExpression{Select: projectionStruct(field)}), expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError()))
+		assert.ErrorIs(t, err, substraitgo.ErrInvalidRel)
+	}
+}

--- a/plan/relations.go
+++ b/plan/relations.go
@@ -86,6 +86,9 @@ func (b *baseReadRel) fromProtoReadRel(rel *proto.ReadRel, reg expr.ExtensionReg
 
 	if rel.Projection != nil {
 		b.projection = expr.MaskExpressionFromProto(rel.Projection)
+		if _, err := projectReadStruct(b.baseSchema.Struct, b.projection.Select()); err != nil {
+			return err
+		}
 	}
 
 	b.advExtension = rel.AdvancedExtension
@@ -93,7 +96,15 @@ func (b *baseReadRel) fromProtoReadRel(rel *proto.ReadRel, reg expr.ExtensionReg
 }
 
 func (b *baseReadRel) directOutputSchema() types.RecordType {
-	return *types.NewRecordTypeFromStruct(b.baseSchema.Struct)
+	schema := b.baseSchema.Struct
+	if b.projection != nil {
+		var err error
+		schema, err = projectReadStruct(schema, b.projection.Select())
+		if err != nil {
+			panic(err)
+		}
+	}
+	return *types.NewRecordTypeFromStruct(schema)
 }
 
 func (b *baseReadRel) RecordType() types.RecordType {

--- a/plan/testdata/ctas_with_filter.json
+++ b/plan/testdata/ctas_with_filter.json
@@ -160,7 +160,7 @@
                               "selection": {
                                 "directReference": {
                                   "structField": {
-                                    "field": 1
+                                    "field": 0
                                   }
                                 },
                                 "rootReference": {}


### PR DESCRIPTION
Read relations accepted a projection but continued to report the full base schema. Projecting only the string field from `[id:i64, label:string]` therefore typed a parent's field `0` as `i64` and rejected valid root output names.

Apply the read mask recursively before emit remapping. Keep filters bound to the base schema and preserve nested struct/list/map containers, nullability, and type variations. This follows the [read specification](https://github.com/substrait-io/substrait/blob/v0.87.0/site/docs/relations/logical_relations.md#read-operation) and the [official validator's mask handling](https://github.com/substrait-io/substrait-validator/blob/2a1047014b25c0f9e2c9f659f34f696c6cb68f03/rs/src/parse/expressions/references/mask.rs).

Preserve absent list/map child masks and all-keys map selections during protobuf conversion. An omitted map selector stays distinct from an explicit empty-string key. Update the existing CTAS fixture to reference `role` at projected column `0`, as its comment already specifies.

## Validation

The valid full-plan regression fails on the base commit and passes with this change:

```sh
go test ./plan -run TestReadProjection -count=1
```

Tests cover binary protobuf roundtrips, downstream field types, base-schema filters, emit mappings, nested masks, preservation of the original schema, and clearing a projection. Also verified `go test ./...`, `go build ./...`, and `golangci-lint run` with CI's version 2.1.6.

## Downsides

Computing a projected read schema now traverses the selected fields and allocates projected containers. Callers that need the unprojected schema should use `BaseSchema()`; `RecordType()` now reflects the actual output columns.
