### PR TITLE
fix(expr): resolve aggregate types by aggregation phase

### DIFF
--- a/expr/aggregate_phase.go
+++ b/expr/aggregate_phase.go
@@ -97,5 +97,10 @@ func resolveAggregateVariant[T aggregateVariant](
 	if err != nil {
 		return nil, nil, err
 	}
+	// A single state can repeat integer parameters across its fields. Check
+	// those bindings even when the final output has no parameters to resolve.
+	if !initial && !types.AreSyncTypeParametersMatching([]types.FuncDefArgType{intermediate}, argTypes) {
+		return nil, nil, fmt.Errorf("%w: intermediate state has conflicting type parameters", substraitgo.ErrInvalidType)
+	}
 	return decl, out, nil
 }

--- a/expr/aggregate_phase.go
+++ b/expr/aggregate_phase.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package expr
+
+import (
+	"fmt"
+
+	substraitgo "github.com/substrait-io/substrait-go/v9"
+	"github.com/substrait-io/substrait-go/v9/extensions"
+	"github.com/substrait-io/substrait-go/v9/types"
+	"github.com/substrait-io/substrait-go/v9/types/parser"
+)
+
+type aggregateVariant interface {
+	*extensions.AggregateFunctionVariant | *extensions.WindowFunctionVariant
+	ResolveType([]types.Type, extensions.Set) (types.Type, error)
+	Args() extensions.FuncParameterList
+	Variadic() *extensions.VariadicBehavior
+	URN() string
+	Nullability() extensions.NullabilityHandling
+	Decomposability() extensions.DecomposeType
+	Intermediate() (types.FuncDefArgType, error)
+	ReturnType() types.FuncDefArgType
+}
+
+func resolveAggregateVariant[T aggregateVariant](
+	id extensions.FunctionID, reg ExtensionRegistry, getter func(extensions.FunctionID) (T, bool),
+	phase types.AggregationPhase, args []types.FuncArg,
+) (T, types.Type, error) {
+	var initial, intermediateOutput bool
+	switch phase {
+	case types.AggPhaseInitialToResult:
+		initial = true
+	case types.AggPhaseInitialToIntermediate:
+		initial, intermediateOutput = true, true
+	case types.AggPhaseIntermediateToIntermediate:
+		intermediateOutput = true
+	case types.AggPhaseIntermediateToResult, types.AggPhaseUnspecified:
+		// The protobuf definition specifies that UNSPECIFIED implies INTERMEDIATE_TO_RESULT.
+	default:
+		return nil, nil, fmt.Errorf("%w: invalid aggregation phase %d", substraitgo.ErrInvalidExpr, phase)
+	}
+
+	argTypes := functionArgumentTypes(args)
+	var decl T
+	if initial {
+		var err error
+		decl, err = lookupVariant(id, reg, getter, argTypes)
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		var found bool
+		decl, found = getter(id)
+		if !found {
+			// Intermediate states do not identify the original signature. For example,
+			// avg:i32 and avg:i64 both consume struct<i64,i64> but return different types.
+			return nil, nil, fmt.Errorf("%w: intermediate-input phase requires a matching function id (use the original compound name): %s", substraitgo.ErrNotFound, id)
+		}
+	}
+	if decl.Decomposability() == extensions.DecomposeNone && phase != types.AggPhaseInitialToResult {
+		return nil, nil, fmt.Errorf("%w: non-decomposable window or agg function '%s' must use InitialToResult phase", substraitgo.ErrInvalidExpr, id)
+	}
+	if initial && !intermediateOutput {
+		out, err := decl.ResolveType(argTypes, reg.Set)
+		return decl, out, err
+	}
+
+	intermediate, err := decl.Intermediate()
+	if err != nil {
+		return nil, nil, err
+	}
+	output := decl.ReturnType()
+	if intermediateOutput {
+		output = intermediate
+	}
+	if output == nil {
+		return nil, nil, fmt.Errorf("%w: missing output type for function %s", substraitgo.ErrInvalidType, id)
+	}
+	parameters, variadic := decl.Args(), decl.Variadic()
+	if !initial {
+		if len(args) != 1 {
+			return nil, nil, fmt.Errorf("%w: intermediate-input phase requires one state argument", substraitgo.ErrInvalidExpr)
+		}
+		if _, ok := args[0].(Expression); !ok {
+			return nil, nil, fmt.Errorf("%w: intermediate state must be a value argument", substraitgo.ErrInvalidExpr)
+		}
+		if derivation, ok := intermediate.(*types.OutputDerivation); ok && len(derivation.Assignments) != 0 {
+			return nil, nil, fmt.Errorf("%w: cannot infer original parameters from a derived intermediate type", substraitgo.ErrNotImplemented)
+		}
+		// Each incoming value holds the complete state, including for functions
+		// whose initial signature takes zero or multiple arguments.
+		parameters = extensions.FuncParameterList{extensions.ValueArg{Value: &parser.TypeExpression{ValueType: intermediate}}}
+		variadic = nil
+	}
+	out, err := extensions.EvaluateTypeExpression(decl.URN(), decl.Nullability(), output, parameters, variadic, argTypes, reg.Set)
+	if err != nil {
+		return nil, nil, err
+	}
+	return decl, out, nil
+}

--- a/expr/aggregate_phase_test.go
+++ b/expr/aggregate_phase_test.go
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package expr_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	substraitgo "github.com/substrait-io/substrait-go/v9"
+	"github.com/substrait-io/substrait-go/v9/expr"
+	"github.com/substrait-io/substrait-go/v9/extensions"
+	"github.com/substrait-io/substrait-go/v9/types"
+	"github.com/substrait-io/substrait-go/v9/types/parser"
+)
+
+func phaseType(t *testing.T, s string) types.Type {
+	t.Helper()
+	parsed, err := parser.ParseType(s)
+	require.NoError(t, err)
+	typ, err := parsed.ReturnType(nil, nil)
+	require.NoError(t, err)
+	return typ
+}
+
+func TestAggregateFunctionPhases(t *testing.T) {
+	tests := []struct {
+		name, function, initial, intermediate, result string
+	}{
+		{"avg", "functions_arithmetic/avg:i32", "i32?", "struct<i64,i64>", "i32?"},
+		{"avg_i64", "functions_arithmetic/avg:i64", "i64", "struct<i64,i64>", "i64?"},
+		{"sum", "functions_arithmetic/sum:i32", "i32?", "i64?", "i64?"},
+		{"count_values", "functions_aggregate_generic/count:any", "string?", "i64", "i64"},
+		{"count_rows", "functions_aggregate_generic/count:", "", "i64", "i64"},
+		{"any_value", "functions_aggregate_generic/any_value:any", "string?", "string?", "string?"},
+		{"decimal_avg", "functions_arithmetic_decimal/avg:dec", "decimal?<12,2>", "struct<decimal<38,2>,i64>", "decimal<38,2>"},
+		{"decimal_sum", "functions_arithmetic_decimal/sum:dec", "decimal?<12,2>", "decimal?<38,2>", "decimal?<38,2>"},
+		{"decimal_min", "functions_arithmetic_decimal/min:dec", "decimal?<12,2>", "decimal?<12,2>", "decimal?<12,2>"},
+	}
+	phases := []types.AggregationPhase{
+		types.AggPhaseInitialToIntermediate,
+		types.AggPhaseIntermediateToIntermediate,
+		types.AggPhaseInitialToResult,
+		types.AggPhaseIntermediateToResult,
+		types.AggPhaseUnspecified,
+	}
+	for _, tt := range tests {
+		for _, phase := range phases {
+			for _, window := range []bool{false, true} {
+				kind := "aggregate"
+				if window {
+					kind = "window"
+				}
+				t.Run(tt.name+"/"+phase.String()+"/"+kind, func(t *testing.T) {
+					reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+					urn, name, _ := strings.Cut(tt.function, "/")
+					id := extensions.FunctionID{URN: extensions.SubstraitDefaultURNPrefix + urn, Name: name}
+					input := tt.intermediate
+					if phase == types.AggPhaseInitialToIntermediate || phase == types.AggPhaseInitialToResult {
+						input = tt.initial
+					}
+					var args []types.FuncArg
+					if input != "" {
+						args = []types.FuncArg{&expr.DynamicParameter{OutputType: phaseType(t, input)}}
+					}
+					expected := tt.result
+					if phase == types.AggPhaseInitialToIntermediate || phase == types.AggPhaseIntermediateToIntermediate {
+						expected = tt.intermediate
+					}
+					if window {
+						fn, err := expr.NewWindowFunc(reg, id, nil, types.AggInvocationAll, phase, args...)
+						require.NoError(t, err)
+						assert.Equal(t, phaseType(t, expected), fn.GetType())
+						assert.Equal(t, types.TypeToProto(phaseType(t, expected)), fn.ToProto().GetWindowFunction().OutputType)
+						assert.Equal(t, id, fn.ID())
+						assert.Equal(t, phase, fn.Phase())
+					} else {
+						fn, err := expr.NewAggregateFunc(reg, id, nil, types.AggInvocationAll, phase, nil, args...)
+						require.NoError(t, err)
+						assert.Equal(t, phaseType(t, expected), fn.GetType())
+						assert.Equal(t, types.TypeToProto(phaseType(t, expected)), fn.ToProto().OutputType)
+						assert.Equal(t, id, fn.ID())
+						assert.Equal(t, phase, fn.Phase())
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestAggregatePhaseRejectsInvalidArguments(t *testing.T) {
+	tests := []struct {
+		name, function string
+		phase          types.AggregationPhase
+		args           []string
+		target         error
+	}{
+		{"original_input", "avg:i32", types.AggPhaseIntermediateToResult, []string{"i32"}, substraitgo.ErrInvalidType},
+		{"missing_state", "avg:i32", types.AggPhaseIntermediateToResult, nil, substraitgo.ErrInvalidExpr},
+		{"multiple_states", "avg:i32", types.AggPhaseIntermediateToResult, []string{"struct<i64,i64>", "struct<i64,i64>"}, substraitgo.ErrInvalidExpr},
+		{"ambiguous_state", "avg", types.AggPhaseIntermediateToResult, []string{"struct<i64,i64>"}, substraitgo.ErrNotFound},
+		{"state_cannot_identify_sum_overload", "sum", types.AggPhaseIntermediateToResult, []string{"i64?"}, substraitgo.ErrNotFound},
+		{"nondecomposable", "mode:i32", types.AggPhaseInitialToIntermediate, []string{"i32"}, substraitgo.ErrInvalidExpr},
+		{"nondecomposable_unspecified", "mode:i32", types.AggPhaseUnspecified, []string{"i32"}, substraitgo.ErrInvalidExpr},
+		{"invalid_phase", "avg:i32", types.AggregationPhase(99), []string{"i32"}, substraitgo.ErrInvalidExpr},
+	}
+	for _, tt := range tests {
+		for _, window := range []bool{false, true} {
+			kind := "aggregate"
+			if window {
+				kind = "window"
+			}
+			t.Run(tt.name+"/"+kind, func(t *testing.T) {
+				reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+				id := extensions.FunctionID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Name: tt.function}
+				var args []types.FuncArg
+				for _, arg := range tt.args {
+					args = append(args, &expr.DynamicParameter{OutputType: phaseType(t, arg)})
+				}
+				var err error
+				if window {
+					_, err = expr.NewWindowFunc(reg, id, nil, types.AggInvocationAll, tt.phase, args...)
+				} else {
+					_, err = expr.NewAggregateFunc(reg, id, nil, types.AggInvocationAll, tt.phase, nil, args...)
+				}
+				require.ErrorIs(t, err, tt.target)
+			})
+		}
+	}
+}
+
+func TestAggregatePhaseTypeParameters(t *testing.T) {
+	const declarations = `
+urn: extension:test:aggregate_phases
+aggregate_functions:
+  - name: nested
+    impls:
+      - args:
+          - value: any1
+        nullability: DECLARED_OUTPUT
+        decomposable: MANY
+        intermediate: struct<any1,i64>
+        return: any1
+  - name: mirror
+    impls:
+      - args:
+          - value: decimal<P,S>
+        nullability: MIRROR
+        decomposable: MANY
+        intermediate: struct<decimal<P,S>,i64>
+        return: decimal<P,S>
+  - name: discrete
+    impls:
+      - args:
+          - value: decimal?<P,S>
+        nullability: DISCRETE
+        decomposable: MANY
+        intermediate: struct<decimal<P,S>,i64>
+        return: decimal?<P,S>
+  - name: lost_parameter
+    impls:
+      - args:
+          - value: decimal<P,S>
+        nullability: DECLARED_OUTPUT
+        decomposable: MANY
+        intermediate: decimal<38,S>
+        return: decimal<P,S>
+  - name: derived_parameter
+    impls:
+      - args:
+          - value: decimal<P,S>
+        nullability: DECLARED_OUTPUT
+        decomposable: MANY
+        intermediate: |
+          P = P + 1
+          decimal<P,S>
+        return: decimal<P,S>
+`
+	var col extensions.Collection
+	require.NoError(t, col.Load(strings.NewReader(declarations)))
+	tests := []struct {
+		name, input, output string
+		phase               types.AggregationPhase
+	}{
+		{"nested:any", "string", "struct<string,i64>", types.AggPhaseInitialToIntermediate},
+		{"nested:any", "struct<string,i64>", "string", types.AggPhaseIntermediateToResult},
+		{"nested:any", "struct<string,i64>", "struct<string,i64>", types.AggPhaseIntermediateToIntermediate},
+		{"mirror:dec", "struct?<decimal<12,2>,i64>", "decimal?<12,2>", types.AggPhaseIntermediateToResult},
+		{"mirror:dec", "struct<decimal?<12,2>,i64>", "decimal<12,2>", types.AggPhaseIntermediateToResult},
+		{"discrete:dec", "struct<decimal<12,2>,i64>", "decimal?<12,2>", types.AggPhaseIntermediateToResult},
+		{"discrete:dec", "struct?<decimal<12,2>,i64>", "", types.AggPhaseIntermediateToResult},
+		{"discrete:dec", "struct<decimal?<12,2>,i64>", "", types.AggPhaseIntermediateToResult},
+		{"lost_parameter:dec", "decimal<12,2>", "decimal<38,2>", types.AggPhaseInitialToIntermediate},
+		{"lost_parameter:dec", "decimal<38,2>", "", types.AggPhaseIntermediateToResult},
+		{"derived_parameter:dec", "decimal<12,2>", "decimal<13,2>", types.AggPhaseInitialToIntermediate},
+		{"derived_parameter:dec", "decimal<13,2>", "", types.AggPhaseIntermediateToResult},
+	}
+	for _, tt := range tests {
+		for _, window := range []bool{false, true} {
+			kind := "aggregate"
+			if window {
+				kind = "window"
+			}
+			t.Run(tt.name+"/"+tt.phase.String()+"/"+kind, func(t *testing.T) {
+				reg := expr.NewEmptyExtensionRegistry(&col)
+				id := extensions.FunctionID{URN: "extension:test:aggregate_phases", Name: tt.name}
+				arg := &expr.DynamicParameter{OutputType: phaseType(t, tt.input)}
+				var output types.Type
+				var err error
+				if window {
+					var fn *expr.WindowFunction
+					fn, err = expr.NewWindowFunc(reg, id, nil, types.AggInvocationAll, tt.phase, arg)
+					if err == nil {
+						output = fn.GetType()
+					}
+				} else {
+					var fn *expr.AggregateFunction
+					fn, err = expr.NewAggregateFunc(reg, id, nil, types.AggInvocationAll, tt.phase, nil, arg)
+					if err == nil {
+						output = fn.GetType()
+					}
+				}
+				if tt.output == "" {
+					require.Error(t, err)
+					return
+				}
+				require.NoError(t, err)
+				assert.Equal(t, phaseType(t, tt.output), output)
+			})
+		}
+	}
+}
+
+func TestAggregatePhaseUniqueAlias(t *testing.T) {
+	const declaration = `
+urn: extension:test:window_phase
+window_functions:
+  - name: partial
+    impls:
+      - args:
+          - value: i32
+        nullability: DECLARED_OUTPUT
+        decomposable: MANY
+        intermediate: i64
+        return: i32
+`
+	var col extensions.Collection
+	require.NoError(t, col.Load(strings.NewReader(declaration)))
+	reg := expr.NewEmptyExtensionRegistry(&col)
+	id := extensions.FunctionID{URN: "extension:test:window_phase", Name: "partial"}
+	arg := &expr.DynamicParameter{OutputType: phaseType(t, "i64")}
+	window, err := expr.NewWindowFunc(reg, id, nil, types.AggInvocationAll, types.AggPhaseIntermediateToResult, arg)
+	require.NoError(t, err)
+	assert.Equal(t, "partial:i32", window.CompoundName())
+	assert.Equal(t, phaseType(t, "i32"), window.GetType())
+}
+
+func TestAggregateInitialPhaseInfersSignature(t *testing.T) {
+	reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
+	id := extensions.FunctionID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Name: "avg"}
+	arg := expr.NewPrimitiveLiteral(int32(7), false)
+	agg, err := expr.NewAggregateFunc(reg, id, nil, types.AggInvocationAll, types.AggPhaseInitialToIntermediate, nil, arg)
+	require.NoError(t, err)
+	assert.Equal(t, "avg:i32", agg.CompoundName())
+	assert.Equal(t, phaseType(t, "struct<i64,i64>"), agg.GetType())
+	window, err := expr.NewWindowFunc(reg, id, nil, types.AggInvocationAll, types.AggPhaseInitialToIntermediate, arg)
+	require.NoError(t, err)
+	assert.Equal(t, "avg:i32", window.CompoundName())
+	assert.Equal(t, phaseType(t, "struct<i64,i64>"), window.GetType())
+}

--- a/expr/aggregate_phase_test.go
+++ b/expr/aggregate_phase_test.go
@@ -256,6 +256,70 @@ window_functions:
 	assert.Equal(t, phaseType(t, "i32"), window.GetType())
 }
 
+func TestAggregatePhaseIntermediateParameterConsistency(t *testing.T) {
+	const declarations = `
+urn: extension:test:state_consistency
+aggregate_functions:
+  - name: integers
+    impls:
+      - args:
+          - value: decimal<P,S>
+          - value: decimal<P,S>
+        nullability: DECLARED_OUTPUT
+        decomposable: MANY
+        intermediate: struct<decimal<P,S>,decimal<P,S>>
+        return: i64
+  - name: any_types
+    impls:
+      - args:
+          - value: any1
+          - value: any1
+        nullability: DECLARED_OUTPUT
+        decomposable: MANY
+        intermediate: struct<any1,any1>
+        return: i64
+`
+	var col extensions.Collection
+	require.NoError(t, col.Load(strings.NewReader(declarations)))
+	for _, tt := range []struct {
+		name, function, state string
+		valid                 bool
+	}{
+		{"matching_integers", "integers:dec_dec", "struct<decimal<12,2>,decimal<12,2>>", true},
+		{"conflicting_precision", "integers:dec_dec", "struct<decimal<12,2>,decimal<13,2>>", false},
+		{"conflicting_scale", "integers:dec_dec", "struct<decimal<12,2>,decimal<12,3>>", false},
+		{"matching_any", "any_types:any_any", "struct<string,string>", true},
+		{"conflicting_any", "any_types:any_any", "struct<string,i64>", false},
+	} {
+		for _, phase := range []types.AggregationPhase{
+			types.AggPhaseIntermediateToResult, types.AggPhaseIntermediateToIntermediate, types.AggPhaseUnspecified,
+		} {
+			for _, window := range []bool{false, true} {
+				kind := "aggregate"
+				if window {
+					kind = "window"
+				}
+				t.Run(tt.name+"/"+phase.String()+"/"+kind, func(t *testing.T) {
+					reg := expr.NewEmptyExtensionRegistry(&col)
+					id := extensions.FunctionID{URN: "extension:test:state_consistency", Name: tt.function}
+					arg := &expr.DynamicParameter{OutputType: phaseType(t, tt.state)}
+					var err error
+					if window {
+						_, err = expr.NewWindowFunc(reg, id, nil, types.AggInvocationAll, phase, arg)
+					} else {
+						_, err = expr.NewAggregateFunc(reg, id, nil, types.AggInvocationAll, phase, nil, arg)
+					}
+					if tt.valid {
+						require.NoError(t, err)
+					} else {
+						require.Error(t, err)
+					}
+				})
+			}
+		}
+	}
+}
+
 func TestAggregateInitialPhaseInfersSignature(t *testing.T) {
 	reg := expr.NewEmptyExtensionRegistry(extensions.GetDefaultCollectionWithNoError())
 	id := extensions.FunctionID{URN: extensions.SubstraitDefaultURNPrefix + "functions_arithmetic", Name: "avg"}

--- a/expr/builder_test.go
+++ b/expr/builder_test.go
@@ -193,7 +193,7 @@ window_functions:
 		Name: "custom_aggr",
 	}).Args(
 		customLiteral,
-	).Build()
+	).Phase(types.AggPhaseInitialToResult).Build()
 	require.NoError(t, err)
 	aggrProto := aggr.ToProto()
 

--- a/expr/functions.go
+++ b/expr/functions.go
@@ -209,10 +209,7 @@ type variant interface {
 	ResolveType([]types.Type, extensions.Set) (types.Type, error)
 }
 
-func resolveVariant[T variant](
-	id extensions.FunctionID, reg ExtensionRegistry, getter func(extensions.FunctionID) (T, bool),
-	args []types.FuncArg,
-) (T, types.Type, error) {
+func functionArgumentTypes(args []types.FuncArg) []types.Type {
 	argTypes := make([]types.Type, 0, len(args))
 	for _, arg := range args {
 		switch a := arg.(type) {
@@ -223,6 +220,13 @@ func resolveVariant[T variant](
 		}
 	}
 
+	return argTypes
+}
+
+func lookupVariant[T variant](
+	id extensions.FunctionID, reg ExtensionRegistry, getter func(extensions.FunctionID) (T, bool),
+	argTypes []types.Type,
+) (T, error) {
 	decl, found := getter(id)
 	if !found {
 		if strings.IndexByte(id.Name, ':') == -1 {
@@ -234,7 +238,7 @@ func resolveVariant[T variant](
 				} else if ud, ok := t.(*types.UserDefinedType); ok {
 					id, found := reg.DecodeType(ud.TypeReference)
 					if !found {
-						return nil, nil, fmt.Errorf("%w: could not find type for reference %d",
+						return nil, fmt.Errorf("%w: could not find type for reference %d",
 							substraitgo.ErrNotFound, ud.TypeReference)
 					}
 					sigs[i] = "u!" + id.Name
@@ -244,20 +248,31 @@ func resolveVariant[T variant](
 			}
 			id.Name += ":" + strings.Join(sigs, "_")
 			if decl, found = getter(id); !found {
-				return nil, nil, fmt.Errorf("%w: could not find matching function for id: %s",
+				return nil, fmt.Errorf("%w: could not find matching function for id: %s",
 					substraitgo.ErrNotFound, id)
 			}
 		} else {
-			return nil, nil, fmt.Errorf("%w: could not find matching function for id: %s",
+			return nil, fmt.Errorf("%w: could not find matching function for id: %s",
 				substraitgo.ErrNotFound, id)
 		}
 	}
 
+	return decl, nil
+}
+
+func resolveVariant[T variant](
+	id extensions.FunctionID, reg ExtensionRegistry, getter func(extensions.FunctionID) (T, bool),
+	args []types.FuncArg,
+) (T, types.Type, error) {
+	argTypes := functionArgumentTypes(args)
+	decl, err := lookupVariant(id, reg, getter, argTypes)
+	if err != nil {
+		return nil, nil, err
+	}
 	outType, err := decl.ResolveType(argTypes, reg.Set)
 	if err != nil {
 		return nil, nil, err
 	}
-
 	return decl, outType, nil
 }
 
@@ -503,18 +518,16 @@ func NewCustomWindowFunc(
 	}, nil
 }
 
+// NewWindowFunc resolves the argument and output types for the requested phase.
+// Intermediate-input phases require the original compound function name unless
+// the name identifies a unique variant in the registry.
 func NewWindowFunc(
 	reg ExtensionRegistry, id extensions.FunctionID, opts []*types.FunctionOption,
 	invoke types.AggregationInvocation, phase types.AggregationPhase, args ...types.FuncArg,
 ) (*WindowFunction, error) {
-	decl, outType, err := resolveVariant(id, reg, reg.c.GetWindowFunc, args)
+	decl, outType, err := resolveAggregateVariant(id, reg, reg.c.GetWindowFunc, phase, args)
 	if err != nil {
 		return nil, err
-	}
-
-	if decl.Decomposability() == extensions.DecomposeNone && phase != types.AggPhaseInitialToResult {
-		return nil, fmt.Errorf("%w: non-decomposable window or agg function '%s' must use InitialToResult phase",
-			substraitgo.ErrInvalidExpr, id)
 	}
 
 	// We use the fully qualified ID for resolving an anchor, to make sure we
@@ -779,12 +792,15 @@ type AggregateFunction struct {
 	Sorts      []SortField
 }
 
+// NewAggregateFunc resolves the argument and output types for the requested phase.
+// Intermediate-input phases require the original compound function name unless
+// the name identifies a unique variant in the registry.
 func NewAggregateFunc(
 	reg ExtensionRegistry, id extensions.FunctionID, opts []*types.FunctionOption,
 	invoke types.AggregationInvocation, phase types.AggregationPhase, sorts []SortField,
 	args ...types.FuncArg,
 ) (*AggregateFunction, error) {
-	decl, outType, err := resolveVariant(id, reg, reg.c.GetAggregateFunc, args)
+	decl, outType, err := resolveAggregateVariant(id, reg, reg.c.GetAggregateFunc, phase, args)
 	if err != nil {
 		return nil, err
 	}

--- a/extensions/variants_test.go
+++ b/extensions/variants_test.go
@@ -338,6 +338,35 @@ func TestVariantWithVariadic(t *testing.T) {
 	}
 }
 
+func TestEvaluateTypeExpressionEmptyVariadicParameters(t *testing.T) {
+	for _, tt := range []struct {
+		name, variadicType, returnType, expectedError string
+	}{
+		{"concrete", "i32", "decimal<P,S>", ""},
+		{"already_bound", "decimal<P,S>", "decimal<P,S>", ""},
+		{"unbound_output", "decimal<Q,T>", "decimal<Q,T>", "parameter Q is not defined"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fixed, err := parser.ParseType("decimal<P,S>")
+			require.NoError(t, err)
+			variadic, err := parser.ParseType(tt.variadicType)
+			require.NoError(t, err)
+			output, err := parser.ParseType(tt.returnType)
+			require.NoError(t, err)
+			input := &types.DecimalType{Precision: 12, Scale: 2, Nullability: types.NullabilityRequired}
+			got, err := extensions.EvaluateTypeExpression("extension:test:variadic", extensions.DeclaredOutputNullability,
+				output, extensions.FuncParameterList{valArg(fixed), valArg(variadic)},
+				&extensions.VariadicBehavior{Min: 0}, []types.Type{input}, extensions.NewSet())
+			if tt.expectedError != "" {
+				require.EqualError(t, err, tt.expectedError)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, input, got)
+		})
+	}
+}
+
 func TestHasSyncParams(t *testing.T) {
 
 	apt_P := integer_parameters.NewVariableIntParam("P")

--- a/types/type_derivation.go
+++ b/types/type_derivation.go
@@ -311,7 +311,9 @@ func buildTypeParametersNameValueMap(funcParameters []FuncDefArgType, argumentTy
 	symbolTable := make(map[string]any)
 	for i, p := range funcParameters {
 		if i >= len(argumentTypes) {
-			return nil, fmt.Errorf("missing argument for function parameter %d", i)
+			// A variadic parameter can have zero values. Bind only supplied
+			// arguments; output derivation reports any unresolved parameters.
+			break
 		}
 		if err := bindTypeParameters(p, argumentTypes[i], symbolTable); err != nil {
 			return nil, err

--- a/types/type_derivation.go
+++ b/types/type_derivation.go
@@ -310,25 +310,68 @@ type SymbolInfo struct {
 func buildTypeParametersNameValueMap(funcParameters []FuncDefArgType, argumentTypes []Type) (map[string]any, error) {
 	symbolTable := make(map[string]any)
 	for i, p := range funcParameters {
-		paramNames := p.GetParameterizedParams()
-		if len(paramNames) > 0 {
-			paramValues := argumentTypes[i].GetParameters()
-			if len(paramNames) != len(paramValues) {
-				return nil, fmt.Errorf("function parameter %s has %d parameters, but %d were provided", p.String(), len(paramNames), len(paramValues))
-			}
-			for j, param := range paramNames {
-				if intParam, ok := param.(*integer_parameters.VariableIntParam); ok {
-					name := string(*intParam)
-					if existingValue, ok := symbolTable[name]; ok && existingValue != paramValues[j] {
-						return nil, fmt.Errorf("sync parameters %s has conflicting values: %v and %v", name, existingValue, paramValues[j])
-					}
-					symbolTable[name] = paramValues[j]
-					continue
-				}
-			}
+		if i >= len(argumentTypes) {
+			return nil, fmt.Errorf("missing argument for function parameter %d", i)
+		}
+		if err := bindTypeParameters(p, argumentTypes[i], symbolTable); err != nil {
+			return nil, err
 		}
 	}
 	return symbolTable, nil
+}
+
+func bindTypeParameters(parameter FuncDefArgType, argument Type, symbolTable map[string]any) error {
+	paramNames := parameter.GetParameterizedParams()
+	// Composite GetParameterizedParams methods omit concrete children. Keep
+	// every child here so its position still corresponds to the actual type.
+	switch p := parameter.(type) {
+	case *ParameterizedStructType:
+		paramNames = make([]interface{}, len(p.Types))
+		for i, child := range p.Types {
+			paramNames[i] = child
+		}
+	case *ParameterizedListType:
+		paramNames = []interface{}{p.Type}
+	case *ParameterizedMapType:
+		paramNames = []interface{}{p.Key, p.Value}
+	case *ParameterizedFuncType:
+		paramNames = make([]interface{}, len(p.Parameters)+1)
+		for i, child := range p.Parameters {
+			paramNames[i] = child
+		}
+		paramNames[len(p.Parameters)] = p.Return
+	case *OutputDerivation:
+		return bindTypeParameters(p.FinalType, argument, symbolTable)
+	}
+	if len(paramNames) == 0 {
+		return nil
+	}
+	if argument == nil {
+		return fmt.Errorf("missing argument for function parameter %s", parameter)
+	}
+	paramValues := argument.GetParameters()
+	if len(paramNames) != len(paramValues) {
+		return fmt.Errorf("function parameter %s has %d parameters, but %d were provided", parameter.String(), len(paramNames), len(paramValues))
+	}
+	for i, param := range paramNames {
+		switch p := param.(type) {
+		case *integer_parameters.VariableIntParam:
+			name := string(*p)
+			if existingValue, ok := symbolTable[name]; ok && existingValue != paramValues[i] {
+				return fmt.Errorf("sync parameters %s has conflicting values: %v and %v", name, existingValue, paramValues[i])
+			}
+			symbolTable[name] = paramValues[i]
+		case FuncDefArgType:
+			child, ok := paramValues[i].(Type)
+			if !ok {
+				return fmt.Errorf("function parameter %s requires a type at position %d", parameter, i)
+			}
+			if err := bindTypeParameters(p, child, symbolTable); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func (m *OutputDerivation) ReturnType(funcParameters []FuncDefArgType, argumentTypes []Type) (Type, error) {

--- a/types/type_derivation_test.go
+++ b/types/type_derivation_test.go
@@ -113,6 +113,21 @@ decimal<prec,scale>`
 		want       types.Type
 		wantErr    assert.ErrorAssertionFunc
 	}{
+		{"nestedStruct", []string{"struct<i64,decimal<38,S>,i64>"}, []string{"struct<i64,decimal<38,2>,i64>"}, "decimal<38,S>",
+			&types.DecimalType{Precision: 38, Scale: 2, Nullability: types.NullabilityRequired}, assert.NoError},
+		{"nestedListMap", []string{"list<map<i32,struct<i64,decimal<P,S>>>>"}, []string{"list<map<i32,struct<i64,decimal<12,2>>>>"}, "decimal<P,S>",
+			&types.DecimalType{Precision: 12, Scale: 2, Nullability: types.NullabilityRequired}, assert.NoError},
+		{"nestedFunction", []string{"func<i32 -> decimal<P,S>>"}, []string{"func<i32 -> decimal<12,2>>"}, "decimal<P,S>",
+			&types.DecimalType{Precision: 12, Scale: 2, Nullability: types.NullabilityRequired}, assert.NoError},
+		{"nestedRepeatedParameter", []string{"struct<i64,decimal<P,S>,decimal<P,S>>"}, []string{"struct<i64,decimal<12,2>,decimal<12,2>>"}, "decimal<P,S>",
+			&types.DecimalType{Precision: 12, Scale: 2, Nullability: types.NullabilityRequired}, assert.NoError},
+		{"nestedConflictingParameter", []string{"struct<i64,decimal<P,S>,decimal<P,S>>"}, []string{"struct<i64,decimal<12,2>,decimal<12,3>>"}, "decimal<P,S>",
+			nil, assert.Error},
+		{"nestedAndTopLevelConflict", []string{"struct<decimal<P,S>,i64>", "decimal<P,S>"}, []string{"struct<decimal<12,2>,i64>", "decimal<12,3>"}, "decimal<P,S>",
+			nil, assert.Error},
+		{"nestedMissingField", []string{"struct<decimal<P,S>,i64>"}, []string{"struct<decimal<12,2>>"}, "decimal<P,S>",
+			nil, assert.Error},
+
 		{"SameAsInput", []string{"varchar<L1>"}, []string{"varchar<8>"}, "varchar<L1>",
 			&types.VarCharType{Length: 8, Nullability: types.NullabilityRequired}, assert.NoError},
 		{"SameAsInput?", []string{"varchar<L1>"}, []string{"varchar<8>"}, "varchar?<L1>",
@@ -201,7 +216,7 @@ func parseFuncArguments(t *testing.T, args []string) []types.Type {
 	for i, a := range args {
 		funcDefArgType, err := parser.ParseType(a)
 		require.NoError(t, err)
-		result[i], err = funcDefArgType.WithParameters(nil)
+		result[i], err = funcDefArgType.ReturnType(nil, nil)
 		require.NoError(t, err)
 	}
 	return result


### PR DESCRIPTION
Aggregate and window builders previously resolved every invocation against the initial arguments and final return type. `avg:i32` in `INITIAL_TO_INTERMEDIATE` consequently emitted `i32?` instead of its `struct<i64,i64>` state, and both intermediate-input phases rejected that valid state.

Resolve argument and output types according to the requested phase. Intermediate phases consume one state value while retaining the original function variant. Initial phases keep ordinary signature inference; intermediate inputs require the original compound name unless the registry resolves a unique alias. Follow the protobuf definition that `UNSPECIFIED` means `INTERMEDIATE_TO_RESULT`, and reject intermediate phases for nondecomposable functions.

Also bind integer type parameters recursively through composite types. This lets decimal average recover its scale from `struct<decimal<38,S>,i64>` and consume its own intermediate output without losing field positions. Validate repeated parameters within a state even when the final result has no parameters, and preserve valid zero-repeat variadic calls.

## Validation

The regression tests fail on the base commit and pass with this change:

```sh
go test ./expr -run 'TestAggregate(FunctionPhases|Phase|InitialPhase)' -count=1
go test ./types -run 'TestReturnType/nested' -count=1
```

Coverage includes aggregate and window variants of integer/decimal average, sum, both count signatures, polymorphic state, nullable inputs, all phases, ambiguous signatures, and malformed state arguments. Also verified `go test ./...`, `go build ./...`, and `golangci-lint run` with CI's version 2.1.6.

## Downsides

Calls that relied on an omitted phase being treated as a complete aggregation must explicitly select `INITIAL_TO_RESULT`. Intermediate states cannot identify an overloaded function's original signature, so callers must retain its compound ID.

Intermediate-input resolution does not invert computed type derivations: those signatures return `ErrNotImplemented`. If the state omits a parameter needed for the final type, resolution returns an error rather than guessing.
